### PR TITLE
Optimized ModelCard

### DIFF
--- a/src/elements/components/link.tsx
+++ b/src/elements/components/link.tsx
@@ -9,6 +9,7 @@ export interface LinkProps {
     external?: boolean;
     type?: string;
     title?: string;
+    tabIndex?: number;
 }
 
 export function Link({ external, children, ...props }: React.PropsWithChildren<LinkProps>) {

--- a/src/elements/components/model-card.module.scss
+++ b/src/elements/components/model-card.module.scss
@@ -1,0 +1,40 @@
+.modelCard {
+    position: relative;
+    height: 350px;
+    overflow: hidden;
+    border-radius: 0.5rem;
+    border-width: 1px;
+    border-style: solid;
+
+    .inner {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        width: 100%;
+    }
+
+    .topTags {
+        position: absolute;
+        top: 0;
+        right: 0;
+        margin: 0.5rem;
+        display: flex;
+        flex-flow: row wrap;
+        column-gap: 0.5rem;
+    }
+
+    .thumbnail {
+        height: 100%;
+        width: 100%;
+        background: url('https://picsum.photos/512/312');
+        background-size: cover;
+        background-position: center;
+    }
+
+    .tagBase {
+        border-radius: 0.5rem;
+        padding: 0.25rem 0.5rem;
+        font-weight: 500;
+    }
+}

--- a/src/elements/components/model-card.tsx
+++ b/src/elements/components/model-card.tsx
@@ -5,11 +5,12 @@ import { joinList } from '../../lib/react-util';
 import { Model, ModelId } from '../../lib/schema';
 import { asArray } from '../../lib/util';
 import { Link } from './link';
+import style from './model-card.module.scss';
 
-type ModelCardProps = {
+interface ModelCardProps {
     id: ModelId;
     model: Model;
-};
+}
 
 export const ModelCard = ({ id, model }: ModelCardProps) => {
     const { tagData } = useTags();
@@ -18,64 +19,49 @@ export const ModelCard = ({ id, model }: ModelCardProps) => {
     const description = fixDescription(model.description, model.scale);
 
     return (
-        <div
-            // eslint-disable-next-line tailwindcss/no-arbitrary-value
-            className="group relative h-[350px] overflow-hidden rounded-lg border border-solid border-gray-300 shadow-lg hover:shadow-xl dark:border-gray-700 "
-        >
-            <div className="relative flex h-full w-full flex-col transition-all ease-in-out">
+        <div className={`${style.modelCard} border-gray-300 shadow-lg hover:shadow-xl dark:border-gray-700 `}>
+            <div className={style.inner}>
                 {/* Arch tag on image */}
-                <div className="absolute top-0 right-0 m-2">
-                    <div className="flex flex-row flex-wrap place-content-center justify-items-center gap-x-2 align-middle">
-                        <div className="rounded-lg bg-accent-500 px-2 py-1 text-sm font-medium text-gray-100 transition-colors ease-in-out dark:bg-accent-600 dark:text-gray-100 ">
-                            {model.architecture}
-                        </div>
-                        <div className="rounded-lg bg-accent-500 px-2 py-1 text-sm font-medium text-gray-100 transition-colors ease-in-out dark:bg-accent-600 dark:text-gray-100 ">
-                            {model.scale}x
-                        </div>
-                    </div>
+                <div className={style.topTags}>
+                    <AccentTag>{model.architecture}</AccentTag>
+                    <AccentTag>{model.scale}x</AccentTag>
                 </div>
 
                 <Link
-                    // eslint-disable-next-line tailwindcss/no-arbitrary-value
-                    className="h-auto w-full flex-1  bg-[url(https://picsum.photos/512/312)] bg-cover bg-center transition-all duration-500 ease-in-out group-hover:h-full"
+                    className={style.thumbnail}
                     href={`/models/${id}`}
+                    tabIndex={-1}
                 />
 
                 <div className="relative inset-x-0 bottom-0 bg-white p-3 pt-2 dark:bg-fade-900">
-                    <Link href={`/models/${id}`}>
-                        <div className="block text-xl font-bold text-gray-800 dark:text-gray-100">{model.name}</div>
+                    <Link
+                        className="block text-xl font-bold text-gray-800 dark:text-gray-100"
+                        href={`/models/${id}`}
+                    >
+                        {model.name}
                     </Link>
                     <div className="text-sm text-gray-600 dark:text-gray-400">
-                        <div>
-                            <span>by </span>
-                            {joinList(
-                                asArray(model.author).map((userId) => (
-                                    <Link
-                                        className="font-bold text-accent-500"
-                                        href={`/users/${userId}`}
-                                        key={userId}
-                                    >
-                                        {userData.get(userId)?.name ?? `unknown user:${userId}`}
-                                    </Link>
-                                ))
-                            )}
-                        </div>
+                        {'by '}
+                        {joinList(
+                            asArray(model.author).map((userId) => (
+                                <Link
+                                    className="font-bold text-accent-600 dark:text-accent-400"
+                                    href={`/users/${userId}`}
+                                    key={userId}
+                                >
+                                    {userData.get(userId)?.name ?? `unknown user:${userId}`}
+                                </Link>
+                            ))
+                        )}
                     </div>
 
                     {/* Description */}
-                    <div className="mb-1 flex flex-col justify-between py-1 text-sm">
-                        <div className="text-gray-500 line-clamp-3 dark:text-gray-400">{description}</div>
-                    </div>
+                    <div className="mb-1 py-1 text-sm text-gray-600 line-clamp-3 dark:text-gray-400">{description}</div>
 
                     {/* Tags */}
                     <div className="flex flex-row flex-wrap gap-1">
                         {model.tags.map((tagId) => (
-                            <div
-                                className="rounded-lg bg-gray-200 px-2 py-1 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-100"
-                                key={tagId}
-                            >
-                                {tagData.get(tagId)?.name ?? `unknown tag:${tagId}`}
-                            </div>
+                            <RegularTag key={tagId}>{tagData.get(tagId)?.name ?? `unknown tag:${tagId}`}</RegularTag>
                         ))}
                     </div>
                 </div>
@@ -112,4 +98,16 @@ function fixDescription(description: string, scale: number): string {
             ? descLines.join('\n').trim()
             : `${purposeSentence} ${datasetSentence} ${pretrainedSentence}`;
     return actualDescription;
+}
+
+function AccentTag({ children }: React.PropsWithChildren<unknown>) {
+    return <div className={`${style.tagBase} bg-accent-600 text-sm text-gray-100`}>{children}</div>;
+}
+
+function RegularTag({ children }: React.PropsWithChildren<unknown>) {
+    return (
+        <div className={`${style.tagBase} bg-gray-200 text-xs text-gray-800 dark:bg-gray-700 dark:text-gray-100`}>
+            {children}
+        </div>
+    );
 }


### PR DESCRIPTION
This PR includes 3 changes:

- Simplify DOM tree, remove unnecessary tailwind classes, and extract some classes out into SCSS.
- Make the card thumbnail not focusable via keyboard. This makes keyboard navigation easier.
- Change some colors for better readability.

The optimization stuff is the main change. I noticed that the main page has grown to 1MB (just HTML!!!). The culprit is `ModelCard` which generates a bunch of HTML. So I optimized `ModelCard` and got the size down to "only" 881KB (17% less). Still not great, but better.

![image](https://user-images.githubusercontent.com/20878432/226402125-dd7921a5-ac89-4b15-8dbf-ac0bb7c3b722.png)
