### PR TITLE
Added new theme system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^1.7.9",
         "@next/font": "13.1.5",
+        "chroma-js": "^2.4.2",
         "next": "13.1.5",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -28,6 +29,7 @@
         "@storybook/react": "^7.0.0-beta.46",
         "@storybook/testing-library": "^0.0.14-next.1",
         "@svgr/webpack": "^6.5.1",
+        "@types/chroma-js": "^2.1.5",
         "@types/node": "18.11.18",
         "@types/react": "18.0.27",
         "@types/react-dom": "18.0.10",
@@ -5203,6 +5205,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chroma-js": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.1.5.tgz",
+      "integrity": "sha512-LnJmElng1zoH7GOYqIo/EuL7L0/vEh5rc+fKaF4rsylJyjwOkX0pXeBemH25FQAWHifKJWqaRwR0EhC+yDod9A==",
+      "dev": true
+    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -7115,6 +7123,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chroma-js": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
+      "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
@@ -21610,6 +21623,12 @@
         "@types/node": "*"
       }
     },
+    "@types/chroma-js": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.1.5.tgz",
+      "integrity": "sha512-LnJmElng1zoH7GOYqIo/EuL7L0/vEh5rc+fKaF4rsylJyjwOkX0pXeBemH25FQAWHifKJWqaRwR0EhC+yDod9A==",
+      "dev": true
+    },
     "@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -23112,6 +23131,11 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "dev": true
+    },
+    "chroma-js": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
+      "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
     },
     "chrome-trace-event": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.9",
     "@next/font": "13.1.5",
+    "chroma-js": "^2.4.2",
     "next": "13.1.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -33,6 +34,7 @@
     "@storybook/react": "^7.0.0-beta.46",
     "@storybook/testing-library": "^0.0.14-next.1",
     "@svgr/webpack": "^6.5.1",
+    "@types/chroma-js": "^2.1.5",
     "@types/node": "18.11.18",
     "@types/react": "18.0.27",
     "@types/react-dom": "18.0.10",

--- a/src/elements/components/switch.module.scss
+++ b/src/elements/components/switch.module.scss
@@ -33,7 +33,7 @@
     }
 
     &[data-headlessui-state='checked'] {
-        background-color: var(--accent-color);
+        background-color: var(--accent);
 
         .circle {
             transform: translate(calc(var(--switch-inner-height) * (var(--switch-ratio) - 1)), 0);

--- a/src/elements/header.module.scss
+++ b/src/elements/header.module.scss
@@ -1,4 +1,7 @@
+@use 'sass:color';
+
 @import './util.module';
+@import '../styles/theme';
 
 .headerSpacer {
     width: 100%;
@@ -8,7 +11,11 @@
 }
 
 .header {
-    background-color: var(--header-bg);
+    @include themed using ($t) {
+        background-color: t($t, color.change(white, $alpha: 0.8), color.change($n-900, $alpha: 0.8));
+    }
+
+    transition: background-color linear 0.2s, border-color linear 0.2s;
     backdrop-filter: saturate(200%) blur(5px);
     border-bottom: 1px solid var(--line-color);
     position: fixed;

--- a/src/elements/side-bar.module.scss
+++ b/src/elements/side-bar.module.scss
@@ -12,6 +12,7 @@
         padding-left: 0.5em;
         margin-left: 0.5em;
         border-left: 1px solid var(--line-color);
+        transition: border-color linear 0.2s;
     }
 
     .list.level1 > * {

--- a/src/pages/palette.tsx
+++ b/src/pages/palette.tsx
@@ -1,0 +1,214 @@
+import chroma from 'chroma-js';
+import { GetStaticProps } from 'next';
+import Head from 'next/head';
+import { useState } from 'react';
+import { PageContainer } from '../elements/page';
+
+const steps = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900] as const;
+type ArrayItem<T> = T extends readonly (infer U)[] ? U : never;
+type Step = ArrayItem<typeof steps>;
+function getNearestStep(x: number): Step {
+    return steps.map((s) => [s, Math.abs(s - x)] as const).sort((a, b) => a[1] - b[1])[0][0];
+}
+
+// reference L values derived from tailwind's neutral color palette
+const referenceL: Readonly<Record<Step, number>> = {
+    50: 98,
+    100: 96,
+    200: 91,
+    300: 85,
+    400: 66.66,
+    500: 48,
+    600: 36,
+    700: 27,
+    800: 16,
+    900: 8,
+} as const;
+const stepToL = (step: Step): number => {
+    return referenceL[step];
+};
+
+class LCH {
+    constructor(public l: number, public c: number, public h: number) {}
+
+    get color() {
+        return chroma.lch(this.l, this.c, this.h);
+    }
+
+    with(key: 'l' | 'c' | 'h', value: number) {
+        const copy = new LCH(this.l, this.c, this.h);
+        copy[key] = value;
+        return copy;
+    }
+}
+
+interface StepColor {
+    step: Step;
+    color: chroma.Color;
+    isCurrent?: boolean;
+}
+
+const methods = ['Reference L', 'Tint & Shade'] as const;
+type Method = ArrayItem<typeof methods>;
+
+export default function Page() {
+    const [lch, setLch] = useState<LCH>(new LCH(50, 0, 0));
+    const [method, setMethod] = useState<Method>('Reference L');
+
+    const methodFn: Record<Method, (step: Step) => StepColor> = {
+        'Reference L': (step) => {
+            return {
+                step,
+                color: lch.with('l', stepToL(step)).color,
+                isCurrent: stepToL(step) === lch.l,
+            };
+        },
+        'Tint & Shade': (step) => {
+            const p = 1 - step / 1000;
+            const center = 1 - getNearestStep((lch.l / 100) * 1000) / 1000;
+            return {
+                step,
+                color:
+                    p <= center
+                        ? chroma.scale(['black', lch.color]).mode('lab')(p / center)
+                        : chroma.scale([lch.color, 'white']).mode('lab')((p - center) / (1 - center)),
+                isCurrent: p === center,
+            };
+        },
+    };
+    const colors = steps.map(methodFn[method]);
+
+    return (
+        <>
+            <Head>
+                <title>Palette Generator</title>
+                <meta
+                    content="width=device-width, initial-scale=1"
+                    name="viewport"
+                />
+                <link
+                    href="/favicon.ico"
+                    rel="icon"
+                />
+            </Head>
+            <PageContainer>
+                <div>
+                    <p>
+                        <input
+                            type="text"
+                            value={lch.color.hex()}
+                            onChange={(e) => {
+                                const text = e.target.value;
+                                let color;
+                                try {
+                                    color = chroma(text);
+                                } catch {
+                                    try {
+                                        color = chroma(`#${text}`);
+                                    } catch {}
+                                }
+                                if (color) setLch(new LCH(...color.lch()));
+                            }}
+                        />
+                    </p>
+                    <p>
+                        <span
+                            style={{
+                                width: '2em',
+                                height: '2em',
+                                display: 'inline-block',
+                                background: lch.color.hex(),
+                            }}
+                        />
+                    </p>
+                    <p>
+                        <span style={{ width: '3em', display: 'inline-block', textAlign: 'right' }}>
+                            L {Math.round(lch.l)}
+                        </span>
+                        <input
+                            max={100}
+                            min={0}
+                            type="range"
+                            value={lch.l}
+                            onChange={(e) => {
+                                setLch(lch.with('l', Number(e.target.value)));
+                            }}
+                        />
+                        <span style={{ width: '3em', display: 'inline-block', textAlign: 'right' }}>
+                            C {Math.round(lch.c)}
+                        </span>
+                        <input
+                            max={150}
+                            min={0}
+                            type="range"
+                            value={lch.c}
+                            onChange={(e) => {
+                                setLch(lch.with('c', Number(e.target.value)));
+                            }}
+                        />
+                        <span style={{ width: '3em', display: 'inline-block', textAlign: 'right' }}>
+                            H {Math.round(lch.h)}
+                        </span>
+                        <input
+                            max={360}
+                            min={0}
+                            type="range"
+                            value={lch.h}
+                            onChange={(e) => {
+                                setLch(lch.with('h', Number(e.target.value)));
+                            }}
+                        />
+                    </p>
+                    <p>
+                        <select
+                            value={method}
+                            onChange={(e) => setMethod(e.target.value as Method)}
+                        >
+                            {methods.map((m) => (
+                                <option
+                                    key={m}
+                                    value={m}
+                                >
+                                    {m}
+                                </option>
+                            ))}
+                        </select>
+                    </p>
+                    <p style={{ display: 'flex' }}>
+                        {colors.map(({ step, color, isCurrent }) => {
+                            return (
+                                <span
+                                    key={step}
+                                    style={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}
+                                >
+                                    <span
+                                        style={{
+                                            width: '4em',
+                                            height: '2em',
+                                            display: 'block',
+                                            background: color.hex(),
+                                        }}
+                                    />
+                                    <span style={{ fontWeight: isCurrent ? 'bold' : 'inherit' }}>{step}</span>
+                                    <span style={{ fontFamily: 'monospace' }}>{color.hex()}</span>
+                                </span>
+                            );
+                        })}
+                    </p>
+                    <pre>
+                        {colors.map(({ step, color }) => {
+                            return <span key={step}>{`$name-${step}: ${color.hex()};\n`}</span>;
+                        })}
+                    </pre>
+                </div>
+            </PageContainer>
+        </>
+    );
+}
+
+export const getStaticProps: GetStaticProps = (_context) => {
+    if (process.env.NODE_ENV === 'production') {
+        return { notFound: true };
+    }
+    return { props: {} };
+};

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,0 +1,37 @@
+// LCh = 36 60 300
+$accent: #4d48a9; // 600
+$accent-50: #feeaff;
+$accent-100: #f8e4ff;
+$accent-200: #e9d6ff;
+$accent-300: #d8c5ff;
+$accent-400: #a394ff;
+$accent-500: #6e64ca;
+$accent-600: #4d48a9;
+$accent-700: #323391;
+$accent-800: #031c74;
+$accent-900: #000c60;
+
+// LCh = 36 60 300
+$accent-fade: #575170; // 600
+$accent-fade-50: #fdf4ff;
+$accent-fade-100: #f7efff;
+$accent-fade-200: #e9e0ff;
+$accent-fade-300: #d8cff5;
+$accent-fade-400: #a59ec1;
+$accent-fade-500: #746e8f;
+$accent-fade-600: #575170;
+$accent-fade-700: #413c5a;
+$accent-fade-800: #282440;
+$accent-fade-900: #17142f;
+
+// easy access to tailwind's neutral palette
+$n-50: #fafafa;
+$n-100: #f5f5f5;
+$n-200: #e5e5e5;
+$n-300: #d4d4d4;
+$n-400: #a3a3a3;
+$n-500: #737373;
+$n-600: #525252;
+$n-700: #404040;
+$n-800: #262626;
+$n-900: #171717;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -17,7 +17,7 @@
     --font-color-light: #{t($t, $n-700, $n-400)};
     --font-color-light-hover: #{t($t, black, white)};
 
-    --line-color: #{t($t, $n-300, hsl(0deg 0% 15%))};
+    --line-color: #{t($t, $n-300, $n-800)};
 
     --link-color: #{t($t, hsl(212deg 100% 45%), hsl(212deg 100% 67%))};
 

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -1,68 +1,49 @@
 /* stylelint-disable scss/at-rule-no-unknown */
+@import './theme';
+
 // @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 // theme colors
 
-@function select($theme, $light, $dark) {
-    @if $theme == dark {
-        @return $dark;
-    }
-    @if $theme == light {
-        @return $light;
-    }
-    @error "#{$theme} is not a valid theme. Only light and dark mode are supported.";
+@mixin theme-colors($t) {
+    --accent: #{t($t, $accent-600, $accent-500)};
+
+    --page-bg: #{t($t, white, $n-900)};
+
+    --font-color: #{t($t, black, $n-100)};
+    --font-color-hover: var(--accent);
+    --font-color-light: #{t($t, $n-700, $n-400)};
+    --font-color-light-hover: #{t($t, black, white)};
+
+    --line-color: #{t($t, $n-300, hsl(0deg 0% 15%))};
+
+    --link-color: #{t($t, hsl(212deg 100% 45%), hsl(212deg 100% 67%))};
+
+    --logo-text: #{t($t, $n-900, white)};
+    --logo-jelly: #{t($t, white, white)};
+    --logo-circle: #{t($t, $n-900, black)};
+    --logo-accent: var(--accent);
+
+    --primary-bg: var(--accent);
+    --primary-bg-hover: #{t($t, $accent-500, $accent-600)};
+    --primary-color: #{t($t, white, white)};
+    --primary-color-hover: #{t($t, white, white)};
+
+    --secondary-bg: #{t($t, transparent, transparent)};
+    --secondary-bg-hover: #{t($t, $accent-300, $accent-fade-800)};
+    --secondary-color: #{t($t, black, $accent-fade-200)};
+    --secondary-color-hover: #{t($t, black, white)};
 }
 
-@mixin theme-colors($theme) {
-    --page-bg: #{select($theme, #fff, #111018)};
-    --header-bg: #{select($theme, rgb(255 255 255/80%), rgb(0 0 0/80%))};
+@include themed using ($t) {
+    @include theme-colors($t);
 
-    --accent-color: #454aab;
+    color-scheme: #{t($t, light, dark)};
 
-    --font-color: #{select($theme, #000, #eee)};
-    --font-color-hover: #{select($theme, var(--accent-color), var(--accent-color))};
-    --font-color-light: #{select($theme, #444, #bbb)};
-    --font-color-light-hover: #{select($theme, #000, #fff)};
-
-    --line-color: #{select($theme, hsl(0deg 0% 80%), hsl(0deg 0% 15%))};
-
-    --link-color: #{select($theme, hsl(212deg 100% 45%), hsl(212deg 100% 67%))};
-
-    --logo-text: #{select($theme, #111018, #fff)};
-    --logo-jelly: #{select($theme, #fff, #fff)};
-    --logo-circle: #{select($theme, #111018, #111018)};
-    --logo-accent: var(--accent-color);
-}
-
-:root:not([data-theme='dark']) {
-    @include theme-colors(light);
-
-    color-scheme: light;
-
-    --dark-mode-switch: block;
-    --light-mode-switch: none;
-}
-
-:root[data-theme='dark'] {
-    @include theme-colors(dark);
-
-    color-scheme: dark;
-
-    --dark-mode-switch: none;
-    --light-mode-switch: block;
-}
-
-@media (prefers-color-scheme: dark) {
-    :root:not([data-theme='light']) {
-        @include theme-colors(dark);
-
-        color-scheme: dark;
-
-        --dark-mode-switch: none;
-        --light-mode-switch: block;
-    }
+    --dark-mode-switch: #{t($t, block, none)};
+    --light-mode-switch: #{t($t, none, block)};
 }
 
 // global variables
@@ -88,6 +69,7 @@ body {
 
 body {
     background-color: var(--page-bg);
+    transition: background-color linear 0.2s;
     line-height: 1.6;
 
     // Storybook hacks

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -1,0 +1,28 @@
+// re-export colors for easy access
+@import './colors';
+
+@mixin themed {
+    :root:not([data-theme='dark']) #{if(&, '&', '')} {
+        @content (light);
+    }
+
+    :root[data-theme='dark'] #{if(&, '&', '')} {
+        @content (dark);
+    }
+
+    @media (prefers-color-scheme: dark) {
+        :root:not([data-theme]) #{if(&, '&', '')} {
+            @content (dark);
+        }
+    }
+}
+
+@function t($theme, $light, $dark) {
+    @if $theme == dark {
+        @return $dark;
+    }
+    @if $theme == light {
+        @return $light;
+    }
+    @error "#{$theme} is not a valid theme. Only light and dark mode are supported.";
+}


### PR DESCRIPTION
This PR sets the tone for how light and dark mode will work.

Firstly, colors are done via SCSS. We may add theme to tailwind later, but SCSS will be the source of truth. That being said, the color palettes I created are heavily inspired by tailwind's and even include tailwind's neutral palette.

## How themes work

Themes are done in SCSS either via semantic colors or the `themed` mixin. Semantic colors are CSS variables defined in `globals.scss`. They describe general concepts that can be reused across components. 

The `themed` mixin is the backbone of the whole theme system. It's used like this:
```scss
@include themed using ($t) {
    prop: t($t, light value, dark value);
}
```

`$t` is the name of the current theme (currently either "light" or "dark"). `t($t, light, dark)` is a selector function that returns the value of the current theme, it's essentially just `$t == light ? light-value : dark-value`.

I also want to point out that `@include themed` is purely additive. You can place it into any existing SCSS selector (even inside nested ones) and it will just work. E.g. here is what the header currently does:
```scss
.header {
    @include themed using ($t) {
        background-color: t($t, color.change(white, $alpha: 0.8), color.change($n-900, $alpha: 0.8));
    }

    // rest of header props
}
```

But this would also work:
```scss
.header {
    @include themed using ($t) {
        background-color: t($t, color.change(white, $alpha: 0.8), color.change($n-900, $alpha: 0.8));

        &:hover {
            background-color: t($t, red, blue);
        }
    }

    // rest of header props
}
```

## Color palettes

Color palettes are defined in `colors.scss`. They are defined as simple SCSS variables, so we get nice completion inside the IDE.
![image](https://user-images.githubusercontent.com/20878432/219428854-af0d0b8c-a4b6-437c-b054-977a0a3e69a4.png)

Right now, I defined 3 color palettes: 1 for neutral gray that I copied from tailwind, and 2 for our accent color (one with full saturation and one less saturated).

---

Since I couldn't find any good tools online that produce nice color palettes after hours of searching, I created my own. `/palette` is a simple page that given a base color will generate a color palette of shades of that color with the same lightness distribution as tailwind's neutral palette. So tweaking and extending our color palette with custom colors will be easy.

![image](https://user-images.githubusercontent.com/20878432/219431210-8720c4b1-b8e2-4fae-ad35-55d4cacd14a2.png)
