### PR TITLE
Added URLs for self-hosted models

### DIFF
--- a/data/models/16x-ESRGAN.json
+++ b/data/models/16x-ESRGAN.json
@@ -21,6 +21,7 @@
             "size": 67249159,
             "sha256": "8701acac21c4c412a3e05242b389700c1248ff52314380793c045326f4c61dfb",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F16x-ESRGAN.pth",
                 "https://mega.nz/#!btwEXAoI!nNxWI89OdQCEkcRoPEFwj6GoFN8uzZyZFaCn1wbhzKY"
             ]
         }

--- a/data/models/1x-AnimeUndeint-Compact.json
+++ b/data/models/1x-AnimeUndeint-Compact.json
@@ -24,6 +24,7 @@
             "size": 4795821,
             "sha256": "f8b2b98c4e5dd3989b836414e2624e0795d74a8eba44e32cba6d18cce181140c",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-AnimeUndeint-Compact.pth",
                 "https://mega.nz/file/9INFwYLD#KlV11g5yDG6fWWdZDXhztnsqhuLSIUP7-Upq3szgMCQ"
             ]
         }

--- a/data/models/1x-Anti-Aliasing.json
+++ b/data/models/1x-Anti-Aliasing.json
@@ -22,6 +22,7 @@
             "size": 66662414,
             "sha256": "7a4cb10276899d6d93ba35f174653a11ebdcea5c6ca93aee226c108d177f311f",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-Anti-Aliasing.pth",
                 "https://de-next.owncube.com/index.php/s/mmYCcK4H3rQQR5Y"
             ]
         }

--- a/data/models/1x-BleedOut-Compact.json
+++ b/data/models/1x-BleedOut-Compact.json
@@ -24,6 +24,7 @@
             "size": 4795821,
             "sha256": "86a9c0bbeb130aa01b7d5c3ea32691a521a4de65771d7133fa57a58ac4f5485c",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-BleedOut-Compact.pth",
                 "https://mega.nz/file/lNdTmSKD#R7GIISShx-zsUVwDHw0oosv72ifbB31GClXXV3UtLLo"
             ]
         }

--- a/data/models/1x-BroadcastToStudioLite.json
+++ b/data/models/1x-BroadcastToStudioLite.json
@@ -23,6 +23,7 @@
             "size": 20098601,
             "sha256": "912ff494e454a135ba2341d522c38089736654daf32bd6c7bb81549bb9512d38",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-BroadcastToStudioLite.pth",
                 "https://mega.nz/file/TO4S3KoT#eOiYCKWp0-O0rgBC0xgUl87DrPTbZ2or-NDgf22kPGA"
             ]
         }

--- a/data/models/1x-Compact-Pretrain.json
+++ b/data/models/1x-Compact-Pretrain.json
@@ -21,6 +21,7 @@
             "size": "d5dff3f43490aaaf1e007445902311034c746ac77363f917f5c15196bfd08dea",
             "sha256": null,
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-Compact-Pretrain.pth",
                 "https://mega.nz/file/Bc0SmIyK#ThTyculaFvrLGMIY8FicUUWBem8O_ZF8LgpPXCn7aVQ"
             ]
         }

--- a/data/models/1x-DeBink-Lite.json
+++ b/data/models/1x-DeBink-Lite.json
@@ -21,6 +21,7 @@
             "size": 20098601,
             "sha256": "4c2e3a7cde1fd73d9df41f5152aa5888c6e512ea5788ab87de486d1f97848a9f",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-DeBink-Lite.pth",
                 "https://mega.nz/folder/6cxHzIxB#IN6ZgG-S0j3LjM0x5DEqew"
             ]
         }

--- a/data/models/1x-DeJpeg-Fatality-PlusULTRA.json
+++ b/data/models/1x-DeJpeg-Fatality-PlusULTRA.json
@@ -22,6 +22,7 @@
             "size": 66662414,
             "sha256": "1c93728803e9a3525afa4d7b23e08be531202e2ffc1f046f79bd1733be139c21",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-DeJpeg-Fatality-PlusULTRA.pth",
                 "https://de-next.owncube.com/index.php/s/w82HLrLWmWi4SQ5"
             ]
         }

--- a/data/models/1x-DeRoqBeta-lite.json
+++ b/data/models/1x-DeRoqBeta-lite.json
@@ -21,6 +21,7 @@
             "size": 20098601,
             "sha256": "47522c0342d41e5d40db84105f3973db2700462b62c2625479201e3f897f44a0",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-DeRoqBeta-lite.pth",
                 "https://mega.nz/file/qAY11ZBR#zgLbwfSI2MDYHb0HxehLkq4cppEg-U9bplxHu5hVrgU"
             ]
         }

--- a/data/models/1x-Debandurh-FS-Ultra-lite.json
+++ b/data/models/1x-Debandurh-FS-Ultra-lite.json
@@ -22,6 +22,7 @@
             "size": 2708872,
             "sha256": "027dfbf10e0ff3f8347960106f89443241b85e91edbd7329d3ded50829ee98f7",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-Debandurh-FS-Ultra-lite.pth",
                 "https://f002.backblazeb2.com/file/ESRGAN/_RELEASE/1x_Debandurh_FS_lite_140000_G.pth"
             ]
         }

--- a/data/models/1x-Dotzilla-Compact.json
+++ b/data/models/1x-Dotzilla-Compact.json
@@ -24,6 +24,7 @@
             "size": 4796829,
             "sha256": "197d59563f635e4ab7c78f558376b7c903737fe14889d3294ec198df27955507",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-Dotzilla-Compact.pth",
                 "https://mega.nz/file/VQkDmSgb#dlVuJZQ__yAKdJaWA_4Nx52YU_c2qy_a2oG9_a98dO4"
             ]
         }

--- a/data/models/1x-ESRGAN.json
+++ b/data/models/1x-ESRGAN.json
@@ -21,6 +21,7 @@
             "size": 66656830,
             "sha256": "25e733e2b0d6ada63b07ace241e0f1065cec0d08945d6b20b9d46cc88bfa8b5d",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-ESRGAN.pth",
                 "https://mega.nz/#!D940CAKR!-BAx7tSj1CgeopGkaMW31VuPsC3hvNBL35TEVAj4LIo"
             ]
         }

--- a/data/models/1x-Epsilon-one-compact.json
+++ b/data/models/1x-Epsilon-one-compact.json
@@ -23,6 +23,7 @@
             "size": 4795821,
             "sha256": "1326bd9e45a198be6ca84919ade3fec458a07d078894a644711ed72cef66d096",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-Epsilon-one-compact.pth",
                 "https://drive.google.com/drive/folders/13PhLXD3Pvo1A7LwHGIeY_ekObva_333e?usp=share_link"
             ]
         }

--- a/data/models/1x-Fatality-DeBlur.json
+++ b/data/models/1x-Fatality-DeBlur.json
@@ -22,6 +22,7 @@
             "size": 66662414,
             "sha256": "949ab41ddccaa13f4ae89c0f2ec3715b6786cca521e5300f5f57f66e85cf4dec",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-Fatality-DeBlur.pth",
                 "https://de-next.owncube.com/index.php/s/aAojXwLTPZto8rP"
             ]
         }

--- a/data/models/1x-Film-Degrainer-1-000.json
+++ b/data/models/1x-Film-Degrainer-1-000.json
@@ -22,6 +22,7 @@
             "size": 37843615,
             "sha256": "6a4ecccaea32825a09150df1106fd6990308e1442d71c1bd9f6a17e6196364fd",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-Film-Degrainer-1-000.pth",
                 "https://drive.google.com/file/d/1kO3fx9FL5rKhoDk2n4kiiPWuCNHojkIR/view",
                 "https://drive.google.com/file/d/1a25Y2S_4LUOOiAyJfFJF29Jp8IGjlBuZ/view"
             ]

--- a/data/models/1x-FrankenMapGenerator-CX-Lite.json
+++ b/data/models/1x-FrankenMapGenerator-CX-Lite.json
@@ -22,6 +22,7 @@
             "size": 20098601,
             "sha256": "15405908c94795a13e1c320bda01287b72f76a0b5ed0bd40d00192dd1223326d",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-FrankenMapGenerator-CX-Lite.pth",
                 "https://u.pcloud.link/publink/show?code=kZecVzXZEO6fAyO6w25YDc43BkSVHRgFdOwX"
             ]
         }

--- a/data/models/1x-HurrDeblur-SuperUltraCompact.json
+++ b/data/models/1x-HurrDeblur-SuperUltraCompact.json
@@ -24,6 +24,7 @@
             "size": 362039,
             "sha256": "d91fa17c4392918af37e3b9b3a4ebbf2affe591f39046a34f0c67543a35f401e",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-HurrDeblur-SuperUltraCompact.pth",
                 "https://mega.nz/file/MZdEja6I#ao8L6INGvzns4IlDpyzjpuzR-kIqm_VrC3Q8pUTZncM"
             ]
         }

--- a/data/models/1x-ITF-SkinDiffDetail-Lite-v1.json
+++ b/data/models/1x-ITF-SkinDiffDetail-Lite-v1.json
@@ -21,6 +21,7 @@
             "size": 20099337,
             "sha256": "94d368b633614958f84f335b129fd85abd30200e8fbc575b859ba6762116222b",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-ITF-SkinDiffDetail-Lite-v1.pth",
                 "https://drive.google.com/drive/folders/1VkT6tpbCPn2gKZYPtawDJGMpLg6EyRpO?usp=sharing"
             ]
         }

--- a/data/models/1x-KDM003-scans.json
+++ b/data/models/1x-KDM003-scans.json
@@ -21,6 +21,7 @@
             "size": 66658226,
             "sha256": "42c5ca0f9f2e7915e0b05af5efea6e4d6cff8c97a0c7903f460d52981ced8168",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-KDM003-scans.pth",
                 "https://www.dropbox.com/s/52hsqa7ymt5pgga/KDM003_scans_1x.pth"
             ]
         }

--- a/data/models/1x-Kim2091-DeJpeg-v0.json
+++ b/data/models/1x-Kim2091-DeJpeg-v0.json
@@ -22,6 +22,7 @@
             "size": 9163566,
             "sha256": "db343cb007e25a6fc2d750385cef21a15b55953a35d4993746998ee8453a91ec",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-Kim2091-DeJpeg-v0.pth",
                 "https://mega.nz/file/jcZQ1J6A#qLlSGBFQPWyQ0kUbOcvPN5kEYalPGUu9iR6EkEuS-T4"
             ]
         }

--- a/data/models/1x-MangaJPEGHQ.json
+++ b/data/models/1x-MangaJPEGHQ.json
@@ -22,6 +22,7 @@
             "size": 20092251,
             "sha256": "e2898bfba74083025a2bd2326b6c159031b882a890bd1cc30fd6910cda2ce4ee",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-MangaJPEGHQ.pth",
                 "https://mega.nz/folder/fAg21TRI#kBk0synXgNqTGaXiW6nSZA"
             ]
         }

--- a/data/models/1x-MangaJPEGHQPlus.json
+++ b/data/models/1x-MangaJPEGHQPlus.json
@@ -22,6 +22,7 @@
             "size": 20092251,
             "sha256": "3126339603a3876f541d054bd40cdad417141a32c14e91fd6adaeaf04677be34",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-MangaJPEGHQPlus.pth",
                 "https://mega.nz/folder/fAg21TRI#kBk0synXgNqTGaXiW6nSZA"
             ]
         }

--- a/data/models/1x-MangaJPEGLQ.json
+++ b/data/models/1x-MangaJPEGLQ.json
@@ -22,6 +22,7 @@
             "size": 20092251,
             "sha256": "af11ec91b6a38e0109cbb926b19e8a01975f947aacb3490f008dcab06e9b922d",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-MangaJPEGLQ.pth",
                 "https://mega.nz/folder/fAg21TRI#kBk0synXgNqTGaXiW6nSZA"
             ]
         }

--- a/data/models/1x-MangaJPEGMQ.json
+++ b/data/models/1x-MangaJPEGMQ.json
@@ -22,6 +22,7 @@
             "size": 20092251,
             "sha256": "42529335f43ac04f615af3442b2570d23dc64a206e2da4741bf5f835206354ae",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-MangaJPEGMQ.pth",
                 "https://mega.nz/folder/fAg21TRI#kBk0synXgNqTGaXiW6nSZA"
             ]
         }

--- a/data/models/1x-NMKD-Jaywreck3-Lite.json
+++ b/data/models/1x-NMKD-Jaywreck3-Lite.json
@@ -22,6 +22,7 @@
             "size": 20096393,
             "sha256": "3b2654a3bfa6e07bdebde48414d69b89ee3a1d1516ff9b26c3f4c6ee14f7d3f0",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-NMKD-Jaywreck3-Lite.pth",
                 "https://icedrive.net/1/43GNBihZyi"
             ]
         }

--- a/data/models/1x-NMKD-Jaywreck3-Soft-Lite.json
+++ b/data/models/1x-NMKD-Jaywreck3-Soft-Lite.json
@@ -22,6 +22,7 @@
             "size": 20096393,
             "sha256": "bbd1b6e9002ad9cbb4c5049850a361e110b8ed0ae22f5ed0fb49ddf5a6951f53",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-NMKD-Jaywreck3-Soft-Lite.pth",
                 "https://icedrive.net/1/43GNBihZyi"
             ]
         }

--- a/data/models/1x-NormalMapGenerator-CX-Lite.json
+++ b/data/models/1x-NormalMapGenerator-CX-Lite.json
@@ -22,6 +22,7 @@
             "size": 20098601,
             "sha256": "dce313777fac7b2f98101538f15a153acfa92cbf4bb62a8cd4a89edc0eb313dc",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-NormalMapGenerator-CX-Lite.pth",
                 "https://u.pcloud.link/publink/show?code=kZEdNHXZ3bpVwUoge94d9igFWxbjQQrcbpny"
             ]
         }

--- a/data/models/1x-ReFocus-Cleanly.json
+++ b/data/models/1x-ReFocus-Cleanly.json
@@ -22,6 +22,7 @@
             "size": 66665765,
             "sha256": "f38e8be5524126e9923849cc37e1c9ca308d2d72f26e89147c95d6fde8b18a13",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-ReFocus-Cleanly.pth",
                 "https://de-next.owncube.com/index.php/s/GjbBw7pcgm5gmYm"
             ]
         }

--- a/data/models/1x-ReFocus-V3.json
+++ b/data/models/1x-ReFocus-V3.json
@@ -22,6 +22,7 @@
             "size": 66665765,
             "sha256": "94d8f38726c7abaa83a3fad27c01863ba961f76a995d8541c173eb3195062547",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-ReFocus-V3.pth",
                 "https://de-next.owncube.com/index.php/s/HyygDgXEB45JqBH"
             ]
         }

--- a/data/models/1x-SBDV-DeJPEG-Lite.json
+++ b/data/models/1x-SBDV-DeJPEG-Lite.json
@@ -22,6 +22,7 @@
             "size": 20098601,
             "sha256": "4a25b158ec7830e742890872a21b5cf900d7653338bbaebd3a67dc8419eed7e5",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-SBDV-DeJPEG-Lite.pth",
                 "https://u.pcloud.link/publink/show?code=kZvfeFXZMyUSYScxAizUmTKjax0JQzTk9Gfk"
             ]
         }

--- a/data/models/1x-SaiyaJin-DeJpeg.json
+++ b/data/models/1x-SaiyaJin-DeJpeg.json
@@ -22,6 +22,7 @@
             "size": 66665765,
             "sha256": "01b61695d20543009a0c8bf17ee80d31f6d8e4e237134ecded3fd9266dbe3750",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-SaiyaJin-DeJpeg.pth",
                 "https://f002.backblazeb2.com/file/ESRGAN/_RELEASE/1x_Saiyajin_DeJPEG_300000_G.pth"
             ]
         }

--- a/data/models/1x-SheeepIt.json
+++ b/data/models/1x-SheeepIt.json
@@ -23,6 +23,7 @@
             "size": 9163070,
             "sha256": "8361b9a7e4c0177d2b05246927b0e9c397dae82473c08587fba60532331d229c",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-SheeepIt.pth",
                 "https://mega.nz/folder/GBQ10DbR#hfQ_Hl9EvUZg0wqdA_M4_A"
             ]
         }

--- a/data/models/1x-SpongeBC1-Lite.json
+++ b/data/models/1x-SpongeBC1-Lite.json
@@ -23,6 +23,7 @@
             "size": 20098601,
             "sha256": "6d31cdd85e382035ba2946017fd10e9268c70b33be2ec7fbc0f6d212c509167b",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-SpongeBC1-Lite.pth",
                 "https://u.pcloud.link/publink/show?code=kZ8f9HXZaNaKIDTqP9YPl33NGlz7VmaA3kqV"
             ]
         }

--- a/data/models/1x-SpongeColor-Lite.json
+++ b/data/models/1x-SpongeColor-Lite.json
@@ -22,6 +22,7 @@
             "size": 20096297,
             "sha256": "60bb61bffe5b2260670f7530173770f35a856a6919eec5962985ac97150bdeec",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-SpongeColor-Lite.pth",
                 "https://u.pcloud.link/publink/show?code=kZpAGFXZARxWIu9Pp4YDLUSIN8I8aFuJ5TKV"
             ]
         }

--- a/data/models/1x-SuperUltraCompact-Pretrain.json
+++ b/data/models/1x-SuperUltraCompact-Pretrain.json
@@ -21,6 +21,7 @@
             "size": "d91fa17c4392918af37e3b9b3a4ebbf2affe591f39046a34f0c67543a35f401e",
             "sha256": null,
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-SuperUltraCompact-Pretrain.pth",
                 "https://mega.nz/file/Bc0SmIyK#ThTyculaFvrLGMIY8FicUUWBem8O_ZF8LgpPXCn7aVQ"
             ]
         }

--- a/data/models/1x-SwatKatsLite.json
+++ b/data/models/1x-SwatKatsLite.json
@@ -23,6 +23,7 @@
             "size": 20098601,
             "sha256": "fc49168dc58e000f2bdaedc69590a34cd7ff0abe970b6691d953c5d7559fcf07",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-SwatKatsLite.pth",
                 "https://mega.nz/file/La5AQCKb#aXvqZE9ZhlImJICJ8DRGI9CZfdtL9J9quQvoRmYFan0"
             ]
         }

--- a/data/models/1x-ThePi7on-Solidd-Deborutify-UltraLite.json
+++ b/data/models/1x-ThePi7on-Solidd-Deborutify-UltraLite.json
@@ -22,6 +22,7 @@
             "size": 4808930,
             "sha256": "f2c86ac406566d4299a061c8578c542d86b3539ce2634e12df65a06c4cee314f",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-ThePi7on-Solidd-Deborutify-UltraLite.pth",
                 "https://mega.nz/file/CYoXCAKR#eRKwpP9rCL9vFCsO41oVImvmVwAEOtYUlp2CquX0Fw8"
             ]
         }

--- a/data/models/1x-UltraCompact-Pretrain.json
+++ b/data/models/1x-UltraCompact-Pretrain.json
@@ -21,6 +21,7 @@
             "size": "7d9a62952d0326934da4881817de7fc23f17c313be6654a9b997145f2e76bff2",
             "sha256": null,
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-UltraCompact-Pretrain.pth",
                 "https://mega.nz/file/Bc0SmIyK#ThTyculaFvrLGMIY8FicUUWBem8O_ZF8LgpPXCn7aVQ"
             ]
         }

--- a/data/models/1x-UnResize-V3.json
+++ b/data/models/1x-UnResize-V3.json
@@ -22,6 +22,7 @@
             "size": 66665765,
             "sha256": "41c1fd640c265375b4649f6c41772714081ea77faf07593456c8021638d3e1d3",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-UnResize-V3.pth",
                 "https://de-next.owncube.com/index.php/s/nmNfcd33mnLLwEC"
             ]
         }

--- a/data/models/1x-cinepak.json
+++ b/data/models/1x-cinepak.json
@@ -21,6 +21,7 @@
             "size": 66662414,
             "sha256": "daff496050e7eccd300f011e3abe08cdcb44d100236fe66cc291de86cb7262b5",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-cinepak.pth",
                 "https://de-next.owncube.com/index.php/s/wKjLmYsq7M5JAmx"
             ]
         }

--- a/data/models/1x-mdeblur.json
+++ b/data/models/1x-mdeblur.json
@@ -22,6 +22,7 @@
             "size": 66662414,
             "sha256": "e4c19f65bc0d217b4c3c17e32ac12d4a351ba6e3f7d5d36118c1f4f7a5b7abec",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F1x-mdeblur.pth",
                 "https://cloud.owncube.com/s/p3w7M2sfaWWYCK9/download?path=%2F&files=1x_mdeblur.pth"
             ]
         }

--- a/data/models/2x-ATLA-KORRA.json
+++ b/data/models/2x-ATLA-KORRA.json
@@ -23,6 +23,7 @@
             "size": 66811909,
             "sha256": "66fb9c47d1ad45ebe82a6f2afd7c2d9cc1bc5f1e3ffca9761eecfde2a0b2f450",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-ATLA-KORRA.pth",
                 "https://www108.zippyshare.com/v/PYWFtETd/file.html"
             ]
         }

--- a/data/models/2x-AnimeClassics-UltraLite.json
+++ b/data/models/2x-AnimeClassics-UltraLite.json
@@ -23,6 +23,7 @@
             "size": 8177814,
             "sha256": "4db0458090cb83a006882ef2469479d6277f2c682012c36cbfe928915db652ad",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-AnimeClassics-UltraLite.pth",
                 "https://mega.nz/file/taBFxAAR#6wW-DrGh6oy2uz6aAKJpa36ngE2eKcDNA8Psy11oK10"
             ]
         }

--- a/data/models/2x-BIGOLDIES.json
+++ b/data/models/2x-BIGOLDIES.json
@@ -23,6 +23,7 @@
             "size": 66758126,
             "sha256": "a7bc580a3c4abb2b04a2cc8b47679de207741f79cebc952eedc03b27e2f27cef",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-BIGOLDIES.pth",
                 "https://1fichier.com/?23hzkj20isef5b75cw3y"
             ]
         }

--- a/data/models/2x-Bubble-AnimeScale-Compact-v1.json
+++ b/data/models/2x-Bubble-AnimeScale-Compact-v1.json
@@ -23,6 +23,7 @@
             "size": 4837293,
             "sha256": "8bdaed28134166520de28ddf75037aae84fd96c1d9bfc6deff1aadb24146d8b3",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-Bubble-AnimeScale-Compact-v1.pth",
                 "https://github.com/Bubblemint864/AI-Models/releases/tag/2x_Bubble_AnimeScale_Compact_v1"
             ]
         }

--- a/data/models/2x-Bubble-AnimeScale-SwinIR-Small-v1.json
+++ b/data/models/2x-Bubble-AnimeScale-SwinIR-Small-v1.json
@@ -24,6 +24,7 @@
             "size": 16834553,
             "sha256": "aea80c061b41e1cbc5b0c0f9bb2603a82c7d00d2451bfd5b98a495244dd5fb2f",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-Bubble-AnimeScale-SwinIR-Small-v1.pth",
                 "https://github.com/Bubblemint864/AI-Models/releases/tag/2x_Bubble_AnimeScale_SwinIR_Small_v1"
             ]
         }

--- a/data/models/2x-CGIMaster-v1.json
+++ b/data/models/2x-CGIMaster-v1.json
@@ -21,6 +21,7 @@
             "size": 66870739,
             "sha256": "1cd831c35f1ac3a74d054e96362c145ac9d2a3abd0651fbb9802f42cc302b013",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-CGIMaster-v1.pth",
                 "https://lbry.tv/@Madiator2011:e/x2_CGIMaster_v1:6"
             ]
         }

--- a/data/models/2x-Compact-Pretrain.json
+++ b/data/models/2x-Compact-Pretrain.json
@@ -21,6 +21,7 @@
             "size": "abdd8f7610fabb1a583ead857e5f3b37da9a8b7865129ba1bad1cf173df8ade7",
             "sha256": null,
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-Compact-Pretrain.pth",
                 "https://mega.nz/file/Bc0SmIyK#ThTyculaFvrLGMIY8FicUUWBem8O_ZF8LgpPXCn7aVQ"
             ]
         }

--- a/data/models/2x-DigiGradients-Lite.json
+++ b/data/models/2x-DigiGradients-Lite.json
@@ -21,6 +21,7 @@
             "size": 20135976,
             "sha256": "a5d0f6043e8db908ad1aeda12d200aae4a69005eaa3e0e5fa876353f30a38ee4",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-DigiGradients-Lite.pth",
                 "https://mega.nz/file/PfhxWCRT#R59B_ovEwdiojZbas76SCbUSv-uNd1ZSOdZ0vQp-6w4"
             ]
         }

--- a/data/models/2x-DigitalFilmV5-Lite.json
+++ b/data/models/2x-DigitalFilmV5-Lite.json
@@ -21,6 +21,7 @@
             "size": 8199999,
             "sha256": "ed75272d5c55318c7307bcb4faaba63a69f0cfa1576dd1068b9737ecdfd3e734",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-DigitalFilmV5-Lite.pth",
                 "https://cdn.discordapp.com/attachments/579685650824036387/812414843939455036/2X_DigitalFilmV5_Lite.pth"
             ]
         }

--- a/data/models/2x-DigitalFlim-SuperUltraCompact.json
+++ b/data/models/2x-DigitalFlim-SuperUltraCompact.json
@@ -21,6 +21,7 @@
             "size": 377655,
             "sha256": "c34cae569319688f1fa10aa75c5734040896790e41bb23f128cd633923d850e5",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-DigitalFlim-SuperUltraCompact.pth",
                 "https://mega.nz/file/lVUDRQYa#LVyZdRS1c1Vo7IQcDA9ivBplLqPYPWjl39px7mBKuFo"
             ]
         }

--- a/data/models/2x-DigitoonLite.json
+++ b/data/models/2x-DigitoonLite.json
@@ -21,6 +21,7 @@
             "size": 20135976,
             "sha256": "3b08cbf2e9adb3121dd5c010812485f43a6e0403cdfd5f3c02fef44aefdd99d2",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-DigitoonLite.pth",
                 "https://mega.nz/file/XWpFzRID#398qZx763bMSBsPB2MfgZqROGxdB0VldrIgH_prwa7U"
             ]
         }

--- a/data/models/2x-ESRGAN.json
+++ b/data/models/2x-ESRGAN.json
@@ -21,6 +21,7 @@
             "size": 66804909,
             "sha256": "fedd0660312effd7febb8c06a4ac0304eaee5ca119b508895a95b0aa11ba6310",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-ESRGAN.pth",
                 "https://mega.nz/#!vtgSWKQT!K7Asn2zKe4N70R2aV89KEMTKhH3aiyGAAiuQDJF09qs"
             ]
         }

--- a/data/models/2x-Faithful-Lite.json
+++ b/data/models/2x-Faithful-Lite.json
@@ -22,6 +22,7 @@
             "size": 20133416,
             "sha256": "6794a3df8a9f3999ce7ce5d20f93241857a661be1ba0d99a99db1229313b3448",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-Faithful-Lite.pth",
                 "https://u.pcloud.link/publink/show?code=XZHawFXZhqD7dF4qtYHnqJVPnQd0ey0vW1JX"
             ]
         }

--- a/data/models/2x-FakeFaith-Lite.json
+++ b/data/models/2x-FakeFaith-Lite.json
@@ -22,6 +22,7 @@
             "size": 20135976,
             "sha256": "51ee3b4b05422f1e48aee115c05dc6dca8fd5ff7b8341e7f6b84be820696c9db",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-FakeFaith-Lite.pth",
                 "https://u.pcloud.link/publink/show?code=kZUMKFXZUG6BpzHR6wFGack19pvWgbQQ9OA7"
             ]
         }

--- a/data/models/2x-Futsuu-Anime.json
+++ b/data/models/2x-Futsuu-Anime.json
@@ -23,6 +23,7 @@
             "size": 4838409,
             "sha256": "5ed232c71599b01911e045c0246530fcfe5b2e0791242ff7d3964f97d74f8df0",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-Futsuu-Anime.pth",
                 "https://mega.nz/file/wdszCQRZ#bs7VIgvjgRiKiL5JVPqzCLlNl0kIQnDeD48-6ltWSLw"
             ]
         }

--- a/data/models/2x-GT-evA.json
+++ b/data/models/2x-GT-evA.json
@@ -23,6 +23,7 @@
             "size": 2417798,
             "sha256": "eeccd98ec73326e13cc4fcd2a4c8394e85b28094c275e3e9dfb8390b80857502",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-GT-evA.pth",
                 "https://drive.google.com/file/d/1bwJpBHynGTIedIaZwp5XapCrJjO4BruF/view?usp=share_link"
             ]
         }

--- a/data/models/2x-KcjpunkAnime-2-0-Lite.json
+++ b/data/models/2x-KcjpunkAnime-2-0-Lite.json
@@ -21,6 +21,7 @@
             "size": 18468480,
             "sha256": "821dc99a36bf16a1521be35e3ebd07c3a0c2572bc9248ea9ba93e1580020705f",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-KcjpunkAnime-2-0-Lite.pth",
                 "https://mega.nz/folder/4oVRHQaA#vE3Lplfetc9z9SJOxZD6nA"
             ]
         }

--- a/data/models/2x-LD-Anime-Compact.json
+++ b/data/models/2x-LD-Anime-Compact.json
@@ -26,6 +26,7 @@
             "size": 4838409,
             "sha256": "92af3344f41272231508dd273c8861052c1261efed362d5f9da19bac4cbae361",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-LD-Anime-Compact.pth",
                 "https://mega.nz/file/xI8D2SCJ#oQ0h3k9lemeNJcuysJql7z55WV_NhOsKRpzpErIhcGc"
             ]
         }

--- a/data/models/2x-Loyaldk-Giroro.json
+++ b/data/models/2x-Loyaldk-Giroro.json
@@ -23,6 +23,7 @@
             "size": 40741492,
             "sha256": "5351f35c3acad7a22d0ac12dedf4a45c5108b6fead351806fedb5ef462f6a9a8",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-Loyaldk-Giroro.pth",
                 "https://mega.nz/folder/5UAlQCRJ#2Bj1lq8PYeB3P9k5UKSvkQ"
             ]
         }

--- a/data/models/2x-Loyaldk-Kororo.json
+++ b/data/models/2x-Loyaldk-Kororo.json
@@ -23,6 +23,7 @@
             "size": 20135976,
             "sha256": "f2126f5eaf76b0384cddf7b784b7c6f60923188c0be5e3c3142504ff09894415",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-Loyaldk-Kororo.pth",
                 "https://mega.nz/folder/5UAlQCRJ#2Bj1lq8PYeB3P9k5UKSvkQ"
             ]
         }

--- a/data/models/2x-Loyaldk-LitePonyV1-0.json
+++ b/data/models/2x-Loyaldk-LitePonyV1-0.json
@@ -23,6 +23,7 @@
             "size": 20135976,
             "sha256": "25f4067bb54764011ceb7657971958c767b5c73e920df8beac1d1231bf662433",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-Loyaldk-LitePonyV1-0.pth",
                 "https://mega.nz/file/RYxGEKRL#nTe0Zy2gB9e9QF5T8UhJSla1oEPQjSCXAB0BpNrTrRk"
             ]
         }

--- a/data/models/2x-Loyaldk-LitePonyV2-0.json
+++ b/data/models/2x-Loyaldk-LitePonyV2-0.json
@@ -23,6 +23,7 @@
             "size": 20135976,
             "sha256": "d3afb756e8d6a34e92a9363f181e2aa7dd86baaf0764637d4b7cfd6a02c83714",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-Loyaldk-LitePonyV2-0.pth",
                 "https://mega.nz/file/VM5WmLwb#QvO1n6w6llYRh8qauXXkXy4tElrBCwclCl5VHM3IH8M"
             ]
         }

--- a/data/models/2x-Loyaldk-MediumPonyV2-0.json
+++ b/data/models/2x-Loyaldk-MediumPonyV2-0.json
@@ -23,6 +23,7 @@
             "size": 40741492,
             "sha256": "de160218f1b7cd404d2b57f632abc4311e6cf043d6d84a6108a9d920205929bb",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-Loyaldk-MediumPonyV2-0.pth",
                 "https://mega.nz/file/YMwm0TbZ#agDBMDkswkpMM7FE1tDRlGX4zIOE4D0WBzcWudkN7Mc"
             ]
         }

--- a/data/models/2x-NMKD-YandereNeo.json
+++ b/data/models/2x-NMKD-YandereNeo.json
@@ -23,6 +23,7 @@
             "size": 20135976,
             "sha256": "a305101b33f804206a9d16d3b53725ed7d9f2b8550830fcdc6bcf68ece32f0ff",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-NMKD-YandereNeo.pth",
                 "https://icedrive.net/1/f0UAiRqz3N"
             ]
         }

--- a/data/models/2x-SHARP-ANIME-V1.json
+++ b/data/models/2x-SHARP-ANIME-V1.json
@@ -23,6 +23,7 @@
             "size": 66810509,
             "sha256": "d8b93d65369ddd366df4dfa58f22cd652104a5cfc34ccc02ef3c45d51b089099",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-SHARP-ANIME-V1.pth",
                 "https://1fichier.com/?cnw3fwws08tdoaxycimj"
             ]
         }

--- a/data/models/2x-SHARP-ANIME-V2.json
+++ b/data/models/2x-SHARP-ANIME-V2.json
@@ -23,6 +23,7 @@
             "size": 66758126,
             "sha256": "5f858442165478ddac475e75c24b9091b1f3c198aba1fe5d7e22008f43c2a87f",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-SHARP-ANIME-V2.pth",
                 "https://1fichier.com/?020t1y83kjrusd95dh0a"
             ]
         }

--- a/data/models/2x-SuperUltraCompact-Pretrain.json
+++ b/data/models/2x-SuperUltraCompact-Pretrain.json
@@ -21,6 +21,7 @@
             "size": "c34cae569319688f1fa10aa75c5734040896790e41bb23f128cd633923d850e5",
             "sha256": null,
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-SuperUltraCompact-Pretrain.pth",
                 "https://mega.nz/file/Bc0SmIyK#ThTyculaFvrLGMIY8FicUUWBem8O_ZF8LgpPXCn7aVQ"
             ]
         }

--- a/data/models/2x-UltraCompact-Pretrain.json
+++ b/data/models/2x-UltraCompact-Pretrain.json
@@ -21,6 +21,7 @@
             "size": "9df7476a0350b3990b3d812d40bdb70ab770b15ad0a9b85d4bc7cbb90ae5697e",
             "sha256": null,
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-UltraCompact-Pretrain.pth",
                 "https://mega.nz/file/Bc0SmIyK#ThTyculaFvrLGMIY8FicUUWBem8O_ZF8LgpPXCn7aVQ"
             ]
         }

--- a/data/models/2x-UniScale-CartoonRestore-lite.json
+++ b/data/models/2x-UniScale-CartoonRestore-lite.json
@@ -23,6 +23,7 @@
             "size": 20135976,
             "sha256": "3533d7e303b78bfe15e416a0bc3f42697edd3c20f995dc9333b093214f196768",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-UniScale-CartoonRestore-lite.pth",
                 "https://mega.nz/folder/eBwyyKbA#CApT1_CrbpGBymLmc-FCTQ"
             ]
         }

--- a/data/models/2x-VimeoScale-Unet.json
+++ b/data/models/2x-VimeoScale-Unet.json
@@ -21,6 +21,7 @@
             "size": 21938817,
             "sha256": "d83d246f10c93057047abab15dab113075b3595eae41c6cc539e9e8f5ca5181c",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-VimeoScale-Unet.pth",
                 "https://mega.nz/folder/qslgTZYQ#wE9l53sTH78B6wjPX5GRwQ"
             ]
         }

--- a/data/models/2x-Waifaux-NL3-SRResNet.json
+++ b/data/models/2x-Waifaux-NL3-SRResNet.json
@@ -20,6 +20,7 @@
             "size": 7715528,
             "sha256": "0d6b1f9d25983f98cb8c4f44459985c3ba0c3f35978358dca4bbfbe4fce4b3f9",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-Waifaux-NL3-SRResNet.pth",
                 "https://u.pcloud.link/publink/show?code=XZPLWuXZbQz9nPrUhlytIN0ne4UjyzQRMHmX"
             ]
         }

--- a/data/models/2x-Waifaux-NL3-SuperLite.json
+++ b/data/models/2x-Waifaux-NL3-SuperLite.json
@@ -23,6 +23,7 @@
             "size": 6886862,
             "sha256": "b0b62d44d1f18f34d2eba4dfbbf0913fb528e49514166b8e9d147de09ffed49e",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-Waifaux-NL3-SuperLite.pth",
                 "https://u.pcloud.link/publink/show?code=XZRAmuXZRy3vkvvBdTftheNOFeJ0tLLv74eX"
             ]
         }

--- a/data/models/2x-anifilm-compact.json
+++ b/data/models/2x-anifilm-compact.json
@@ -23,6 +23,7 @@
             "size": 2419014,
             "sha256": "13b85e0d310976c4b3db5d00d2cd2c4bcae7a0ad17d3793f6746c78330c57d07",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-anifilm-compact.pth",
                 "https://mega.nz/folder/XZgSmAoa#KNKbXZVBDq4UD1NJLHm1oQ"
             ]
         }

--- a/data/models/2x-cainREALTIME.json
+++ b/data/models/2x-cainREALTIME.json
@@ -18,6 +18,7 @@
             "size": 18979084,
             "sha256": "16e48f46a1f284c4a0e88ca001a0c491c35e8d9b865a9bcfd64dfc03b8c9504d",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-cainREALTIME.pth",
                 "https://cdn.discordapp.com/attachments/579685650824036387/936636497640165436/model.pth"
             ]
         }

--- a/data/models/2x-cainliteanime.json
+++ b/data/models/2x-cainliteanime.json
@@ -18,6 +18,7 @@
             "size": 35959343,
             "sha256": "092401d94d9b0aef33017df9f38ec6915d82171ea40fb109dee7b8d8b34ca761",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-cainliteanime.pth",
                 "https://cdn.discordapp.com/attachments/873173887427416114/874695897257246770/726770_JIT.pth"
             ]
         }

--- a/data/models/2x-cvpv6.json
+++ b/data/models/2x-cvpv6.json
@@ -18,6 +18,7 @@
             "size": 105106008,
             "sha256": "44a8fb7c8b56b1669bc1e692dae51b3dd96cf6f49db142194480e50645db8618",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-cvpv6.pth",
                 "https://files.catbox.moe/nxh1cv.pth"
             ]
         }

--- a/data/models/2x-fidelbd-pokemodel.json
+++ b/data/models/2x-fidelbd-pokemodel.json
@@ -23,6 +23,7 @@
             "size": 66810509,
             "sha256": "79ad512557eaf052f1d540c117b4408a7fa24999c75abbf1c2f52a5b1d2353b2",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-fidelbd-pokemodel.pth",
                 "https://www23.zippyshare.com/v/lhOStpVa/file.html"
             ]
         }

--- a/data/models/2x-pokemodel-lite.json
+++ b/data/models/2x-pokemodel-lite.json
@@ -23,6 +23,7 @@
             "size": 20133756,
             "sha256": "ad5d18490463ec75976fe1b93435bfef9bce8167867c9c91a00cdc9bf6814666",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-pokemodel-lite.pth",
                 "https://www115.zippyshare.com/v/O2do1VCf/file.html"
             ]
         }

--- a/data/models/2x-rvpV1.json
+++ b/data/models/2x-rvpV1.json
@@ -18,6 +18,7 @@
             "size": 70896469,
             "sha256": "8720b47f8ceded96dc61575acd23880f6d0bc95360b3ea9748f1fcbe6f27eb7a",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-rvpV1.pth",
                 "https://e.pcloud.link/publink/show?code=kZhh05ZMvnTmaKOepQPfMoQlv9sMRD3nQw7",
                 "https://www.mediafire.com/folder/y4kvdjs45lefp/rvpV1"
             ]

--- a/data/models/2x-sudo-RealESRGAN-Dropout.json
+++ b/data/models/2x-sudo-RealESRGAN-Dropout.json
@@ -23,6 +23,7 @@
             "size": 17784133,
             "sha256": "d5f184e41865201b251c693d96e3a787eaaa9736179a4037c01a69d3125469a7",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-sudo-RealESRGAN-Dropout.pth",
                 "https://e1.pcloud.link/publink/show?code=kZ7rGRZW2IcOpNMQeXDTTRQ4aPVBFyyJV5X",
                 "https://www.mediafire.com/folder/gk7f61e2kut0z/sudo_RealESRGAN2x"
             ]

--- a/data/models/2x-sudo-RealESRGAN.json
+++ b/data/models/2x-sudo-RealESRGAN.json
@@ -23,6 +23,7 @@
             "size": 17784133,
             "sha256": "ded8cd65642b94f658e248d9833565e8a549020baf2ff8b9837866c6c36cfca4",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-sudo-RealESRGAN.pth",
                 "https://e1.pcloud.link/publink/show?code=kZ7rGRZW2IcOpNMQeXDTTRQ4aPVBFyyJV5X",
                 "https://www.mediafire.com/folder/gk7f61e2kut0z/sudo_RealESRGAN2x"
             ]

--- a/data/models/2x-sudo-UltraCompact.json
+++ b/data/models/2x-sudo-UltraCompact.json
@@ -23,6 +23,7 @@
             "size": 1226766,
             "sha256": "e53987f0312dee424b4dbd9dce7b2eacbe03fdf1380e44a11f8a4d2ca88c99e3",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-sudo-UltraCompact.pth",
                 "https://e1.pcloud.link/publink/show?code=kZufYRZj1INMisvFehhfS763L4ow5YUy0VV",
                 "https://www.mediafire.com/folder/7e7752gf42eky/sudo_UltraCompact_2x_1.121.175"
             ]

--- a/data/models/2x-sudo-rife4-testV1.json
+++ b/data/models/2x-sudo-rife4-testV1.json
@@ -18,6 +18,7 @@
             "size": 33719173,
             "sha256": "1c9dff599a1c05c38cdc52930a739e7144ce8210fdd098a364e0155c1d23c27c",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F2x-sudo-rife4-testV1.pth",
                 "https://e1.pcloud.link/publink/show?code=kZfoGRZNuvokO5THhVzVLOt7ocHkR9vDdF7"
             ]
         }

--- a/data/models/3x-Video-TSSM.json
+++ b/data/models/3x-Video-TSSM.json
@@ -18,6 +18,7 @@
             "size": 4730412,
             "sha256": "3ed58c98012ee903fcda6c26fd28f27bd2e3560a10d4904fb384b3de6f7c52fb",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F3x-Video-TSSM.pth",
                 "https://u.pcloud.link/publink/show?code=XZMmozXZjW4hHqJu7ikbQpyeqUItTh7QJO6k"
             ]
         }

--- a/data/models/4x-1ch-Alpha-Lite.json
+++ b/data/models/4x-1ch-Alpha-Lite.json
@@ -21,6 +21,7 @@
             "size": 20167004,
             "sha256": "a34d4d6a1a6501c44a92e6547db2b1c5a7ff1d5738219c94a448328a73c2bf9b",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-1ch-Alpha-Lite.pth",
                 "https://u.pcloud.link/publink/show?code=kZQfN4XZmIrkODabBWhtmmA95c0GMb19WUuy"
             ]
         }

--- a/data/models/4x-2C2-ESRGAN-Nomos2K.json
+++ b/data/models/4x-2C2-ESRGAN-Nomos2K.json
@@ -19,6 +19,7 @@
             "size": 39444095,
             "sha256": "7d728ac6e7a673be71b0222a11a0bf159d773a2f8e1330e22b302dead24d4f70",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-2C2-ESRGAN-Nomos2K.pth",
                 "https://github.com/joeyballentine/2C2-ESRGAN/tree/main/models"
             ]
         }

--- a/data/models/4x-AbeScale.json
+++ b/data/models/4x-AbeScale.json
@@ -23,6 +23,7 @@
             "size": 67025055,
             "sha256": "ceb79b179c05bab71a8de3900f173de3a10cf17d0422e0e62e4e5b395db3ccaa",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-AbeScale.pth",
                 "http://cloud.mitch.best/index.php/s/iio9SL9BdgWiCoi"
             ]
         }

--- a/data/models/4x-AnimeSharp-lite.json
+++ b/data/models/4x-AnimeSharp-lite.json
@@ -23,6 +23,7 @@
             "size": 20173354,
             "sha256": "a0a224521dcc547768e8442e83b68f98f485b3cbcc8bd207a6284fff6636329c",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-AnimeSharp-lite.pth",
                 "https://mega.nz/folder/bEoRQIRR#kEsaVHtwRL9vwfa5k2osyQ"
             ]
         }

--- a/data/models/4x-Cat-Patch.json
+++ b/data/models/4x-Cat-Patch.json
@@ -21,6 +21,7 @@
             "size": 66961958,
             "sha256": "9260fac8bee3794ba2b9081d317ddbdee82e2ab99338741bf00cd33020dd757a",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-Cat-Patch.pth",
                 "https://f002.backblazeb2.com/file/ESRGAN/_RELEASE/4x_cat_patch_325000_G.pth"
             ]
         }

--- a/data/models/4x-Compact-Pretrain.json
+++ b/data/models/4x-Compact-Pretrain.json
@@ -21,6 +21,7 @@
             "size": "8896f4755f63a2c7cc427e17644c39c7c3a37b0207a370b90b1e1b436da370a1",
             "sha256": null,
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-Compact-Pretrain.pth",
                 "https://mega.nz/file/Bc0SmIyK#ThTyculaFvrLGMIY8FicUUWBem8O_ZF8LgpPXCn7aVQ"
             ]
         }

--- a/data/models/4x-ESRGAN.json
+++ b/data/models/4x-ESRGAN.json
@@ -21,6 +21,7 @@
             "size": 66952991,
             "sha256": "545805ce2d861ee90972b5fa50b851f19ee4bb35dedd2eb090be1f7c935b6b00",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-ESRGAN.pth",
                 "https://mega.nz/#!uhAVEaAA!qfwIQ44Ba3rXMAb2-M3aM3zFBCwzmyQ64IO_0O-csJE"
             ]
         }

--- a/data/models/4x-FSDedither-Riven.json
+++ b/data/models/4x-FSDedither-Riven.json
@@ -22,6 +22,7 @@
             "size": 66958607,
             "sha256": "712f18baca9bcc09cd30f4ba8a524d66d0960ea72e2fe33f939e190cdc27745d",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-FSDedither-Riven.pth",
                 "https://buildism.net/files/4xFSDedither_Riven.pth"
             ]
         }

--- a/data/models/4x-Face-Ality-V1.json
+++ b/data/models/4x-Face-Ality-V1.json
@@ -23,6 +23,7 @@
             "size": 66958607,
             "sha256": "6bc795427098441bb1a90a56244fe0970fa80b2c25e9a7a88fd98d89824877cf",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-Face-Ality-V1.pth",
                 "https://de-next.owncube.com/index.php/s/mZRG4HB3KdP2iP6"
             ]
         }

--- a/data/models/4x-Faces-04-N.json
+++ b/data/models/4x-Faces-04-N.json
@@ -23,6 +23,7 @@
             "size": 66958607,
             "sha256": "d2d7f702cdd22db2575f70694c2baabb7f6893bfdda84b1159fe158d065456bb",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-Faces-04-N.pth",
                 "https://de-next.owncube.com/index.php/s/PF5GTJ9jix4Log8"
             ]
         }

--- a/data/models/4x-Fatal-Anime.json
+++ b/data/models/4x-Fatal-Anime.json
@@ -23,6 +23,7 @@
             "size": 66958607,
             "sha256": "54cfb3217bb68bfc31678bd79c2ebd6559f5cdbd9f3420332bf84c24b83b5b67",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-Fatal-Anime.pth",
                 "https://de-next.owncube.com/index.php/s/x99pKzS7TNaErrC"
             ]
         }

--- a/data/models/4x-Fatal-Pixels.json
+++ b/data/models/4x-Fatal-Pixels.json
@@ -22,6 +22,7 @@
             "size": 66958607,
             "sha256": "d30ac78343e0a7ffaa805b8ab7840fb1d6b9e6083fe1728c651e2064210e5994",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-Fatal-Pixels.pth",
                 "https://de-next.owncube.com/index.php/s/KRa4bDzZpAGgyWr"
             ]
         }

--- a/data/models/4x-FatalimiX.json
+++ b/data/models/4x-FatalimiX.json
@@ -23,6 +23,7 @@
             "size": 66958607,
             "sha256": "3d3ebdc1abcd24b02556a64d9c65adc3c31ec2f55d731f70370ddc49067ecbb8",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-FatalimiX.pth",
                 "https://de-next.owncube.com/index.php/s/jYnFtncarkBmpcF"
             ]
         }

--- a/data/models/4x-Fatality-MK2.json
+++ b/data/models/4x-Fatality-MK2.json
@@ -22,6 +22,7 @@
             "size": 66958607,
             "sha256": "4240715ce77c04159a0712ffe065acf098b458109d63824686c8fafeed857a30",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-Fatality-MK2.pth",
                 "https://de-next.owncube.com/index.php/s/bT8nHoK4oD2MjoH"
             ]
         }

--- a/data/models/4x-Fatality.json
+++ b/data/models/4x-Fatality.json
@@ -22,6 +22,7 @@
             "size": 66958607,
             "sha256": "fde2299d8c98794e5fa36669978e6b69cce6fd7390ec6fe3a30d39da71ce5f30",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-Fatality.pth",
                 "https://de-next.owncube.com/index.php/s/LQSgW98ZeaoA3Po"
             ]
         }

--- a/data/models/4x-FatePlus-lite.json
+++ b/data/models/4x-FatePlus-lite.json
@@ -21,6 +21,7 @@
             "size": 20173354,
             "sha256": "959c8d9c39e57092d02cb90d82ad1a8d9297cd57d59e43c0243bea2c9eae83da",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-FatePlus-lite.pth",
                 "https://mega.nz/folder/zRYh3SII#QIm6T-rzhxjBLeYF1zSDpg"
             ]
         }

--- a/data/models/4x-Loyaldk-Giroro.json
+++ b/data/models/4x-Loyaldk-Giroro.json
@@ -23,6 +23,7 @@
             "size": 40825014,
             "sha256": "720291e947dbcab715929867e991085c13a1efbbd7e55beb353f9a52dfc865c4",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-Loyaldk-Giroro.pth",
                 "https://mega.nz/folder/5UAlQCRJ#2Bj1lq8PYeB3P9k5UKSvkQ"
             ]
         }

--- a/data/models/4x-Loyaldk-Kororo.json
+++ b/data/models/4x-Loyaldk-Kororo.json
@@ -23,6 +23,7 @@
             "size": 20173354,
             "sha256": "d7a06a03594c11209191c96df29a4df1d67e66a3b17455c6edcfecd38ab22ff1",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-Loyaldk-Kororo.pth",
                 "https://mega.nz/folder/5UAlQCRJ#2Bj1lq8PYeB3P9k5UKSvkQ"
             ]
         }

--- a/data/models/4x-Loyaldk-LitePonyV2-0.json
+++ b/data/models/4x-Loyaldk-LitePonyV2-0.json
@@ -23,6 +23,7 @@
             "size": 20173354,
             "sha256": "d4e8a970a1364da4cd1dbba9ec54fcd028f98a9d9f5784219a30f20e58cc5cb7",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-Loyaldk-LitePonyV2-0.pth",
                 "https://mega.nz/file/hcoViIQQ#O1cmQ8FsLk5RAIP5lxB3Q2L0suh9IWX_dGHhuSuL9U4"
             ]
         }

--- a/data/models/4x-Loyaldk-MediumPonyV2-0.json
+++ b/data/models/4x-Loyaldk-MediumPonyV2-0.json
@@ -23,6 +23,7 @@
             "size": 40825014,
             "sha256": "c8b660ef4051e89da7112d6d76bbdd74f5fc67ab153e14a1c25da99f7c5ca1d7",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-Loyaldk-MediumPonyV2-0.pth",
                 "https://mega.nz/file/lYo01DRI#HIiJ7M5YaXjwAb3zEbtSLzAI59iljwEX72Ad88CvUf0"
             ]
         }

--- a/data/models/4x-Manga109Attempt.json
+++ b/data/models/4x-Manga109Attempt.json
@@ -22,6 +22,7 @@
             "size": 66946549,
             "sha256": "fa4ef999435d9dda0e68c855bbddf1fa54dcc8fe207b05c5867193446f59ac4c",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-Manga109Attempt.pth",
                 "http://www.mediafire.com/file/w3jujtm752hvdj1/Manga109Attempt.pth.zip/file"
             ]
         }

--- a/data/models/4x-MeguUp.json
+++ b/data/models/4x-MeguUp.json
@@ -23,6 +23,7 @@
             "size": 66961958,
             "sha256": "4dad22166896c14cf04f222cf1a69c46f7a6c6e6358ade157f7107a243225fde",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-MeguUp.pth",
                 "https://s.katou.pw/4x_MeguUp_150000_G.pth"
             ]
         }

--- a/data/models/4x-NMKD-UltraYandere-Lite.json
+++ b/data/models/4x-NMKD-UltraYandere-Lite.json
@@ -23,6 +23,7 @@
             "size": 20173354,
             "sha256": "20bcc2e823c26271a6d89d14578fd80ffb3aa727535284298161cb6a81cb501c",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-NMKD-UltraYandere-Lite.pth",
                 "https://icedrive.net/1/43GNBihZyi"
             ]
         }

--- a/data/models/4x-NMKD-YandereNeo-Superlite.json
+++ b/data/models/4x-NMKD-YandereNeo-Superlite.json
@@ -23,6 +23,7 @@
             "size": 6376496,
             "sha256": "9d584ad24087472ffb24f8e2c0ec797838b1d2ed4b8a71a503e72235155120e1",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-NMKD-YandereNeo-Superlite.pth",
                 "https://icedrive.net/1/f0UAiRqz3N"
             ]
         }

--- a/data/models/4x-NMKD-YandereNeo.json
+++ b/data/models/4x-NMKD-YandereNeo.json
@@ -23,6 +23,7 @@
             "size": 20173354,
             "sha256": "988f57dd12e63cf7aad10192fd06518e3300b449362df2a03eb1f9774a10f8b3",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-NMKD-YandereNeo.pth",
                 "https://icedrive.net/1/f0UAiRqz3N"
             ]
         }

--- a/data/models/4x-OLDIES-ALTERNATIVE-FINAL.json
+++ b/data/models/4x-OLDIES-ALTERNATIVE-FINAL.json
@@ -23,6 +23,7 @@
             "size": 66906130,
             "sha256": "92828eb90a56eab72f2bf1227ec6e7204378c499400286e46e3016b6a514bc8d",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-OLDIES-ALTERNATIVE-FINAL.pth",
                 "https://1fichier.com/?u7kwdxdn6uljha3icte8"
             ]
         }

--- a/data/models/4x-OLDIESFINAL.json
+++ b/data/models/4x-OLDIESFINAL.json
@@ -23,6 +23,7 @@
             "size": 66906130,
             "sha256": "2239f776c6be3af296b42a4bbc66d9fda064b342316d9ca82b3e09c11529f302",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-OLDIESFINAL.pth",
                 "https://1fichier.com/?tsmmdifzgwkwtdfcc5uo"
             ]
         }

--- a/data/models/4x-REDSVAL-7f-RRDB-Lite.json
+++ b/data/models/4x-REDSVAL-7f-RRDB-Lite.json
@@ -21,6 +21,7 @@
             "size": 22343759,
             "sha256": "2d65f1f6733437e1870c0d147279b07494d7ed538bf1bda0ed2e1257e4ed8c4c",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-REDSVAL-7f-RRDB-Lite.pth",
                 "https://u.pcloud.link/publink/show?code=kZojwLXZfeqA3Eoyv6SKXXt01AlSeuHH0WKX"
             ]
         }

--- a/data/models/4x-anifilm-compact.json
+++ b/data/models/4x-anifilm-compact.json
@@ -23,6 +23,7 @@
             "size": 2502086,
             "sha256": "e0b43e038cf891fdd1aa5729e310c3f7532e84faaa53135795d18d495a10238b",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-anifilm-compact.pth",
                 "https://mega.nz/folder/XZgSmAoa#KNKbXZVBDq4UD1NJLHm1oQ"
             ]
         }

--- a/data/models/4x-eula-anifilm-v1.json
+++ b/data/models/4x-eula-anifilm-v1.json
@@ -23,6 +23,7 @@
             "size": 66961958,
             "sha256": "c168436f137f91e842d952821391b7efb689bfc7b316c0886b2913c31f0d02f0",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-eula-anifilm-v1.pth",
                 "https://cdn.discordapp.com/attachments/450036622940045325/1052663903064162426/4x_eula_anifilm_v1_225k.pth"
             ]
         }

--- a/data/models/4x-eula-digimanga-bw-v1.json
+++ b/data/models/4x-eula-digimanga-bw-v1.json
@@ -22,6 +22,7 @@
             "size": 67010245,
             "sha256": "a3ba78a589cf2f2c39fe77cf3f472173cdcb3ade7dcc77ee5d1cd266d733e3d3",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-eula-digimanga-bw-v1.pth",
                 "https://cdn.discordapp.com/attachments/450036622940045325/936099965300768808/4x_eula_digimanga_bw_v1_860k.pth"
             ]
         }

--- a/data/models/4x-eula-digimanga-bw-v2-nc1.json
+++ b/data/models/4x-eula-digimanga-bw-v2-nc1.json
@@ -22,6 +22,7 @@
             "size": 67010885,
             "sha256": "0c3ff9f7b4fc11b21e1262bca06efada0b0723436623db5e2af37fa2291cb750",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-eula-digimanga-bw-v2-nc1.pth",
                 "https://cdn.discordapp.com/attachments/894310505622155264/1008498310597857290/4x_eula_digimanga_bw_v2_nc1_307k.pth"
             ]
         }

--- a/data/models/4x-video-G.json
+++ b/data/models/4x-video-G.json
@@ -18,6 +18,7 @@
             "size": 4204067,
             "sha256": "73ffa44dd7deab5a43c03b9776279ed64b1649c8e1596620e67c942aca353aa9",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F4x-video-G.pth",
                 "https://mega.nz/file/28JmyLrK#xhRP-EZKR7Vg7UjIRZQqotiFLix21JaGGLSvZq7cjt4"
             ]
         }

--- a/data/models/8x-ESRGAN.json
+++ b/data/models/8x-ESRGAN.json
@@ -21,6 +21,7 @@
             "size": 67101075,
             "sha256": "885d9fa1eadb277b5157f97d3fdd3893d7fb78f91331fc8a8bf9a3e4a9dd4651",
             "urls": [
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/models%2F8x-ESRGAN.pth",
                 "https://mega.nz/#!6kwQiCCS!v2uN8R44vVrlzmSqffGaCnzgogkPhhl67myJbuG45SA"
             ]
         }

--- a/src/elements/components/download-button.tsx
+++ b/src/elements/components/download-button.tsx
@@ -42,7 +42,9 @@ const getHostFromUrl = (url: string) => {
 };
 
 export const DownloadButton = ({ url, resource }: DownloadButtonProps) => {
-    const isExternal = !url.includes('oracle');
+    const isExternal = !url.startsWith(
+        'https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/'
+    );
     const host = getHostFromUrl(url);
 
     return (


### PR DESCRIPTION
This adds the URLs for all self-hosted models (119). Since we currently don't have enough storage to host all models, I prioritized models with uncommon hosters and small models.