### PR TITLE
Always set `data-theme` attribute

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,7 +3,11 @@ import Script from 'next/script';
 
 // This little script will read the last theme from localStorage and assign it to the HTML element.
 // This ensure that the website is always displayed with the correct them.
-const themeInit = `(()=>{var t=localStorage.getItem('theme');if(t)document.documentElement.dataset.theme=t})()`;
+const themeInit =
+    `document.documentElement.dataset.theme=` +
+    `localStorage.getItem('theme')` +
+    `||` +
+    `(window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light')`;
 
 export default function Document() {
     return (

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -9,12 +9,6 @@
     :root[data-theme='dark'] #{if(&, '&', '')} {
         @content (dark);
     }
-
-    @media (prefers-color-scheme: dark) {
-        :root:not([data-theme]) #{if(&, '&', '')} {
-            @content (dark);
-        }
-    }
 }
 
 @function t($theme, $light, $dark) {


### PR DESCRIPTION
PR always sets the `data-theme` attribute, even if the user has not previously selected a theme, in which case the attribute is initialized based on system preferences. Since the attribute is now the source of truth for the current theme, the `themed` SASS mixin also got simpler.