### PR TITLE
Added tag categories

### DIFF
--- a/data/tag-categories.json
+++ b/data/tag-categories.json
@@ -1,0 +1,89 @@
+{
+    "media-type": {
+        "name": "Media type",
+        "description": "",
+        "order": 0,
+        "tags": [
+            "audio",
+            "image",
+            "video"
+        ]
+    },
+    "purpose": {
+        "name": "Purpose",
+        "description": "",
+        "order": 1,
+        "tags": [
+            "anime",
+            "anti-aliasing",
+            "cartoon",
+            "colorization",
+            "debanding",
+            "deblur",
+            "dedither",
+            "dehalo",
+            "denoise",
+            "face-upscaling",
+            "faces",
+            "game-texture-maps",
+            "game-textures",
+            "general-upscaler",
+            "inpainting",
+            "manga",
+            "photo",
+            "pixel-art",
+            "restoration",
+            "text"
+        ]
+    },
+    "color": {
+        "name": "Color",
+        "description": "",
+        "order": 2,
+        "tags": [
+            "color:1",
+            "color:3",
+            "color:4",
+            "color:1-3"
+        ]
+    },
+    "license": {
+        "name": "License",
+        "description": "",
+        "order": 3,
+        "tags": [
+            "license:by",
+            "license:commercial",
+            "license:modifications",
+            "license:sa",
+            "license:no-license",
+            "license:unknown"
+        ]
+    },
+    "platform": {
+        "name": "Platform",
+        "description": "",
+        "order": 4,
+        "tags": [
+            "platform:pytorch",
+            "platform:pytorch-compatible",
+            "platform:onnx",
+            "platform:onnx-compatible",
+            "platform:ncnn",
+            "platform:ncnn-compatible"
+        ]
+    },
+    "scale": {
+        "name": "Scale",
+        "description": "",
+        "order": 5,
+        "tags": [
+            "scale:1",
+            "scale:2",
+            "scale:3",
+            "scale:4",
+            "scale:8",
+            "scale:16"
+        ]
+    }
+}

--- a/data/tags.json
+++ b/data/tags.json
@@ -107,17 +107,13 @@
         "name": "RGBA",
         "description": "This model upscales images with transparency."
     },
-    "color:null": {
-        "name": "color:null",
-        "description": ""
-    },
     "license:by": {
         "name": "Credit",
         "description": ""
     },
     "license:commercial": {
         "name": "Commercial",
-        "description": ""
+        "description": "This model may be included in commercial products."
     },
     "license:modifications": {
         "name": "Modifications",

--- a/src/elements/components/editable-label.module.scss
+++ b/src/elements/components/editable-label.module.scss
@@ -1,0 +1,37 @@
+.editable {
+    color: inherit;
+
+    button {
+        border: none;
+        background: transparent;
+        padding: 0;
+        margin: 0;
+        margin-left: 0.25em;
+        font: inherit;
+        line-height: inherit;
+        display: inline;
+    }
+
+    svg {
+        vertical-align: middle;
+    }
+
+    .icon {
+        opacity: 0;
+    }
+
+    &:hover,
+    button:focus {
+        .icon {
+            opacity: 1;
+        }
+    }
+}
+
+.input {
+    color: inherit;
+    font: inherit;
+    padding-top: 0;
+    padding-bottom: 0;
+    line-height: 1;
+}

--- a/src/elements/components/editable-label.tsx
+++ b/src/elements/components/editable-label.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { AiFillEdit } from 'react-icons/ai';
+import { joinClasses } from '../../lib/util';
+import style from './editable-label.module.scss';
+
+export interface EditableLabelProps {
+    text: string;
+    className?: string;
+    readonly?: boolean;
+    onChange?: (newText: string) => void;
+}
+
+export function EditableLabel({ className, text, onChange, readonly }: EditableLabelProps) {
+    const [edit, setEdit] = useState(false);
+    const [value, setValue] = useState(text);
+
+    useEffect(() => setValue(text), [text]);
+
+    if (readonly || !onChange) {
+        return <span className={className}>{value}</span>;
+    }
+    if (!edit) {
+        return (
+            <span
+                className={joinClasses(style.editable, className)}
+                onClick={() => setEdit(true)}
+            >
+                {value}
+                <button>
+                    <AiFillEdit className={style.icon} />
+                </button>
+            </span>
+        );
+    }
+
+    const submit = () => {
+        if (value !== text) {
+            onChange(value);
+        }
+        setEdit(false);
+    };
+
+    return (
+        <input
+            autoFocus
+            className={style.input}
+            type="text"
+            value={value}
+            onBlur={submit}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                    submit();
+                }
+            }}
+        />
+    );
+}

--- a/src/elements/components/editable-markdown.module.scss
+++ b/src/elements/components/editable-markdown.module.scss
@@ -1,0 +1,32 @@
+.view {
+    position: relative;
+
+    & > button {
+        position: absolute;
+        top: 0;
+        right: 0;
+        opacity: 0.5;
+
+        &:hover {
+            opacity: 1;
+        }
+    }
+
+    & > div {
+        & > *:first-child {
+            margin-top: 0 !important;
+        }
+
+        & > *:last-child {
+            margin-bottom: 0 !important;
+        }
+    }
+}
+
+.textarea {
+    color: inherit;
+    font: inherit;
+    width: 100%;
+    min-height: 10em;
+    resize: vertical;
+}

--- a/src/elements/components/editable-markdown.tsx
+++ b/src/elements/components/editable-markdown.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+import { AiFillEdit } from 'react-icons/ai';
+import { MarkdownContainer } from '../markdown';
+import style from './editable-markdown.module.scss';
+
+export interface EditableMarkdownProps {
+    markdown: string;
+    placeholder?: string;
+    readonly?: boolean;
+    onChange?: (newText: string) => void;
+}
+
+export function EditableMarkdownContainer({
+    markdown,
+    placeholder = '*No description*',
+    readonly,
+    onChange,
+}: EditableMarkdownProps) {
+    const [edit, setEdit] = useState(false);
+    const [value, setValue] = useState(markdown);
+
+    useEffect(() => setValue(markdown), [markdown]);
+
+    if (readonly || !onChange) {
+        return (
+            <div className={style.view}>
+                <MarkdownContainer markdown={value || placeholder} />
+            </div>
+        );
+    }
+    if (!edit) {
+        return (
+            <div
+                className={style.view}
+                onDoubleClick={() => setEdit(true)}
+            >
+                <button onClick={() => setEdit(true)}>
+                    <AiFillEdit /> Edit
+                </button>
+                <MarkdownContainer markdown={value || placeholder} />
+            </div>
+        );
+    }
+
+    const submit = () => {
+        const final = value.trim();
+        if (final !== markdown) {
+            onChange(final);
+        }
+        setValue(final);
+        setEdit(false);
+    };
+
+    return (
+        <textarea
+            autoFocus
+            className={style.textarea}
+            value={value}
+            onBlur={submit}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                    submit();
+                }
+            }}
+        />
+    );
+}

--- a/src/elements/tag-view.module.scss
+++ b/src/elements/tag-view.module.scss
@@ -1,0 +1,17 @@
+.tagView {
+    margin: 0.5em 0;
+}
+
+.delete {
+    color: inherit;
+    font: inherit;
+    line-height: inherit;
+    border: none;
+    padding: 0;
+    margin: 0;
+    background: none;
+
+    svg {
+        vertical-align: middle;
+    }
+}

--- a/src/elements/tag-view.tsx
+++ b/src/elements/tag-view.tsx
@@ -13,7 +13,7 @@ interface TagViewProps {
     onDelete?: () => void;
 }
 export function TagView({ tag, usage, onRename, onDelete, onDescriptionChange }: TagViewProps) {
-    const { webApi, editMode } = useWebApi();
+    const { editMode } = useWebApi();
 
     return (
         <div className={style.tagView}>

--- a/src/elements/tag-view.tsx
+++ b/src/elements/tag-view.tsx
@@ -1,0 +1,44 @@
+import { MdDelete } from 'react-icons/md';
+import { useWebApi } from '../lib/hooks/use-web-api';
+import { MarkDownString, Tag } from '../lib/schema';
+import { EditableLabel } from './components/editable-label';
+import { EditableMarkdownContainer } from './components/editable-markdown';
+import style from './tag-view.module.scss';
+
+interface TagViewProps {
+    tag: Tag;
+    usage?: number;
+    onRename?: (name: string) => void;
+    onDescriptionChange?: (description: MarkDownString) => void;
+    onDelete?: () => void;
+}
+export function TagView({ tag, usage, onRename, onDelete, onDescriptionChange }: TagViewProps) {
+    const { webApi, editMode } = useWebApi();
+
+    return (
+        <div className={style.tagView}>
+            <div>
+                <EditableLabel
+                    readonly={!editMode}
+                    text={tag.name}
+                    onChange={onRename}
+                />
+                {onDelete && (
+                    <button
+                        className={style.delete}
+                        onClick={onDelete}
+                    >
+                        <MdDelete />
+                    </button>
+                )}
+                {usage !== undefined && <span className="opacity-50"> ({usage})</span>}
+            </div>
+            <div>
+                <EditableMarkdownContainer
+                    markdown={tag.description}
+                    onChange={onDescriptionChange}
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/lib/data-api.ts
+++ b/src/lib/data-api.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { RWLock } from './lock';
-import { Model, ModelId, Tag, TagId, User, UserId } from './schema';
+import { Model, ModelId, Tag, TagCategory, TagCategoryId, TagId, User, UserId } from './schema';
 import { noop } from './util';
 
 export interface DBApi {
     readonly models: CollectionApi<ModelId, Model>;
     readonly tags: CollectionApi<TagId, Tag>;
+    readonly tagCategories: CollectionApi<TagCategoryId, TagCategory>;
     readonly users: CollectionApi<UserId, User>;
 }
 

--- a/src/lib/hooks/use-tags.ts
+++ b/src/lib/hooks/use-tags.ts
@@ -1,12 +1,17 @@
-import { Tag, TagId } from '../schema';
-import { STATIC_TAG_DATA } from '../static-data';
+import { Tag, TagCategory, TagCategoryId, TagId } from '../schema';
+import { STATIC_TAG_CATEGORY_DATA, STATIC_TAG_DATA } from '../static-data';
+import { getTagCategoryOrder } from '../util';
 
 export interface UseTags {
     readonly tagData: ReadonlyMap<TagId, Tag>;
+    readonly tagCategoryData: ReadonlyMap<TagCategoryId, TagCategory>;
+    readonly categoryOrder: readonly (readonly [TagCategoryId, TagCategory])[];
 }
 
 const result: UseTags = {
     tagData: STATIC_TAG_DATA,
+    tagCategoryData: STATIC_TAG_CATEGORY_DATA,
+    categoryOrder: getTagCategoryOrder(STATIC_TAG_CATEGORY_DATA),
 };
 
 export function useTags(): UseTags {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -11,6 +11,7 @@ export type SPDXLicense = string & { readonly SPDXLicense: never };
  */
 export type SPDXLicenseId = string & { readonly SPDXLicenseId: never };
 export type TagId = string & { readonly TagId: never };
+export type TagCategoryId = string & { readonly TagCategoryId: never };
 export type MarkDownString = string;
 
 export interface Model extends Partial<ExtraModelProperties> {
@@ -62,6 +63,13 @@ export interface User {
 export interface Tag {
     name: string;
     description: MarkDownString;
+}
+
+export interface TagCategory {
+    name: string;
+    description: MarkDownString;
+    order: number;
+    tags: TagId[];
 }
 
 export const ModelIdPattern = /^\d+x-[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$/;

--- a/src/lib/static-data.ts
+++ b/src/lib/static-data.ts
@@ -1,15 +1,12 @@
+import tagCategories from '../../data/tag-categories.json';
 import tags from '../../data/tags.json';
 import users from '../../data/users.json';
-import { Tag, TagId, User, UserId } from './schema';
+import { Tag, TagCategory, TagCategoryId, TagId, User, UserId } from './schema';
 
-export const STATIC_TAG_DATA: ReadonlyMap<TagId, Tag> = new Map(
-    Object.entries(tags).map(([k, v]: [string, Tag]) => {
-        return [k as TagId, v];
-    })
+export const STATIC_TAG_DATA: ReadonlyMap<TagId, Tag> = new Map(Object.entries(tags) as [TagId, Tag][]);
+
+export const STATIC_TAG_CATEGORY_DATA: ReadonlyMap<TagCategoryId, TagCategory> = new Map(
+    Object.entries(tagCategories) as [TagCategoryId, TagCategory][]
 );
 
-export const STATIC_USER_DATA: ReadonlyMap<UserId, User> = new Map(
-    Object.entries(users).map(([k, v]: [string, User]) => {
-        return [k as UserId, v];
-    })
-);
+export const STATIC_USER_DATA: ReadonlyMap<UserId, User> = new Map(Object.entries(users) as [UserId, User][]);

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,4 +1,4 @@
-import { TagId } from './schema';
+import { TagCategory, TagCategoryId, TagId } from './schema';
 
 export const EMPTY_ARRAY: readonly never[] = [];
 export const EMPTY_SET: ReadonlySet<never> = new Set();
@@ -129,6 +129,9 @@ function getTagCategory(id: TagId): string | undefined {
 export function compareTagId(a: TagId, b: TagId): number {
     return compareString(getTagCategory(a) ?? '', getTagCategory(b) ?? '') || compareString(a, b);
 }
+export function isDerivedTags(id: TagId): boolean {
+    return id.includes(':');
+}
 
 export function getColorMode(numberOfChannels: number) {
     switch (numberOfChannels) {
@@ -141,4 +144,16 @@ export function getColorMode(numberOfChannels: number) {
         default:
             return numberOfChannels;
     }
+}
+
+export function getTagCategoryOrder(
+    iter: Iterable<readonly [TagCategoryId, TagCategory]>
+): (readonly [TagCategoryId, TagCategory])[] {
+    const array = [...iter];
+    array.sort((a, b) => {
+        const order = a[1].order - b[1].order;
+        if (order) return order;
+        return compareString(a[0], b[0]);
+    });
+    return array;
 }

--- a/src/lib/web-api.ts
+++ b/src/lib/web-api.ts
@@ -71,8 +71,9 @@ function createWebCollection<Id, Value>(path: string): CollectionApi<Id, Value> 
 export const getWebApi = lazy(async (): Promise<DBApi | undefined> => {
     const webApi: DBApi = {
         models: createWebCollection('/api/models'),
-        tags: createWebCollection('/api/tags'),
         users: createWebCollection('/api/users'),
+        tags: createWebCollection('/api/tags'),
+        tagCategories: createWebCollection('/api/tag-categories'),
     };
 
     // we do an empty update to test the waters

--- a/src/pages/api/tag-categories.ts
+++ b/src/pages/api/tag-categories.ts
@@ -1,0 +1,4 @@
+import { handleJsonApi } from '../../lib/server/api-impl';
+import { fileApi } from '../../lib/server/file-data';
+
+export default handleJsonApi(fileApi.tagCategories);

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -4,6 +4,8 @@ import Link from 'next/link';
 import { ParsedUrlQuery } from 'querystring';
 import React, { useCallback } from 'react';
 import { DownloadButton } from '../../elements/components/download-button';
+import { EditableLabel } from '../../elements/components/editable-label';
+import { EditableMarkdownContainer } from '../../elements/components/editable-markdown';
 import { ImageCarousel } from '../../elements/components/image-carousel';
 import { PageContainer } from '../../elements/page';
 import { useCurrent } from '../../lib/hooks/use-current';
@@ -82,15 +84,13 @@ export default function Page({ modelId, modelData }: Props) {
                         <ImageCarousel images={dummyImages} />
                         <div className="relative">
                             <div>
-                                <h1
-                                    className="m-0"
-                                    contentEditable={editMode}
-                                    dangerouslySetInnerHTML={{ __html: modelData.name }}
-                                    onInput={(event) => {
-                                        const content = String((event.target as Element).textContent);
-                                        updateModelProperty('name', content);
-                                    }}
-                                />
+                                <h1 className="m-0">
+                                    <EditableLabel
+                                        readonly={!editMode}
+                                        text={modelData.name}
+                                        onChange={(value) => updateModelProperty('name', value)}
+                                    />
+                                </h1>
                                 <p className="m-0">
                                     by{' '}
                                     <strong className="m-0 text-lg text-accent-600 dark:text-accent-500">
@@ -133,15 +133,11 @@ export default function Page({ modelId, modelData }: Props) {
                                     </strong>
                                 </p>
                             </div>
-                            <div>
-                                <p
-                                    className="whitespace-pre-line"
-                                    contentEditable={editMode}
-                                    dangerouslySetInnerHTML={{ __html: modelData.description }}
-                                    onInput={(event) => {
-                                        const content = String((event.target as Element).textContent);
-                                        updateModelProperty('description', content);
-                                    }}
+                            <div className="py-4">
+                                <EditableMarkdownContainer
+                                    markdown={modelData.description}
+                                    readonly={!editMode}
+                                    onChange={(value) => updateModelProperty('description', value)}
                                 />
                             </div>
                         </div>
@@ -171,7 +167,13 @@ export default function Page({ modelId, modelData }: Props) {
                                         >
                                             Architecture
                                         </th>
-                                        <td className="px-6 py-4">{model.architecture}</td>
+                                        <td className="px-6 py-4">
+                                            <EditableLabel
+                                                readonly={!editMode}
+                                                text={model.architecture}
+                                                onChange={(value) => updateModelProperty('architecture', value)}
+                                            />
+                                        </td>
                                     </tr>
                                     <tr className="">
                                         <th

--- a/src/pages/tags.tsx
+++ b/src/pages/tags.tsx
@@ -1,0 +1,141 @@
+import Head from 'next/head';
+import React, { useMemo } from 'react';
+import { EditableLabel } from '../elements/components/editable-label';
+import { PageContainer } from '../elements/page';
+import { TagView } from '../elements/tag-view';
+import { deriveTags } from '../lib/derive-tags';
+import { useModels } from '../lib/hooks/use-models';
+import { useTags } from '../lib/hooks/use-tags';
+import { useWebApi } from '../lib/hooks/use-web-api';
+import { Tag, TagCategory, TagCategoryId, TagId } from '../lib/schema';
+import { compareTagId } from '../lib/util';
+
+export default function Page() {
+    const { tagData, tagCategoryData, categoryOrder } = useTags();
+    const { modelData } = useModels({});
+
+    const { webApi, editMode } = useWebApi();
+
+    const updateTag = (id: TagId, value: Partial<Tag>): void => {
+        if (!webApi) return;
+        const tag = tagData.get(id);
+        if (!tag) return;
+        webApi.tags.update([[id, { ...tag, ...value }]]).catch((e) => console.error(e));
+    };
+    const deleteTag = (id: TagId): void => {
+        if (!webApi) return;
+        webApi.tags.delete([id]).catch((e) => console.error(e));
+    };
+    const updateCategory = (id: TagCategoryId, value: Partial<TagCategory>): void => {
+        if (!webApi) return;
+        const category = tagCategoryData.get(id);
+        if (!category) return;
+        webApi.tagCategories.update([[id, { ...category, ...value }]]).catch((e) => console.error(e));
+    };
+
+    const tagUsage = useMemo(() => {
+        const byTag = new Map<TagId, number>();
+        for (const model of modelData.values()) {
+            for (const tag of deriveTags(model)) {
+                byTag.set(tag, (byTag.get(tag) ?? 0) + 1);
+            }
+        }
+        return byTag;
+    }, [modelData]);
+
+    const noCategory = useMemo(() => {
+        const categorized = new Set([...tagCategoryData.values()].flatMap((c) => c.tags));
+        return [...tagData.keys()].filter((id) => !categorized.has(id)).sort(compareTagId);
+    }, [tagData, tagCategoryData]);
+    const unknown = useMemo(() => {
+        const known = new Set(tagData.keys());
+        return [...tagUsage.keys()].filter((id) => !known.has(id) && !id.startsWith('by:')).sort(compareTagId);
+    }, [tagUsage, tagData]);
+
+    return (
+        <>
+            <Head>
+                <title>Tags</title>
+                <meta
+                    content="width=device-width, initial-scale=1"
+                    name="viewport"
+                />
+                <link
+                    href="/favicon.ico"
+                    rel="icon"
+                />
+            </Head>
+            <PageContainer>
+                <h1>Tags</h1>
+
+                {!editMode && <p className="text-red-700 dark:text-red-300">Not in edit mode!</p>}
+
+                <div className="my-6 rounded-lg bg-fade-100 p-4 dark:bg-fade-800">
+                    {categoryOrder.map(([categoryId, category]) => {
+                        return (
+                            <div key={categoryId}>
+                                <h2>
+                                    <EditableLabel
+                                        readonly={!editMode}
+                                        text={category.name}
+                                        onChange={(name) => updateCategory(categoryId, { name })}
+                                    />
+                                </h2>
+
+                                <div>
+                                    {category.tags.map((tagId) => {
+                                        const tag = tagData.get(tagId);
+                                        if (!tag) return <React.Fragment key={tagId} />;
+                                        return (
+                                            <TagView
+                                                key={tagId}
+                                                tag={tag}
+                                                usage={tagUsage.get(tagId) ?? 0}
+                                                onDelete={() => deleteTag(tagId)}
+                                                onDescriptionChange={(description) => updateTag(tagId, { description })}
+                                                onRename={(name) => updateTag(tagId, { name })}
+                                            />
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+
+                {noCategory.length > 0 && (
+                    <div className="my-6 rounded-lg bg-fade-100 p-4 dark:bg-fade-800">
+                        <h2>Uncategorized</h2>
+
+                        <div>
+                            {noCategory.map((tagId) => {
+                                const tag = tagData.get(tagId);
+                                if (!tag) return <React.Fragment key={tagId} />;
+                                return (
+                                    <TagView
+                                        key={tagId}
+                                        tag={tag}
+                                        usage={tagUsage.get(tagId) ?? 0}
+                                        onDelete={() => deleteTag(tagId)}
+                                        onDescriptionChange={(description) => updateTag(tagId, { description })}
+                                        onRename={(name) => updateTag(tagId, { name })}
+                                    />
+                                );
+                            })}
+                        </div>
+                    </div>
+                )}
+
+                {unknown.length > 0 && (
+                    <div className="my-6 rounded-lg bg-fade-100 p-4 dark:bg-fade-800">
+                        <h2>Unknown tags</h2>
+
+                        {unknown.map((id) => {
+                            return <div key={id}>{id}</div>;
+                        })}
+                    </div>
+                )}
+            </PageContainer>
+        </>
+    );
+}


### PR DESCRIPTION
This PR adds tag categories and a simple page to edit tags.

Tag categories are a list of tags with a name. They will be used for implementing the tag selector I proposed a while back.
![image](https://user-images.githubusercontent.com/20878432/225397775-0689a860-6ad5-4c93-ae49-1787e121aaa8.png)

That tags page itself is a simple list of all tag categories with their respective tags. All tag names, tag descriptions, and tag category names are editable.
![image](https://user-images.githubusercontent.com/20878432/225398341-315fe181-7780-462d-91c3-0d3778187485.png)

To make these properties editable, I added 2 new components: `EditableLabel` and `EditableMarkdownContainer`. Both components are thin wrappers around their underlying components (`<span>` or `MarkdownContainer`), but switch to a different component while editing. This makes these components really easy to use, so I used them in model pages as well.
![image](https://user-images.githubusercontent.com/20878432/225399531-cc6f51d3-f4d9-4d4c-b40d-e7f694711775.png) ![image](https://user-images.githubusercontent.com/20878432/225399418-82175e81-08a0-46b4-af7d-25c1e591f4d2.png)

