### PR TITLE
Reload model data on mutation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@headlessui/react": "^1.7.9",
         "@next/font": "13.1.5",
         "@tailwindcss/line-clamp": "^0.4.2",
+        "chokidar": "^3.5.3",
         "chroma-js": "^2.4.2",
         "next": "13.1.5",
         "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@headlessui/react": "^1.7.9",
     "@next/font": "13.1.5",
     "@tailwindcss/line-clamp": "^0.4.2",
+    "chokidar": "^3.5.3",
     "chroma-js": "^2.4.2",
     "next": "13.1.5",
     "react": "18.2.0",

--- a/src/lib/hooks/use-models.ts
+++ b/src/lib/hooks/use-models.ts
@@ -1,0 +1,28 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Model, ModelId } from '../schema';
+import { typedEntries } from '../util';
+import { addUpdateListener, getWebApi, startListeningForUpdates } from '../web-api';
+
+export interface UseModels {
+    readonly modelData: ReadonlyMap<ModelId, Model>;
+}
+
+export function useModels(models: Readonly<Record<ModelId, Model>>): UseModels {
+    const staticData = useMemo(() => new Map(typedEntries(models)), [models]);
+    const [dynamicData, setDynamicData] = useState<ReadonlyMap<ModelId, Model>>();
+
+    useEffect(() => {
+        startListeningForUpdates();
+        return addUpdateListener(() => {
+            getWebApi()
+                .then(async (webApi) => {
+                    if (!webApi) return;
+                    const models = await webApi.models.getAll();
+                    setDynamicData(models);
+                })
+                .catch((e) => console.error(e));
+        });
+    }, []);
+
+    return { modelData: dynamicData ?? staticData };
+}

--- a/src/pages/api/mutation-sse.ts
+++ b/src/pages/api/mutation-sse.ts
@@ -1,0 +1,35 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getFileApiMutationCounter } from '../../lib/server/file-data';
+import { delay } from '../../lib/util';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    res.setHeader('Content-Type', 'text/event-stream;charset=utf-8');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('X-Accel-Buffering', 'no');
+
+    let lastCount = NaN;
+    let ticksSinceLastMessage = 0;
+    for (;;) {
+        try {
+            await delay(10);
+            const count = await getFileApiMutationCounter();
+            if (count !== lastCount) {
+                lastCount = count;
+                ticksSinceLastMessage = 0;
+                res.write(`data: ${count}\n\n`);
+            } else {
+                ticksSinceLastMessage++;
+
+                if (ticksSinceLastMessage > 1000) {
+                    ticksSinceLastMessage = 0;
+                    res.write(`: keep alive\n\n`);
+                }
+            }
+        } catch (error) {
+            console.error(error);
+            break;
+        }
+    }
+
+    res.end('done\n');
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,22 +5,25 @@ import { ModelCard } from '../elements/components/model-card';
 import { SearchBar } from '../elements/components/searchbar';
 import { PageContainer } from '../elements/page';
 import { deriveTags } from '../lib/derive-tags';
+import { useModels } from '../lib/hooks/use-models';
 import { useTags } from '../lib/hooks/use-tags';
 import { Model, ModelId, TagId } from '../lib/schema';
 import { Condition, compileCondition } from '../lib/search/logical-condition';
 import { CorpusEntry, SearchIndex } from '../lib/search/search-index';
 import { tokenize } from '../lib/search/token';
 import { fileApi } from '../lib/server/file-data';
-import { asArray, compareTagId, joinClasses, typedEntries } from '../lib/util';
+import { asArray, compareTagId, joinClasses } from '../lib/util';
 
 interface Props {
     modelData: Record<ModelId, Model>;
 }
 
-export default function Page({ modelData }: Props) {
+export default function Page({ modelData: staticModelData }: Props) {
+    const { modelData } = useModels(staticModelData);
+
     const searchIndex = useMemo(() => {
         return new SearchIndex(
-            typedEntries(modelData).map(([id, model]): CorpusEntry<ModelId, TagId> => {
+            [...modelData].map(([id, model]): CorpusEntry<ModelId, TagId> => {
                 return {
                     id,
                     tags: new Set(deriveTags(model)),
@@ -51,7 +54,7 @@ export default function Page({ modelData }: Props) {
     const allTags = useMemo(
         () => [
             ...new Set(
-                Object.values(modelData)
+                [...modelData.values()]
                     .flatMap(deriveTags)
                     .filter((t) => !t.startsWith('by:'))
                     .sort(compareTagId)
@@ -148,7 +151,8 @@ export default function Page({ modelData }: Props) {
                                             <ModelCard
                                                 id={id}
                                                 key={id}
-                                                model={modelData[id]}
+                                                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                                                model={modelData.get(id)!}
                                             />
                                         );
                                     })}


### PR DESCRIPTION
This PR adds SSE to make the backend tell the frontend about mutations to the underlying database. This includes mutations done by the frontend and mutations done my manual edits (e.g. by directly editing data files in an editor). As a result, the data shown in the frontend is now synchronized, so when you make an edit in one page, those changes are reflected everywhere in real time.

Detecting manual edits to files is done using chokidar. I have seen some problems with chokidar and NextJS hot reloading, but it seems to mostly work fine now.