### PR TITLE
Fixed CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -22,8 +22,6 @@ jobs:
             - run: npm ci
             - name: ESLint & StyleLint
               run: npm run lint:ci
-            - name: typescript
-              run: npx tsc
 
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
NextJs already checks types during build, it wasn't necessary.