### PR TITLE
Show names for tags, users, and models

### DIFF
--- a/data/tags.json
+++ b/data/tags.json
@@ -88,6 +88,7 @@
         "description": ""
     },
     "dedither": {
-        "name": "Dedither"
+        "name": "Dedither",
+        "description": ""
     }
 }

--- a/src/elements/components/model-card.tsx
+++ b/src/elements/components/model-card.tsx
@@ -1,18 +1,25 @@
 import React from 'react';
+import { useTags } from '../../lib/hooks/use-tags';
+import { useUsers } from '../../lib/hooks/use-users';
 import { joinList } from '../../lib/react-util';
+import { ModelId, TagId, UserId } from '../../lib/schema';
 import { asArray } from '../../lib/util';
 import { Link } from './link';
 
 type ModelCardProps = {
-    id: string;
-    author: string | string[];
+    id: ModelId;
+    name: string;
+    author: UserId | UserId[];
     architecture: string;
     scale: number;
-    tags: string[];
+    tags: TagId[];
     description: string;
 };
 
-export const ModelCard = ({ id, author, architecture, scale, tags, description }: ModelCardProps) => {
+export const ModelCard = ({ id, name, author, architecture, scale, tags, description }: ModelCardProps) => {
+    const { tagData } = useTags();
+    const { userData } = useUsers();
+
     return (
         <div
             // eslint-disable-next-line tailwindcss/no-arbitrary-value
@@ -39,7 +46,7 @@ export const ModelCard = ({ id, author, architecture, scale, tags, description }
 
                 <div className="relative inset-x-0 bottom-0 bg-white p-3 pt-2 dark:bg-fade-900">
                     <Link href={`/models/${id}`}>
-                        <div className="block text-xl font-bold text-gray-800 dark:text-gray-100">{id}</div>
+                        <div className="block text-xl font-bold text-gray-800 dark:text-gray-100">{name}</div>
                     </Link>
                     <div className="text-sm text-gray-600 dark:text-gray-400">
                         <div>
@@ -51,7 +58,7 @@ export const ModelCard = ({ id, author, architecture, scale, tags, description }
                                         href={`/users/${userId}`}
                                         key={userId}
                                     >
-                                        {userId}
+                                        {userData.get(userId)?.name ?? `unknown user:${userId}`}
                                     </Link>
                                 ))
                             )}
@@ -65,12 +72,12 @@ export const ModelCard = ({ id, author, architecture, scale, tags, description }
 
                     {/* Tags */}
                     <div className="flex flex-row flex-wrap gap-1">
-                        {tags.map((tag) => (
+                        {tags.map((tagId) => (
                             <div
-                                className="rounded-lg bg-gray-200 px-2 py-1 text-xs font-medium uppercase text-gray-800 dark:bg-gray-700 dark:text-gray-100"
-                                key={tag}
+                                className="rounded-lg bg-gray-200 px-2 py-1 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-100"
+                                key={tagId}
                             >
-                                {tag}
+                                {tagData.get(tagId)?.name ?? `unknown tag:${tagId}`}
                             </div>
                         ))}
                     </div>

--- a/src/lib/hooks/use-tags.ts
+++ b/src/lib/hooks/use-tags.ts
@@ -1,0 +1,14 @@
+import { Tag, TagId } from '../schema';
+import { STATIC_TAG_DATA } from '../static-data';
+
+export interface UseTags {
+    readonly tagData: ReadonlyMap<TagId, Tag>;
+}
+
+const result: UseTags = {
+    tagData: STATIC_TAG_DATA,
+};
+
+export function useTags(): UseTags {
+    return result;
+}

--- a/src/lib/hooks/use-users.ts
+++ b/src/lib/hooks/use-users.ts
@@ -1,0 +1,14 @@
+import { User, UserId } from '../schema';
+import { STATIC_USER_DATA } from '../static-data';
+
+export interface UseUsers {
+    readonly userData: ReadonlyMap<UserId, User>;
+}
+
+const result: UseUsers = {
+    userData: STATIC_USER_DATA,
+};
+
+export function useUsers(): UseUsers {
+    return result;
+}

--- a/src/lib/static-data.ts
+++ b/src/lib/static-data.ts
@@ -1,0 +1,15 @@
+import tags from '../../data/tags.json';
+import users from '../../data/users.json';
+import { Tag, TagId, User, UserId } from './schema';
+
+export const STATIC_TAG_DATA: ReadonlyMap<TagId, Tag> = new Map(
+    Object.entries(tags).map(([k, v]: [string, Tag]) => {
+        return [k as TagId, v];
+    })
+);
+
+export const STATIC_USER_DATA: ReadonlyMap<UserId, User> = new Map(
+    Object.entries(users).map(([k, v]: [string, User]) => {
+        return [k as UserId, v];
+    })
+);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState } from 'react';
 import { ModelCard } from '../elements/components/model-card';
 import { SearchBar } from '../elements/components/searchbar';
 import { PageContainer } from '../elements/page';
+import { useTags } from '../lib/hooks/use-tags';
 import { Model, ModelId, TagId } from '../lib/schema';
 import { Condition, compileCondition } from '../lib/search/logical-condition';
 import { CorpusEntry, SearchIndex } from '../lib/search/search-index';
@@ -46,7 +47,7 @@ export default function Page({ modelData }: Props) {
     }, [modelData]);
     const modelCount = searchIndex.entries.size;
 
-    const allTags = useMemo(() => new Set<string>(Object.values(modelData).flatMap((m) => m.tags)), [modelData]);
+    const allTags = useMemo(() => [...new Set(Object.values(modelData).flatMap((m) => m.tags))], [modelData]);
     const [selectedTag, setSelectedTag] = useState<TagId>();
     const [searchQuery, setSearchQuery] = useState<string>('');
 
@@ -60,6 +61,8 @@ export default function Page({ modelData }: Props) {
             .sort((a, b) => b.score - a.score);
         return searchResults.map((r) => r.id);
     }, [selectedTag, searchQuery, searchIndex]);
+
+    const { tagData } = useTags();
 
     return (
         <>
@@ -106,23 +109,23 @@ export default function Page({ modelData }: Props) {
                             <div className="mb-2 flex flex-row flex-wrap place-content-center justify-items-center align-middle">
                                 <div
                                     className={joinClasses(
-                                        'mr-2 mb-2 w-fit cursor-pointer rounded-lg bg-gray-200 px-2 py-1 text-sm font-medium uppercase text-gray-800 transition-colors ease-in-out hover:bg-fade-500 hover:text-gray-100 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-fade-500',
+                                        'mr-2 mb-2 w-fit cursor-pointer rounded-lg bg-gray-200 px-2 py-1 text-sm font-medium text-gray-800 transition-colors ease-in-out hover:bg-fade-500 hover:text-gray-100 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-fade-500',
                                         !selectedTag && 'bg-accent-500 text-gray-100 dark:bg-accent-500 '
                                     )}
                                     onClick={() => setSelectedTag(undefined)}
                                 >
                                     All
                                 </div>
-                                {Array.from(allTags).map((tag) => (
+                                {allTags.map((tag) => (
                                     <div
                                         className={joinClasses(
-                                            'mr-2 mb-2 w-fit cursor-pointer rounded-lg bg-gray-200 px-2 py-1 text-sm font-medium uppercase text-gray-800 transition-colors ease-in-out hover:bg-fade-500 hover:text-gray-100 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-fade-500',
+                                            'mr-2 mb-2 w-fit cursor-pointer rounded-lg bg-gray-200 px-2 py-1 text-sm font-medium text-gray-800 transition-colors ease-in-out hover:bg-fade-500 hover:text-gray-100 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-fade-500',
                                             selectedTag == tag && 'bg-accent-500 text-gray-100 dark:bg-accent-500 '
                                         )}
                                         key={tag}
-                                        onClick={() => setSelectedTag(selectedTag == tag ? undefined : (tag as TagId))}
+                                        onClick={() => setSelectedTag(selectedTag == tag ? undefined : tag)}
                                     >
-                                        {tag}
+                                        {tagData.get(tag)?.name ?? `unknown tag:${tag}`}
                                     </div>
                                 ))}
                             </div>
@@ -130,7 +133,7 @@ export default function Page({ modelData }: Props) {
                             {availableModels.length > 0 ? (
                                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                                     {availableModels.map((id) => {
-                                        const { architecture, author, scale, description, tags } = modelData[id];
+                                        const { name, architecture, author, scale, description, tags } = modelData[id];
 
                                         const actualDescription = fixDescription(description, scale);
 
@@ -141,6 +144,7 @@ export default function Page({ modelData }: Props) {
                                                 description={actualDescription}
                                                 id={id}
                                                 key={id}
+                                                name={name}
                                                 scale={scale}
                                                 tags={tags}
                                             />

--- a/src/pages/users/[id].tsx
+++ b/src/pages/users/[id].tsx
@@ -6,7 +6,7 @@ import { ModelCard } from '../../elements/components/model-card';
 import { PageContainer } from '../../elements/page';
 import { Model, ModelId, User, UserId } from '../../lib/schema';
 import { fileApi } from '../../lib/server/file-data';
-import { fixDescription } from '../../lib/util';
+import { fixDescription, typedKeys } from '../../lib/util';
 
 interface Params extends ParsedUrlQuery {
     id: UserId;
@@ -45,8 +45,8 @@ export default function Page({ user, models }: Props) {
 
                             {/* Model Cards */}
                             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                                {Object.keys(models).map((id) => {
-                                    const { architecture, author, scale, description, tags } = models[id as ModelId];
+                                {typedKeys(models).map((id) => {
+                                    const { name, architecture, author, scale, description, tags } = models[id];
 
                                     const actualDescription = fixDescription(description, scale);
 
@@ -57,6 +57,7 @@ export default function Page({ user, models }: Props) {
                                             description={actualDescription}
                                             id={id}
                                             key={id}
+                                            name={name}
                                             scale={scale}
                                             tags={tags}
                                         />


### PR DESCRIPTION
Model names still have to be cleaned up, but that's for later.

![image](https://user-images.githubusercontent.com/20878432/224106358-c2a6c24d-6c04-4ecc-82a0-2bfe658b833f.png)

`useTags` and `useUsers` are hooks, because their implementation will likely change in the future. I expect that we will likely have to refetch data in edit mode in the future, so I made these hooks for that.