### PR TITLE
Minor fixes

### DIFF
--- a/src/elements/components/download-button.tsx
+++ b/src/elements/components/download-button.tsx
@@ -1,5 +1,6 @@
 import { FiExternalLink } from 'react-icons/fi';
 import { Resource } from '../../lib/schema';
+import { Link } from './link';
 
 type DownloadButtonProps = {
     url: string;
@@ -39,12 +40,11 @@ export const DownloadButton = ({ url, resource }: DownloadButtonProps) => {
     const host = getHostFromUrl(url);
 
     return (
-        <div key={resource.sha256}>
-            <a
+        <div>
+            <Link
+                external
                 className="mr-2 mb-2 inline-flex w-full cursor-pointer items-center rounded-lg border-0 border-accent-700 bg-accent-600 px-5 py-2.5 text-center text-lg font-medium text-white transition duration-100 ease-in-out hover:bg-accent-500 focus:outline-none focus:ring-4 focus:ring-accent-700 dark:bg-accent-500 dark:hover:bg-accent-600 dark:focus:ring-accent-500"
                 href={url}
-                rel="noreferrer"
-                target="_blank"
                 type="button"
             >
                 <div className="w-full">
@@ -64,7 +64,7 @@ export const DownloadButton = ({ url, resource }: DownloadButtonProps) => {
                     )}
                     Download {resource.size ? `(${(resource.size / 1024 / 1024).toFixed(1)} MB)` : ''}
                 </div>
-            </a>
+            </Link>
             <div className="w-full text-center">
                 {isExternal ? `Hosted offsite by ${host}` : 'Hosted by OpenModelDB'}
             </div>

--- a/src/elements/components/link.tsx
+++ b/src/elements/components/link.tsx
@@ -7,37 +7,32 @@ export interface LinkProps {
     href: string;
     className?: string;
     external?: boolean;
+    type?: string;
+    title?: string;
 }
 
-export function Link({ external, className, href, children }: React.PropsWithChildren<LinkProps>) {
+export function Link({ external, children, ...props }: React.PropsWithChildren<LinkProps>) {
     if (external) {
         return (
             <a
-                className={className}
-                href={href}
                 rel="noopener noreferrer"
                 target="_blank"
+                {...props}
             >
                 {children}
             </a>
         );
     }
 
-    return (
-        <InternalLink
-            className={className}
-            href={href}
-        >
-            {children}
-        </InternalLink>
-    );
+    return <InternalLink {...props}>{children}</InternalLink>;
 }
 
-export function TextLink({ external, className, href, children }: React.PropsWithChildren<LinkProps>) {
+export function TextLink({ external, className, children, ...props }: React.PropsWithChildren<LinkProps>) {
     return (
         <Link
             className={joinClasses(className, style.textLink)}
-            href={href}
+            external={external}
+            {...props}
         >
             {children}
             {external && <BiLinkExternal className={style.externalIcon} />}

--- a/src/elements/components/model-card.tsx
+++ b/src/elements/components/model-card.tsx
@@ -1,6 +1,6 @@
-import Link from 'next/link';
 import React from 'react';
 import { asArray } from '../../lib/util';
+import { Link } from './link';
 
 const startsWithVowel = (str: string) => {
     const firstLetter = str[0].toLowerCase();
@@ -21,7 +21,6 @@ export const ModelCard = ({ id, author, architecture, scale, tags, description }
         <div
             // eslint-disable-next-line tailwindcss/no-arbitrary-value
             className="group relative h-[350px] overflow-hidden rounded-lg border border-solid border-gray-300 shadow-lg hover:shadow-xl dark:border-gray-700 "
-            key={id}
         >
             <div className="relative flex h-full w-full flex-col transition-all ease-in-out">
                 {/* Arch tag on image */}
@@ -36,12 +35,10 @@ export const ModelCard = ({ id, author, architecture, scale, tags, description }
                     </div>
                 </div>
 
-                <a
+                <Link
                     // eslint-disable-next-line tailwindcss/no-arbitrary-value
                     className="h-auto w-full flex-1  bg-[url(https://picsum.photos/512/312)] bg-cover bg-center transition-all duration-500 ease-in-out group-hover:h-full"
                     href={`/models/${id}`}
-                    rel="noreferrer"
-                    target="_blank"
                 />
 
                 <div className="relative inset-x-0 bottom-0 bg-white p-3 pt-2 dark:bg-fade-900">
@@ -56,11 +53,12 @@ export const ModelCard = ({ id, author, architecture, scale, tags, description }
                             </Link>
                             <div className="mr-1">model by</div>
                             {asArray(author).map((userId) => (
-                                <React.Fragment key={userId}>
-                                    <Link href={`/users/${userId}`}>
-                                        <div className="font-bold text-accent-500">{userId}</div>
-                                    </Link>
-                                </React.Fragment>
+                                <Link
+                                    href={`/users/${userId}`}
+                                    key={userId}
+                                >
+                                    <div className="font-bold text-accent-500">{userId}</div>
+                                </Link>
                             ))}
                         </div>
                     </div>

--- a/src/elements/components/searchbar.tsx
+++ b/src/elements/components/searchbar.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent } from 'react';
 
 type SearchBarProps = {
-    value?: string;
+    value: string;
     onChange: (event: ChangeEvent<HTMLInputElement>) => void;
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -92,7 +92,8 @@ export default function Page({ modelData }: Props) {
                             </p>
 
                             <p className="mx-auto max-w-screen-md text-center text-gray-500 md:text-lg">
-                                Currently listing <a className="font-bold text-accent-500">{modelCount}</a> models.
+                                Currently listing <span className="font-bold text-accent-500">{modelCount}</span>{' '}
+                                models.
                             </p>
 
                             {/* Search */}

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -116,7 +116,7 @@ export default function Page({ modelId, modelData }: Props) {
                     <div className="col-span-1 w-full">
                         {/* Download Button */}
                         <div className="mb-2">
-                            {model.resources.map((resource) => {
+                            {model.resources.flatMap((resource) => {
                                 return resource.urls.map((url) => (
                                     <DownloadButton
                                         key={url}


### PR DESCRIPTION
- Fixed incorrect usage of `key`.
- Removed unnecessary `React.Fragement`s.
- Proper usage of `a` and `Link` (our).
- Fixed model card using internal and external links inconsistently. They are all internal now.
- Fixed `SearchBar` allowing optional `value`. If `value` is undefined, the underlying `input` is uncontrolled and switching from uncontrolled to controlled is not allowed by React.

@Joey about links: The idea of my `Link` component was to have a link component that we control and that handles internal vs external links. This difference needs to be handled because NextJS uses client side routing, so it's `Link` (from `next/link`) is special and cannot be exchanged with a regular `a` lightly.