### PR TITLE
No more absolute imports

### DIFF
--- a/src/elements/components/link.tsx
+++ b/src/elements/components/link.tsx
@@ -1,6 +1,6 @@
 import { default as InternalLink } from 'next/link';
 import { BiLinkExternal } from 'react-icons/bi';
-import { joinClasses } from 'src/lib/util';
+import { joinClasses } from '../../lib/util';
 import style from './link.module.scss';
 
 export interface LinkProps {

--- a/src/elements/header.tsx
+++ b/src/elements/header.tsx
@@ -3,8 +3,8 @@
 import React from 'react';
 import { FaDiscord, FaGithub } from 'react-icons/fa';
 import { MdDarkMode, MdLightMode } from 'react-icons/md';
-import { toggleColorScheme } from 'src/lib/color-scheme';
 import Logo from '../../public/logo.svg';
+import { toggleColorScheme } from '../lib/color-scheme';
 import { Link } from './components/link';
 import style from './header.module.scss';
 

--- a/src/elements/markdown.tsx
+++ b/src/elements/markdown.tsx
@@ -5,8 +5,8 @@ import { HeadingComponent } from 'react-markdown/lib/ast-to-react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { atomDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import remarkGfm from 'remark-gfm';
-import { textToLinkId } from 'src/lib/docs/doc';
-import { useCurrentPath } from 'src/lib/hooks/use-current-path';
+import { textToLinkId } from '../lib/docs/doc';
+import { useCurrentPath } from '../lib/hooks/use-current-path';
 import { Link, TextLink } from './components/link';
 import style from './markdown.module.scss';
 

--- a/src/elements/side-bar.tsx
+++ b/src/elements/side-bar.tsx
@@ -4,8 +4,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { BiChevronDown, BiChevronRight } from 'react-icons/bi';
 import { BsDot } from 'react-icons/bs';
 import { IconType } from 'react-icons/lib';
-import { withoutHash } from 'src/lib/util';
 import { SideBar, SideBarItem } from '../lib/docs/side-bar';
+import { withoutHash } from '../lib/util';
 import style from './side-bar.module.scss';
 
 export interface SideBarProps {

--- a/src/pages/api/model-id.ts
+++ b/src/pages/api/model-id.ts
@@ -1,8 +1,8 @@
 import { rename } from 'fs/promises';
-import { ChangeIdRequest } from 'src/lib/api-types';
-import { ModelId } from 'src/lib/schema';
-import { post, synchronizeDB } from 'src/lib/server/api-impl';
-import { getAllModelIds, getModelDataPath, mutateModels } from 'src/lib/server/data';
+import { ChangeIdRequest } from '../../lib/api-types';
+import { ModelId } from '../../lib/schema';
+import { post, synchronizeDB } from '../../lib/server/api-impl';
+import { getAllModelIds, getModelDataPath, mutateModels } from '../../lib/server/data';
 
 export type ModelsRequestBody = ChangeIdRequest<ModelId>;
 

--- a/src/pages/api/models.ts
+++ b/src/pages/api/models.ts
@@ -1,9 +1,9 @@
 import { unlink } from 'fs/promises';
-import { UpdateRequest } from 'src/lib/api-types';
-import { Model, ModelId } from 'src/lib/schema';
-import { groupUpdatesByType, post, synchronizeDB } from 'src/lib/server/api-impl';
-import { getModelDataPath, writeModelData } from 'src/lib/server/data';
-import { fileExists } from 'src/lib/server/fs-util';
+import { UpdateRequest } from '../../lib/api-types';
+import { Model, ModelId } from '../../lib/schema';
+import { groupUpdatesByType, post, synchronizeDB } from '../../lib/server/api-impl';
+import { getModelDataPath, writeModelData } from '../../lib/server/data';
+import { fileExists } from '../../lib/server/fs-util';
 
 export type ModelsRequestBody = UpdateRequest<ModelId, Model>[];
 

--- a/src/pages/api/tag-id.ts
+++ b/src/pages/api/tag-id.ts
@@ -1,8 +1,8 @@
-import { ChangeIdRequest } from 'src/lib/api-types';
-import { TagId } from 'src/lib/schema';
-import { post, synchronizeDB } from 'src/lib/server/api-impl';
-import { getTags, mutateModels, writeTags } from 'src/lib/server/data';
-import { hasOwn, sortObjectKeys } from 'src/lib/util';
+import { ChangeIdRequest } from '../../lib/api-types';
+import { TagId } from '../../lib/schema';
+import { post, synchronizeDB } from '../../lib/server/api-impl';
+import { getTags, mutateModels, writeTags } from '../../lib/server/data';
+import { hasOwn, sortObjectKeys } from '../../lib/util';
 
 export type TagsRequestBody = ChangeIdRequest<TagId>;
 

--- a/src/pages/api/tags.ts
+++ b/src/pages/api/tags.ts
@@ -1,7 +1,7 @@
-import { UpdateRequest } from 'src/lib/api-types';
-import { Tag, TagId } from 'src/lib/schema';
-import { groupUpdatesByType, post, synchronizeDB } from 'src/lib/server/api-impl';
-import { getTags, writeTags } from 'src/lib/server/data';
+import { UpdateRequest } from '../../lib/api-types';
+import { Tag, TagId } from '../../lib/schema';
+import { groupUpdatesByType, post, synchronizeDB } from '../../lib/server/api-impl';
+import { getTags, writeTags } from '../../lib/server/data';
 
 export type TagsRequestBody = UpdateRequest<TagId, Tag>[];
 

--- a/src/pages/api/user-id.ts
+++ b/src/pages/api/user-id.ts
@@ -1,8 +1,8 @@
-import { ChangeIdRequest } from 'src/lib/api-types';
-import { UserId } from 'src/lib/schema';
-import { post, synchronizeDB } from 'src/lib/server/api-impl';
-import { getUsers, mutateModels, writeUsers } from 'src/lib/server/data';
-import { hasOwn } from 'src/lib/util';
+import { ChangeIdRequest } from '../../lib/api-types';
+import { UserId } from '../../lib/schema';
+import { post, synchronizeDB } from '../../lib/server/api-impl';
+import { getUsers, mutateModels, writeUsers } from '../../lib/server/data';
+import { hasOwn } from '../../lib/util';
 
 export type UsersRequestBody = ChangeIdRequest<UserId>;
 

--- a/src/pages/api/users.ts
+++ b/src/pages/api/users.ts
@@ -1,7 +1,7 @@
-import { UpdateRequest } from 'src/lib/api-types';
-import { User, UserId } from 'src/lib/schema';
-import { groupUpdatesByType, post, synchronizeDB } from 'src/lib/server/api-impl';
-import { getUsers, writeUsers } from 'src/lib/server/data';
+import { UpdateRequest } from '../../lib/api-types';
+import { User, UserId } from '../../lib/schema';
+import { groupUpdatesByType, post, synchronizeDB } from '../../lib/server/api-impl';
+import { getUsers, writeUsers } from '../../lib/server/data';
 
 export type UsersRequestBody = UpdateRequest<UserId, User>[];
 

--- a/src/pages/docs/[[...slug]].tsx
+++ b/src/pages/docs/[[...slug]].tsx
@@ -4,15 +4,15 @@ import Link from 'next/link';
 import { ParsedUrlQuery } from 'querystring';
 import { useMemo } from 'react';
 import { BiChevronLeft, BiChevronRight } from 'react-icons/bi';
-import { TextLink } from 'src/elements/components/link';
-import { MarkdownContainer } from 'src/elements/markdown';
-import { PageContainer } from 'src/elements/page';
-import { SideBarView } from 'src/elements/side-bar';
-import { Doc, DocPagePath, docPathToSlug } from 'src/lib/docs/doc';
-import { SideBar, SideBarItem, generateSideBar, getPageList } from 'src/lib/docs/side-bar';
-import { useCurrentPath } from 'src/lib/hooks/use-current-path';
-import { getAllDocPaths, getAllDocs, getDocFileMetadata, getManifest } from 'src/lib/server/docs';
-import { withoutHash } from 'src/lib/util';
+import { TextLink } from '../../elements/components/link';
+import { MarkdownContainer } from '../../elements/markdown';
+import { PageContainer } from '../../elements/page';
+import { SideBarView } from '../../elements/side-bar';
+import { Doc, DocPagePath, docPathToSlug } from '../../lib/docs/doc';
+import { SideBar, SideBarItem, generateSideBar, getPageList } from '../../lib/docs/side-bar';
+import { useCurrentPath } from '../../lib/hooks/use-current-path';
+import { getAllDocPaths, getAllDocs, getDocFileMetadata, getManifest } from '../../lib/server/docs';
+import { withoutHash } from '../../lib/util';
 import style from './docs.module.scss';
 
 interface Params extends ParsedUrlQuery {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,10 +2,10 @@ import { GetStaticProps } from 'next';
 import Head from 'next/head';
 import Link from 'next/link';
 import React from 'react';
-import { PageContainer } from 'src/elements/page';
-import { Model, ModelId } from 'src/lib/schema';
-import { getAllModelIds, getModelData } from 'src/lib/server/data';
-import { asArray } from 'src/lib/util';
+import { PageContainer } from '../elements/page';
+import { Model, ModelId } from '../lib/schema';
+import { getAllModelIds, getModelData } from '../lib/server/data';
+import { asArray } from '../lib/util';
 
 interface Props {
     modelIds: ModelId[];

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -1,8 +1,8 @@
 import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import { ParsedUrlQuery } from 'querystring';
-import { Model, ModelId } from 'src/lib/schema';
-import { getAllModelIds, getModelData } from 'src/lib/server/data';
+import { Model, ModelId } from '../../lib/schema';
+import { getAllModelIds, getModelData } from '../../lib/server/data';
 
 interface Params extends ParsedUrlQuery {
     id: ModelId;

--- a/src/pages/users/[id].tsx
+++ b/src/pages/users/[id].tsx
@@ -3,8 +3,8 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { ParsedUrlQuery } from 'querystring';
 import React from 'react';
-import { Model, ModelId, User, UserId } from 'src/lib/schema';
-import { getAllModelIds, getModelData, getUsers } from 'src/lib/server/data';
+import { Model, ModelId, User, UserId } from '../../lib/schema';
+import { getAllModelIds, getModelData, getUsers } from '../../lib/server/data';
 
 interface Params extends ParsedUrlQuery {
     id: UserId;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "baseUrl": ".",
     "plugins": [{"name": "typescript-plugin-css-modules"}]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "src/"],


### PR DESCRIPTION
I noticed that Joey changed an absolute import to a relative one in #11, and I agree. I only used absolute paths because that's what VSCode auto import used. 

Removing `baseUrl` from `tsconfig.json` makes all absolute paths invalid, so we have to use relative paths now. `baseUrl` was added by nextjs btw, so I won't miss it.