### PR TITLE
Don't try to access the backend API when deployed

### DIFF
--- a/src/lib/site-data.ts
+++ b/src/lib/site-data.ts
@@ -1,1 +1,3 @@
 export const SITE_URL = 'https://openmodeldb.info';
+
+export const IS_DEPLOYED = typeof location !== 'undefined' && location.host === 'openmodeldb.info';

--- a/src/lib/web-api.ts
+++ b/src/lib/web-api.ts
@@ -1,5 +1,6 @@
 import { CollectionApi, DBApi, notifyOnWrite } from './data-api';
 import { JsonApiCollection, JsonApiRequestHandler, JsonRequest, JsonResponse, Method } from './data-json-api';
+import { IS_DEPLOYED } from './site-data';
 import { delay, lazy, noop } from './util';
 
 const updateListeners = new Set<() => void>();
@@ -69,6 +70,11 @@ function createWebCollection<Id, Value>(path: string): CollectionApi<Id, Value> 
     });
 }
 export const getWebApi = lazy(async (): Promise<DBApi | undefined> => {
+    if (IS_DEPLOYED) {
+        // we only have API access locally
+        return Promise.resolve(undefined);
+    }
+
     const webApi: DBApi = {
         models: createWebCollection('/api/models'),
         users: createWebCollection('/api/users'),


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/20878432/229292689-97264682-a6c9-40f4-a386-cc2bf93a6fe6.png)

Since we don't deploy API routes, we know that this is going to always fail, so I added a little check to skip the request.