### PR TITLE
Derive input type from architecture

### DIFF
--- a/data/architectures.json
+++ b/data/architectures.json
@@ -1,24 +1,28 @@
 {
     "2c2-esrgan": {
         "name": "2C2-ESRGAN",
+        "input": "image",
         "compatiblePlatforms": [
             "pytorch"
         ]
     },
     "cain": {
         "name": "CAIN",
+        "input": "video",
         "compatiblePlatforms": [
             "pytorch"
         ]
     },
     "cain-yuv": {
         "name": "CAIN YUV",
+        "input": "video",
         "compatiblePlatforms": [
             "pytorch"
         ]
     },
     "compact": {
         "name": "Compact",
+        "input": "image",
         "compatiblePlatforms": [
             "pytorch",
             "onnx",
@@ -27,12 +31,14 @@
     },
     "edsr": {
         "name": "EDSR (SRResNet)",
+        "input": "image",
         "compatiblePlatforms": [
             "pytorch"
         ]
     },
     "esrgan": {
         "name": "ESRGAN",
+        "input": "image",
         "compatiblePlatforms": [
             "pytorch",
             "onnx",
@@ -41,30 +47,35 @@
     },
     "esrgan+": {
         "name": "ESRGAN+",
+        "input": "image",
         "compatiblePlatforms": [
             "pytorch"
         ]
     },
     "rife": {
         "name": "RIFE",
+        "input": "image",
         "compatiblePlatforms": [
             "pytorch"
         ]
     },
     "sofvsr": {
         "name": "SOFVSR",
+        "input": "video",
         "compatiblePlatforms": [
             "pytorch"
         ]
     },
     "spsr": {
         "name": "SPSR",
+        "input": "image",
         "compatiblePlatforms": [
             "pytorch"
         ]
     },
     "swinir": {
         "name": "SwinIR",
+        "input": "image",
         "compatiblePlatforms": [
             "pytorch",
             "onnx"

--- a/data/models/16x-ESRGAN.json
+++ b/data/models/16x-ESRGAN.json
@@ -2,9 +2,7 @@
     "name": "16xESRGAN",
     "author": "victorca25",
     "license": "Apache-2.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\nPretrained: RRDB_ESRGAN_x4.pth\n\n",
     "date": "2019-07-06",
     "architecture": "esrgan",

--- a/data/models/16x-PSNR.json
+++ b/data/models/16x-PSNR.json
@@ -2,9 +2,7 @@
     "name": "16x PSNR Pretrained Model",
     "author": "blueamulet",
     "license": "Apache-2.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\nPretrained: RRDB_PSNR_x4.pth\n\nThe original RRDB_PSNR_x4.pth model converted to 1x, 2x, 8x and 16x scales, intended to be used as pretrained models for new models at those scales. These are compatible with victor's 4xESRGAN.pth conversions",
     "date": "2020-04-20",
     "architecture": "esrgan",

--- a/data/models/1x-AnimeUndeint-Compact.json
+++ b/data/models/1x-AnimeUndeint-Compact.json
@@ -3,7 +3,6 @@
     "author": "zarxrax",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon",
         "restoration"

--- a/data/models/1x-Anti-Aliasing.json
+++ b/data/models/1x-Anti-Aliasing.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "anti-aliasing"
     ],
     "description": "Purpose: Anti aliasing / Images with pixelated edges",

--- a/data/models/1x-ArtClarity.json
+++ b/data/models/1x-ArtClarity.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "WTFPL",
     "tags": [
-        "image",
         "deblur"
     ],
     "description": "Purpose: Pixel Art\nPretrained: 4xPSNR\n\nTexture retaining denoiser and sharpener for digital artwork",

--- a/data/models/1x-BC1-smooth2.json
+++ b/data/models/1x-BC1-smooth2.json
@@ -3,7 +3,6 @@
     "author": "blueamulet",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: DDS (BC1/DXT1, BC3/DXT5 Compression)\nPurpose: BC1 Compression\n\nA model to help remove compression artifacts in BC1-BC3/DXT1-DXT5 compressed images (these all have color encoded the same way)",

--- a/data/models/1x-BCGone-Detailed.json
+++ b/data/models/1x-BCGone-Detailed.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": null,
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: DDS (BC1/DXT1, BC3/DXT5 Compression)\nPurpose: BC1 Compression\n\n",

--- a/data/models/1x-BCGone-DetailedV2-40-60.json
+++ b/data/models/1x-BCGone-DetailedV2-40-60.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: DDS (BC1/DXT1, BC3/DXT5 Compression)\nPurpose: BC1 Compression\n\n",

--- a/data/models/1x-BCGone-Smooth.json
+++ b/data/models/1x-BCGone-Smooth.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: DDS (BC1/DXT1, BC3/DXT5 Compression)\nPurpose: BC1 Compression\n\nAttempts to remove the damages done by BC1 compression.",

--- a/data/models/1x-BS-Colorizer.json
+++ b/data/models/1x-BS-Colorizer.json
@@ -3,7 +3,6 @@
     "author": "blackscout",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "colorization"
     ],
     "description": "B/W | 100% Desaturated images. It mostly results in Blue and Yellow images with slight hints of Green, Orange and Magenta. You are free to use this as a pretrain to achieve better results.",

--- a/data/models/1x-BSChroma.json
+++ b/data/models/1x-BSChroma.json
@@ -2,9 +2,7 @@
     "name": "BSChroma",
     "author": "blackscout",
     "license": "GPL-3.0-only",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Luminance/Chroma\nPurpose: Sharpen\n\nChromaSharpen - makes the colors slightly more vibrant with a sideeffect of possibly adding Chromatic Abberation to the image. I am not sure about the usage of this model on real case scenarios but anything blurry or with fuzzy colors could work",
     "date": "2020-02-29",
     "architecture": "esrgan",

--- a/data/models/1x-BSLuma.json
+++ b/data/models/1x-BSLuma.json
@@ -2,9 +2,7 @@
     "name": "BSLuma",
     "author": "blackscout",
     "license": "GPL-3.0-only",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Luminance/Chroma\nPurpose: Luma\n\nFix Luminance issues?? LumaSharpen ESRGAN Edition? - This model mostly does what \"Lumasharpen\" algorithms do. It may help fixing images with Luminance images issues? Like old DVD rips? I am not sure, didn't test.",
     "date": "2020-02-28",
     "architecture": "esrgan",

--- a/data/models/1x-BaldrickVHSFixV0-2.json
+++ b/data/models/1x-BaldrickVHSFixV0-2.json
@@ -3,7 +3,7 @@
     "author": "nimrodzorg",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: VHS Tapes\nPurpose: VHS\n\nFixing minor VHS Chroma and Pattern Noise - NOTE: only works on deinterlaced sources",
     "date": "2021-03-03",

--- a/data/models/1x-Bandage-Smooth.json
+++ b/data/models/1x-Bandage-Smooth.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "debanding"
     ],
     "description": "Attempts to remove the damages done by color banding. For this model, I downscaled all of the HR images to make their pixel size closer to 1000x1000 using the Box filter and then downscaled them again by 50% using the Point filter. Afterwards, I applied 64-bit color banding to every image in the dataset.",

--- a/data/models/1x-BleedOut-Compact.json
+++ b/data/models/1x-BleedOut-Compact.json
@@ -3,7 +3,6 @@
     "author": "zarxrax",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon",
         "restoration"

--- a/data/models/1x-BroadcastToStudioLite.json
+++ b/data/models/1x-BroadcastToStudioLite.json
@@ -3,7 +3,6 @@
     "author": "saurusx",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/1x-Compact-Pretrain.json
+++ b/data/models/1x-Compact-Pretrain.json
@@ -2,9 +2,7 @@
     "name": "Compact Pretrain",
     "author": "zarxrax",
     "license": "WTFPL",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\n\nThis is a collection of pretrained models for Real-ESRGAN's Compact architecture. There are 1x, 2x, and 4x models, as well as 1x and 2x \"UltraCompact\" and \"SuperUltraCompact\" models (think of these as the equivalent to ESRGAN \"lite\" models). By using these are pretrains for your models, you can ensure that your models are able to be interpolated with other Compact models that were trained from these. These pretrains are compatible with most existing compact models.",
     "date": "2022-07-31",
     "architecture": "compact",

--- a/data/models/1x-DEDXT.json
+++ b/data/models/1x-DEDXT.json
@@ -3,7 +3,6 @@
     "author": "cf2lter",
     "license": "WTFPL",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: DDS (BC1/DXT1, BC3/DXT5 Compression)\nPurpose: DXT compression\n\nTo retain details while removing artifacts caused by dxt compression on textures",

--- a/data/models/1x-DXTDecompressor-Source-V3.json
+++ b/data/models/1x-DXTDecompressor-Source-V3.json
@@ -3,7 +3,6 @@
     "author": "josephthekp",
     "license": "WTFPL",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: DDS (BC1/DXT1, BC3/DXT5 Compression)\nPurpose: DXT1 Compression\n\nRemoving compression artifacts from DXT1 compressed textures. This model was created to remove DXT1 compression artifacts from textures imported into the Source Engine. Compressed textures in the engine sometimes have a green-tint which this model also corrects. The data for this model contained a good mix of diffuse textures and normal maps which means this model is pretty good at removing compression from normals as well. Creating this model was a real learning experience for me and I hope someone finds a good use for it.",

--- a/data/models/1x-DXTless-SourceEngine.json
+++ b/data/models/1x-DXTless-SourceEngine.json
@@ -3,7 +3,6 @@
     "author": "xeller",
     "license": "WTFPL",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: DTX5 Compression\n\nThis model is made for Source Engine textures. It tries to remove compression artifacts such as blockyness, discoloration, green tint. It does pretty well on a lot of things, realistic stuff as well, but it was mostly made to work on TF2 textures. It's made to keep as much detail as possible, without any unnecessary denoising/sharpening. Huge thanks to Twittman for assisting me along this journey.",

--- a/data/models/1x-DeBLR.json
+++ b/data/models/1x-DeBLR.json
@@ -3,7 +3,6 @@
     "author": "blackscout",
     "license": null,
     "tags": [
-        "image",
         "deblur"
     ],
     "description": "General Deblurring",

--- a/data/models/1x-DeBink-Lite.json
+++ b/data/models/1x-DeBink-Lite.json
@@ -3,7 +3,7 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: Video Compression\nPurpose: Compression\n\nThis model was trained on lossless video frames of Metal Arms: Glitch in the System, compressed with Bink V1 for the LR frames. It's a lot more efficient than my first DeBink model, and also has less artifacts. It's not quite as robust, but the compression is barely noticeable in videos after processing with this.",
     "date": "2021-10-30",

--- a/data/models/1x-DeBink-v4.json
+++ b/data/models/1x-DeBink-v4.json
@@ -3,7 +3,7 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: Video Compression\nPurpose: Compression\n\nThis model removes early 2000s Bink and other compression artifacts. Works well on almost any image or video compression type.",
     "date": "2021-06-08",

--- a/data/models/1x-DeBink-v5.json
+++ b/data/models/1x-DeBink-v5.json
@@ -3,7 +3,7 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: Video Compression\nPurpose: Compression\n\nThis model removes early 2000s Bink and other compression artifacts. Works well on almost any image or video compression type.",
     "date": "2021-06-08",

--- a/data/models/1x-DeBink-v6.json
+++ b/data/models/1x-DeBink-v6.json
@@ -3,7 +3,7 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: Video Compression\nPurpose: Compression\n\nThis model removes early 2000s Bink and other compression artifacts. Works well on almost any image or video compression type.",
     "date": "2021-06-08",

--- a/data/models/1x-DeEdge.json
+++ b/data/models/1x-DeEdge.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "dehalo"
     ],
     "description": "Halo Removal",

--- a/data/models/1x-DeJpeg-Fatality-PlusULTRA.json
+++ b/data/models/1x-DeJpeg-Fatality-PlusULTRA.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\n\n",

--- a/data/models/1x-DeRoqBeta-lite.json
+++ b/data/models/1x-DeRoqBeta-lite.json
@@ -3,7 +3,7 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: Video Compression\nPurpose: Compression\n\nIncomplete lite model to remove ROQ compression",
     "date": "2022-07-26",

--- a/data/models/1x-DeSharpen.json
+++ b/data/models/1x-DeSharpen.json
@@ -2,9 +2,7 @@
     "name": "DeSharpen",
     "author": "loinne",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Oversharpening\nPurpose: Denoise\nPretrained: 1st attempt on random sharpening with the same dataset at 200000 iterations, which was trained on non-random desharp model, total ~600000 iterations on 3 models.\n\nMade for rare particular cases when the image was destroyed by applying noise, i.e. game textures or any badly exported photos. If your image does not have any oversharpening, it won't hurt them, leaving as is. In theory, this model knows when to activate and when to skip, also can successfully remove artifacts if only some parts of the image are oversharpened, for example in image consisting of several combined images, 1 of them with sharpen noise.",
     "date": "2019-06-03",
     "architecture": "esrgan",

--- a/data/models/1x-Debandurh-FS-Ultra-lite.json
+++ b/data/models/1x-Debandurh-FS-Ultra-lite.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "debanding"
     ],
     "description": "Purpose: Debanding images",

--- a/data/models/1x-DitherDeleterV2-Smooth.json
+++ b/data/models/1x-DitherDeleterV2-Smooth.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "dedither"
     ],
     "description": "https://imgsli.com/Mzg0MTk/1/2",

--- a/data/models/1x-DitherDeleterV3-Smooth.json
+++ b/data/models/1x-DitherDeleterV3-Smooth.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "dedither"
     ],
     "description": "Attempts to remove the damages done by dithering. For this model, I downscaled all of the HR images to make their pixel size closer to 1000x1000 using the Box filter and then downscaled them again by 50% using the Point filter. Afterwards, I applied 32-bit Riemersma to every image in the dataset.",

--- a/data/models/1x-Dotzilla-Compact.json
+++ b/data/models/1x-Dotzilla-Compact.json
@@ -3,7 +3,6 @@
     "author": "zarxrax",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon",
         "restoration"

--- a/data/models/1x-DoubleDetoon.json
+++ b/data/models/1x-DoubleDetoon.json
@@ -2,9 +2,7 @@
     "name": "DoubleDetoon",
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: DeToon\nPurpose: Detooning\n\nAn attempt to detoon images/drawings of people",
     "date": "2020-07-31",
     "architecture": "esrgan",

--- a/data/models/1x-ESRGAN.json
+++ b/data/models/1x-ESRGAN.json
@@ -2,9 +2,7 @@
     "name": "1xESRGAN",
     "author": "victorca25",
     "license": "Apache-2.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\nPretrained: RRDB_ESRGAN_x4.pth\n\n",
     "date": "2019-07-06",
     "architecture": "esrgan",

--- a/data/models/1x-Epsilon-one-compact.json
+++ b/data/models/1x-Epsilon-one-compact.json
@@ -3,7 +3,6 @@
     "author": "eva-01",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/1x-Fatality-DeBlur.json
+++ b/data/models/1x-Fatality-DeBlur.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "deblur"
     ],
     "description": "",

--- a/data/models/1x-Film-Degrainer-1-000.json
+++ b/data/models/1x-Film-Degrainer-1-000.json
@@ -3,7 +3,6 @@
     "author": "tika",
     "license": "CC0-1.0",
     "tags": [
-        "image",
         "denoise"
     ],
     "description": "Remove film grain/noise",

--- a/data/models/1x-Filmify4K-v2.json
+++ b/data/models/1x-Filmify4K-v2.json
@@ -3,7 +3,7 @@
     "author": "muf",
     "license": "CC0-1.0",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: Video Compression\nPurpose: artifact\n\nThis model attempts to make films upscaled to 4K with Topaz Gaia-HQ look more natural and filmic. It sharpens, adds film grain, and smooths out small artefacts from the upscaling process. I recommend adding a tiny amount of grain to the input to seed the model (you can do this in VEAI), otherwise the film grain will remain static across frames that don't move much. Pretrain model used with permission to relicense from Twittman.",
     "date": "2021-07-19",

--- a/data/models/1x-Focus-Moderate.json
+++ b/data/models/1x-Focus-Moderate.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "deblur"
     ],
     "description": "These models deblur most images. It was trained mostly on aniso2 and iso blurring (BSRGAN augmentation) with some gaussian mixed in. It performs well on most blurry images, but I'd recommend using something like Fatality_Deblur for very strong gaussian blur.",

--- a/data/models/1x-Focus.json
+++ b/data/models/1x-Focus.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "deblur"
     ],
     "description": "These models deblur most images. It was trained mostly on aniso2 and iso blurring (BSRGAN augmentation) with some gaussian mixed in. It performs well on most blurry images, but I'd recommend using something like Fatality_Deblur for very strong gaussian blur.",

--- a/data/models/1x-FrankenMapGenerator-CX-Lite.json
+++ b/data/models/1x-FrankenMapGenerator-CX-Lite.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-texture-maps"
     ],
     "description": "Category: Normal Map/Bump Map Generation\nPurpose: Map Generation - roughness and displacement maps\n\nThis model generates \"Franken Maps\" (named after Frankenstein), which is a custom material map combination I made. Basically, the Red channel of RGB is just the texture converted to grayscale, the Green channel is the roughness map, and the Blue channel is the displacement map. I had to do this to get around the current limitation of CX loss where it requires a 3 channel output (otherwise I would have just made a 2 channel model, or separate single channel models). As of right now the channels need to be manually split from each other but I will be making a tool for doing this automatically in the coming days.",

--- a/data/models/1x-GainRESV3-Aggro.json
+++ b/data/models/1x-GainRESV3-Aggro.json
@@ -3,7 +3,6 @@
     "author": "cf2lter",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anti-aliasing"
     ],
     "description": "Purpose: Anti aliasing / Deblur\n\nTo eliminate aliasing and general artifacts caused by not enough resolution while bringing out details Im stopping its training here because it's getting worse, i think of some aligment issues by game's rendering pipeline + downscaling...",

--- a/data/models/1x-GainRESV3-Natural.json
+++ b/data/models/1x-GainRESV3-Natural.json
@@ -3,7 +3,6 @@
     "author": "cf2lter",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anti-aliasing"
     ],
     "description": "Purpose: Anti aliasing / Deblur\n\nTo eliminate aliasing and general artifacts caused by not enough resolution while bringing out details Im stopping its training here because it's getting worse, i think of some aligment issues by game's rendering pipeline + downscaling...",

--- a/data/models/1x-GainRESV3-Passive.json
+++ b/data/models/1x-GainRESV3-Passive.json
@@ -3,7 +3,6 @@
     "author": "cf2lter",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anti-aliasing"
     ],
     "description": "Purpose: Anti aliasing / Deblur\n\nTo eliminate aliasing and general artifacts caused by not enough resolution while bringing out details Im stopping its training here because it's getting worse, i think of some aligment issues by game's rendering pipeline + downscaling...",

--- a/data/models/1x-Ghibli-Grain.json
+++ b/data/models/1x-Ghibli-Grain.json
@@ -2,9 +2,7 @@
     "name": "Ghibli Grain",
     "author": "nonogamester",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Images\nPurpose: Realistic Ghibli Grain\n\nText or Anime",
     "date": "2022-11-16",
     "architecture": "esrgan",

--- a/data/models/1x-HurrDeblur-SuperUltraCompact.json
+++ b/data/models/1x-HurrDeblur-SuperUltraCompact.json
@@ -3,7 +3,6 @@
     "author": "zarxrax",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon",
         "restoration"

--- a/data/models/1x-ISO-denoise-v1.json
+++ b/data/models/1x-ISO-denoise-v1.json
@@ -3,7 +3,6 @@
     "author": "alpha",
     "license": "WTFPL",
     "tags": [
-        "image",
         "denoise"
     ],
     "description": "Remove high ISO noise",

--- a/data/models/1x-ISO-denoise-v2.json
+++ b/data/models/1x-ISO-denoise-v2.json
@@ -3,7 +3,6 @@
     "author": "alpha",
     "license": "WTFPL",
     "tags": [
-        "image",
         "denoise"
     ],
     "description": "Remove high ISO noise",

--- a/data/models/1x-ITF-SkinDiffDDS-v1.json
+++ b/data/models/1x-ITF-SkinDiffDDS-v1.json
@@ -3,7 +3,6 @@
     "author": "intheflesh-3116",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: DDS (BC1/DXT1, BC3/DXT5 Compression)\nPurpose: BC1 Compression\n\nRemoves banding, blocking, dithering, aliasing, noise and color tint on DDS Compressed Skin Diffuse Textures.\n\nThis should work extremely well on most modern DDS compression types. The training set was compressed with BC3/DXT5, BC3/DXT5 Fast, BC2/DXT3, BC2/DXT3 Fast, and a small number of JPEG compressed images to cover outliers.\n\nThis model is trained to remove the slight green color tint that DDS compression tends to add to skin textures, so the model output will not match the original color tone of the input image. This is the desired result though, as DDS compression shifts the colors to a sickly green tint and this model corrects that to more natural color tones.\n\nThe training set included faces, body parts, eyes, mouths and hair in a variety of skin types and tones so it should work well on most related diffuse textures.\n\nHowever it's not just limited to skin, many other images and textures can be cleaned with this model. Designed to be used as a first step cleaning pass before applying additional models after. Check out the other ITF Models.",

--- a/data/models/1x-ITF-SkinDiffDetail-Lite-v1.json
+++ b/data/models/1x-ITF-SkinDiffDetail-Lite-v1.json
@@ -2,9 +2,7 @@
     "name": "ITF SkinDiffDetail Lite v1",
     "author": "intheflesh-3116",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Skin\nPurpose: Skin Upscaling\n\nAdds plausible high frequency detail and removes subtle blur. This is an early unfinished attempt at a x1 Lite model designed specifically for enhancing detail on skin diffuse textures of 3d characters. Even in its current state it works quite well.\n\nBest suited for uncompressed or cleaned textures - otherwise it may just enhance any existing compression artefacts too. The training set included faces, body parts, eyes and hair in a variety of skin types and tones so it should work well on most related diffuse textures.\n\nHowever it's not just limited to skin, many other images and textures can be enhanced with this model. The results are subtle, so run multiple times if desired.",
     "date": null,
     "architecture": "esrgan",

--- a/data/models/1x-JPEGDestroyer.json
+++ b/data/models/1x-JPEGDestroyer.json
@@ -3,7 +3,6 @@
     "author": "blackscout",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\n\nThis model is meant to reduce or eliminate JPEG Compression without making the original images too smooth or killing detail. It manages to do a fairly good job but don't expect overly compressed images to work with this.",

--- a/data/models/1x-JPG-00-20-alsa.json
+++ b/data/models/1x-JPG-00-20-alsa.json
@@ -3,7 +3,6 @@
     "author": "alsa",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\nPretrained: Trained on Custom (Photos / Manga)\n\n",

--- a/data/models/1x-JPG-00-20.json
+++ b/data/models/1x-JPG-00-20.json
@@ -3,7 +3,6 @@
     "author": "blueamulet",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\nPretrained: Trained on Custom (CC0 Textures)\n\n",

--- a/data/models/1x-JPG-20-40-alsa.json
+++ b/data/models/1x-JPG-20-40-alsa.json
@@ -3,7 +3,6 @@
     "author": "alsa",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\nPretrained: Trained on Custom (Photos / Manga)\n\n",

--- a/data/models/1x-JPG-20-40.json
+++ b/data/models/1x-JPG-20-40.json
@@ -3,7 +3,6 @@
     "author": "blueamulet",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\nPretrained: Trained on Custom (CC0 Textures)\n\n",

--- a/data/models/1x-JPG-40-60-alsa.json
+++ b/data/models/1x-JPG-40-60-alsa.json
@@ -3,7 +3,6 @@
     "author": "alsa",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\nPretrained: Trained on Custom (Photos / Manga)\n\n",

--- a/data/models/1x-JPG-40-60.json
+++ b/data/models/1x-JPG-40-60.json
@@ -3,7 +3,6 @@
     "author": "blueamulet",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\nPretrained: Trained on Custom (CC0 Textures)\n\n",

--- a/data/models/1x-JPG-60-80-alsa.json
+++ b/data/models/1x-JPG-60-80-alsa.json
@@ -3,7 +3,6 @@
     "author": "alsa",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\nPretrained: Trained on Custom (Photos / Manga)\n\n",

--- a/data/models/1x-JPG-60-80.json
+++ b/data/models/1x-JPG-60-80.json
@@ -3,7 +3,6 @@
     "author": "blueamulet",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\nPretrained: Trained on Custom (CC0 Textures)\n\n",

--- a/data/models/1x-JPG-80-100-alsa.json
+++ b/data/models/1x-JPG-80-100-alsa.json
@@ -3,7 +3,6 @@
     "author": "alsa",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\nPretrained: Trained on Custom (Photos / Manga)\n\n",

--- a/data/models/1x-JPG-80-100.json
+++ b/data/models/1x-JPG-80-100.json
@@ -3,7 +3,6 @@
     "author": "blueamulet",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\nPretrained: Trained on Custom (CC0 Textures)\n\n",

--- a/data/models/1x-KDM003-scans.json
+++ b/data/models/1x-KDM003-scans.json
@@ -2,9 +2,7 @@
     "name": "KDM003 scans",
     "author": "boxdrop",
     "license": null,
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Drawings\nPurpose: Art\n\nClean up model for scanned illustrations. - Made to remove moire patterns, reduce small imperfections, and correct mild compression artifacts in scanned Kingdom Death: Monster illustrations. CMYK printing often shifts colors, so this is intended to reverse that color shifting as well.",
     "date": "2019-07-29",
     "architecture": "esrgan",

--- a/data/models/1x-Kim2091-DeJpeg-v0.json
+++ b/data/models/1x-Kim2091-DeJpeg-v0.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\nPretrained: Custom JPEG dataset\n\nModel I forgot to release. This doesn't totally remove JPEG artifacts, but it does a decent job at a fast rate. It seemingly does a better job of retaining detail than some other JPEG models. The model is incomplete, I need to train it further on compact rather than ESRGAN. This is just a temporary release",

--- a/data/models/1x-Loyaldk-SharpKeroro.json
+++ b/data/models/1x-Loyaldk-SharpKeroro.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/1x-MangaJPEGHQ.json
+++ b/data/models/1x-MangaJPEGHQ.json
@@ -3,7 +3,6 @@
     "author": "bunzero",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\n\nRemove JPEG artifacts from manga without destroying screentone and other details. For 80-50 JPEG Quality",

--- a/data/models/1x-MangaJPEGHQPlus.json
+++ b/data/models/1x-MangaJPEGHQPlus.json
@@ -3,7 +3,6 @@
     "author": "bunzero",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\n\nRemove JPEG artifacts from manga without destroying screentone and other details. For 95-80 JPEG Quality",

--- a/data/models/1x-MangaJPEGLQ.json
+++ b/data/models/1x-MangaJPEGLQ.json
@@ -3,7 +3,6 @@
     "author": "bunzero",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\n\nRemove JPEG artifacts from manga without destroying screentone and other details. For 25-5 JPEG Quality",

--- a/data/models/1x-MangaJPEGMQ.json
+++ b/data/models/1x-MangaJPEGMQ.json
@@ -3,7 +3,6 @@
     "author": "bunzero",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\n\nRemove JPEG artifacts from manga without destroying screentone and other details. For 60-30 JPEG Quality",

--- a/data/models/1x-N64clean.json
+++ b/data/models/1x-N64clean.json
@@ -3,7 +3,6 @@
     "author": "blueamulet",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "debanding"
     ],
     "description": "N64 textures use a color depth of 5-bits per channel, this model attempts to clean them, restoring smooth gradients in textures",

--- a/data/models/1x-NMKD-Jaywreck3-Lite.json
+++ b/data/models/1x-NMKD-Jaywreck3-Lite.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG compression\n\n1xESRGAN",

--- a/data/models/1x-NMKD-Jaywreck3-Soft-Lite.json
+++ b/data/models/1x-NMKD-Jaywreck3-Soft-Lite.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG compression\n\n1xESRGAN",

--- a/data/models/1x-NMKD-YandereInpaint.json
+++ b/data/models/1x-NMKD-YandereInpaint.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": null,
     "tags": [
-        "image",
         "inpainting"
     ],
     "description": "",

--- a/data/models/1x-NMKD-h264Texturize.json
+++ b/data/models/1x-NMKD-h264Texturize.json
@@ -3,7 +3,7 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: Video Compression\nPurpose: Texturizing\n\nTries to reverse heavy h264 compression. Fails. Can be used to texturize images though.",
     "date": "2020-10-20",

--- a/data/models/1x-NoiseToner-Poisson-Detailed.json
+++ b/data/models/1x-NoiseToner-Poisson-Detailed.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "denoise"
     ],
     "description": "Purpose: Noise remover\n\nAttempts to remove the damages done from noise. Successor of sorts to Noisetoner_Poisson_150000_G",

--- a/data/models/1x-NoiseToner-Poisson-Soft.json
+++ b/data/models/1x-NoiseToner-Poisson-Soft.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": null,
     "tags": [
-        "image",
         "denoise"
     ],
     "description": "",

--- a/data/models/1x-NoiseToner-Poisson.json
+++ b/data/models/1x-NoiseToner-Poisson.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "denoise"
     ],
     "description": "Noise remover",

--- a/data/models/1x-NoiseToner-Uniform-Detailed.json
+++ b/data/models/1x-NoiseToner-Uniform-Detailed.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": null,
     "tags": [
-        "image",
         "denoise"
     ],
     "description": "",

--- a/data/models/1x-NoiseToner-Uniform-Soft.json
+++ b/data/models/1x-NoiseToner-Uniform-Soft.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": null,
     "tags": [
-        "image",
         "denoise"
     ],
     "description": "",

--- a/data/models/1x-NoiseToner-Uniform.json
+++ b/data/models/1x-NoiseToner-Uniform.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "denoise"
     ],
     "description": "Noise remover",

--- a/data/models/1x-NormalMapGenerator-CX-Lite.json
+++ b/data/models/1x-NormalMapGenerator-CX-Lite.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-texture-maps"
     ],
     "description": "Category: Normal Map/Bump Map Generation\nPurpose: Map Generation - normal maps\n\nGenerating normal maps from textures",

--- a/data/models/1x-PSNR.json
+++ b/data/models/1x-PSNR.json
@@ -2,9 +2,7 @@
     "name": "1x PSNR Pretrained Model",
     "author": "blueamulet",
     "license": "Apache-2.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\nPretrained: RRDB_PSNR_x4.pth\n\nThe original RRDB_PSNR_x4.pth model converted to 1x, 2x, 8x and 16x scales, intended to be used as pretrained models for new models at those scales. These are compatible with victor's 4xESRGAN.pth conversions",
     "date": "2020-04-20",
     "architecture": "esrgan",

--- a/data/models/1x-PixelSharpen.json
+++ b/data/models/1x-PixelSharpen.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "deblur"
     ],
     "description": "Purpose: Pixel Art\n\nRestores blurry/upscaled pixel art.",

--- a/data/models/1x-Plants.json
+++ b/data/models/1x-Plants.json
@@ -2,9 +2,7 @@
     "name": "Plants",
     "author": "muf",
     "license": "CC0-1.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Foliage/Ground\nPurpose: bad upscale\n\nImages of plants, trees or other foliage upscaled with Photoshop Preserve Details 2.0. Sharpens and \"subdivides\" details and noise so it doesn't look upscaled.",
     "date": "2021-06-23",
     "architecture": "esrgan",

--- a/data/models/1x-ReFocus-Cleanly.json
+++ b/data/models/1x-ReFocus-Cleanly.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "deblur"
     ],
     "description": "Purpose: Deblur / ReFocus\n\nPurpose: DeBlur, ReFocus, Sharpen Manga, Anime and cartoon style images, but will work on real life images too.",

--- a/data/models/1x-ReFocus-V3.json
+++ b/data/models/1x-ReFocus-V3.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "deblur"
     ],
     "description": "Purpose: Deblur / ReFocus\n\nPurpose: DeBlur, ReFocus, Sharpen Real life style images, but will work on Anime images too.",

--- a/data/models/1x-RedImage.json
+++ b/data/models/1x-RedImage.json
@@ -2,9 +2,7 @@
     "name": "RedImage10000",
     "author": "3majsie1995",
     "license": "CC-BY-NC-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: CGI\nPurpose: Correct old color photos that are tinted red\n\nCorrect old color photos that are tinted red. Model only tested in nature.",
     "date": "2022-08-04",
     "architecture": "esrgan",

--- a/data/models/1x-RoQ-nRoll.json
+++ b/data/models/1x-RoQ-nRoll.json
@@ -3,7 +3,7 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: Video Compression\nPurpose: Compression\n\nThis model decompresses images and video compressed using RoQ. Config and presets will be added when Mega decides to let me use their site!",
     "date": "2021-11-21",

--- a/data/models/1x-SBDV-DeJPEG-Lite.json
+++ b/data/models/1x-SBDV-DeJPEG-Lite.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG compression\n\n",

--- a/data/models/1x-SS-Anti-Alias-9x.json
+++ b/data/models/1x-SS-Anti-Alias-9x.json
@@ -3,7 +3,6 @@
     "author": "blueamulet",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "anti-aliasing"
     ],
     "description": "",

--- a/data/models/1x-SaiyaJin-DeJpeg.json
+++ b/data/models/1x-SaiyaJin-DeJpeg.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG\n\n",

--- a/data/models/1x-SheeepIt.json
+++ b/data/models/1x-SheeepIt.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/1x-SpongeBC1-Lite.json
+++ b/data/models/1x-SpongeBC1-Lite.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/1x-SpongeColor-Lite.json
+++ b/data/models/1x-SpongeColor-Lite.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "colorization"
     ],
     "description": "The first attempt at ESRGAN colorization that produces more than 2 colors. Doesn't work that great but it was a neat experiment.",

--- a/data/models/1x-Spongebob-De-Quantize.json
+++ b/data/models/1x-Spongebob-De-Quantize.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/1x-SuperUltraCompact-Pretrain.json
+++ b/data/models/1x-SuperUltraCompact-Pretrain.json
@@ -2,9 +2,7 @@
     "name": "SuperUltraCompact Pretrain",
     "author": "zarxrax",
     "license": "WTFPL",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\n\nThis is a collection of pretrained models for Real-ESRGAN's Compact architecture. There are 1x, 2x, and 4x models, as well as 1x and 2x \"UltraCompact\" and \"SuperUltraCompact\" models (think of these as the equivalent to ESRGAN \"lite\" models). By using these are pretrains for your models, you can ensure that your models are able to be interpolated with other Compact models that were trained from these. These pretrains are compatible with most existing compact models.",
     "date": "2022-07-31",
     "architecture": "compact",

--- a/data/models/1x-SwatKatsLite.json
+++ b/data/models/1x-SwatKatsLite.json
@@ -3,7 +3,6 @@
     "author": "saurusx",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/1x-ThePi7on-Solidd-Deborutify-UltraLite.json
+++ b/data/models/1x-ThePi7on-Solidd-Deborutify-UltraLite.json
@@ -3,7 +3,6 @@
     "author": "thepi7on",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "deblur"
     ],
     "description": "Sharpening, line darkening and slight line thinning, specifically made for the Boruto anime.",

--- a/data/models/1x-ToonVHS.json
+++ b/data/models/1x-ToonVHS.json
@@ -3,7 +3,7 @@
     "author": "redslam",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: VHS Tapes\nPurpose: VHS\n\nBest when used on cartoons, it can work on anime. Due to the dataset it does struggle a bit with orange colors and grainy dark spots. This model is meant to be used to clean up the image before using it on a 2x or 4x model.",
     "date": "2022-02-06",

--- a/data/models/1x-UltraCompact-Pretrain.json
+++ b/data/models/1x-UltraCompact-Pretrain.json
@@ -2,9 +2,7 @@
     "name": "UltraCompact Pretrain",
     "author": "zarxrax",
     "license": "WTFPL",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\n\nThis is a collection of pretrained models for Real-ESRGAN's Compact architecture. There are 1x, 2x, and 4x models, as well as 1x and 2x \"UltraCompact\" and \"SuperUltraCompact\" models (think of these as the equivalent to ESRGAN \"lite\" models). By using these are pretrains for your models, you can ensure that your models are able to be interpolated with other Compact models that were trained from these. These pretrains are compatible with most existing compact models.",
     "date": "2022-07-31",
     "architecture": "compact",

--- a/data/models/1x-UnResize-V3.json
+++ b/data/models/1x-UnResize-V3.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "deblur"
     ],
     "description": "Purpose: Deblur / Unresize\n\nPurpose: Fix images that have been arbitrarily / poorly resized, such as non-integer nearest-neighbor upscaling/downscaling - Also acts as an image sharpener/deblur when used on slightly soft inputs",

--- a/data/models/1x-VHS-Sharpen.json
+++ b/data/models/1x-VHS-Sharpen.json
@@ -3,7 +3,7 @@
     "author": "rtx-2080-ti-hoarder",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: VHS Tapes\nPurpose: VHS\n\nMake old VHS footage crispy. This model will not work on video and images with noticeable JPEG/Video compression artifacts, noticeable interlacing or haloing, heavy tape distortion/artifacts and scenes with tons of detail. For best results, use a downscaled HD capture of the VHS tape you intend to use it on.",
     "date": "2021-03-19",

--- a/data/models/1x-artifacts-bc1-free-alsa.json
+++ b/data/models/1x-artifacts-bc1-free-alsa.json
@@ -3,7 +3,6 @@
     "author": "alsa",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: DDS (BC1/DXT1, BC3/DXT5 Compression)\nPurpose: BC1 Compression\nPretrained: BC1 take 2\n\n",

--- a/data/models/1x-artifacts-dithering-alsa.json
+++ b/data/models/1x-artifacts-dithering-alsa.json
@@ -3,7 +3,6 @@
     "author": "alsa",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "dedither"
     ],
     "description": "Dithered Images",

--- a/data/models/1x-cinepak.json
+++ b/data/models/1x-cinepak.json
@@ -3,7 +3,7 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: Video Compression\nPurpose: Compression\n\nRemoval of Compression such as Cinepak, msvideo1 and Roq",
     "date": "2019-07-03",

--- a/data/models/1x-mdeblur.json
+++ b/data/models/1x-mdeblur.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": null,
     "tags": [
-        "image",
         "deblur"
     ],
     "description": "Strong deblurring model",

--- a/data/models/1x-normals-generator-general.json
+++ b/data/models/1x-normals-generator-general.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-texture-maps"
     ],
     "description": "Category: Normal Map/Bump Map Generation\nPurpose: Map Generation - Normal Maps\n\nThis model generates \"Franken Maps\" (named after Frankenstein), which is a custom material map combination I made. Basically, the Red channel of RGB is just the texture converted to grayscale, the Green channel is the roughness map, and the Blue channel is the displacement map. I had to do this to get around the current limitation of CX loss where it requires a 3 channel output (otherwise I would have just made a 2 channel model, or separate single channel models). As of right now the channels need to be manually split from each other but I will be making a tool for doing this automatically in the coming days.",

--- a/data/models/1x-sudo-inpaint-PartialConv2D.json
+++ b/data/models/1x-sudo-inpaint-PartialConv2D.json
@@ -3,7 +3,6 @@
     "author": "sudo",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "inpainting"
     ],
     "description": "Experimental PartialConv2D attempt to paint with ESRGAN. Took ~10.4 days of training on a P100 and around 1.5 months in total due to Colab limits. Not sure if I will continue training it since training is very slow, but may get better.. Warning: Result can vary with different tilesizes. Try not to tile your data.",

--- a/data/models/2x-190562-vimeo-enchanced.json
+++ b/data/models/2x-190562-vimeo-enchanced.json
@@ -2,9 +2,7 @@
     "name": "Vimeo Enchanced",
     "author": "hubert",
     "license": "MIT",
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained SOFVSR Models\nPurpose: RL videos - interpolation\n\n",
     "date": "2021-07-13",
     "architecture": "cain",

--- a/data/models/2x-ATLA-KORRA.json
+++ b/data/models/2x-ATLA-KORRA.json
@@ -3,7 +3,6 @@
     "author": "aptitude",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-AnimeClassics-UltraLite.json
+++ b/data/models/2x-AnimeClassics-UltraLite.json
@@ -3,7 +3,6 @@
     "author": "cg1989",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-BIGOLDIES.json
+++ b/data/models/2x-BIGOLDIES.json
@@ -3,7 +3,6 @@
     "author": "solidd93110",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-BS-Wolly.json
+++ b/data/models/2x-BS-Wolly.json
@@ -2,9 +2,7 @@
     "name": "BSWolly",
     "author": "blackscout",
     "license": "GPL-3.0-only",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: CGI\nPurpose: CGI Animation\n\nPixar Movies or Wall-E pictures/frames",
     "date": "2020-02-07",
     "architecture": "esrgan",

--- a/data/models/2x-BSTexty.json
+++ b/data/models/2x-BSTexty.json
@@ -3,7 +3,6 @@
     "author": "blackscout",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "text"
     ],
     "description": "As the name might suggest, this model aims to upscale text with less distortion that other models. It seems to do a good job generally, but don't expect it to be a state of the art model that can upscale magazines and stuff. It makes things more readable but since it was train on B/W pictures it desaturates them.",

--- a/data/models/2x-Bubble-AnimeScale-Compact-v1.json
+++ b/data/models/2x-Bubble-AnimeScale-Compact-v1.json
@@ -3,7 +3,6 @@
     "author": "bubblemint",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-Bubble-AnimeScale-SwinIR-Small-v1.json
+++ b/data/models/2x-Bubble-AnimeScale-SwinIR-Small-v1.json
@@ -3,7 +3,6 @@
     "author": "bubblemint",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-Byousoku-5-Centimeter.json
+++ b/data/models/2x-Byousoku-5-Centimeter.json
@@ -3,7 +3,6 @@
     "author": "mystery-bullet",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-CGIMaster-v1.json
+++ b/data/models/2x-CGIMaster-v1.json
@@ -2,9 +2,7 @@
     "name": "CGIMaster v1",
     "author": "madiator",
     "license": "GPL-3.0-only",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: CGI\nPurpose: CGI Animation\n\nmixed 3D/2D CGI animations on some 2D animations it might sharpen the edges. General usage is to upscale CGI animations compressed by YouTube.",
     "date": "2021-01-14",
     "architecture": "esrgan",

--- a/data/models/2x-Compact-Pretrain.json
+++ b/data/models/2x-Compact-Pretrain.json
@@ -2,9 +2,7 @@
     "name": "Compact Pretrain",
     "author": "zarxrax",
     "license": "WTFPL",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\n\nThis is a collection of pretrained models for Real-ESRGAN's Compact architecture. There are 1x, 2x, and 4x models, as well as 1x and 2x \"UltraCompact\" and \"SuperUltraCompact\" models (think of these as the equivalent to ESRGAN \"lite\" models). By using these are pretrains for your models, you can ensure that your models are able to be interpolated with other Compact models that were trained from these. These pretrains are compatible with most existing compact models.",
     "date": "2022-07-31",
     "architecture": "compact",

--- a/data/models/2x-DeGif.json
+++ b/data/models/2x-DeGif.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: GIF\nPurpose: GIF Restoration\n\nGIF Restoration",

--- a/data/models/2x-DigiGradients-Lite.json
+++ b/data/models/2x-DigiGradients-Lite.json
@@ -2,9 +2,7 @@
     "name": "DigiGradients Lite",
     "author": "saurusx",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Digital Animation\nPurpose: Digital Animation\n\nA very focused model meant for upscaling the TMNT 2003 DVDs. Degradations were added via AVISynth in order to match the video on the TMNT 2003 DVDs to correct the source problems. Problems corrected include aliased red chroma, chroma vertical blur, bad deinterlacing, banding, compression \"grain\", and poor animation line detail. The AVS scripts for the LR's were run through HCEnc to get authentic low bit rate MPEG-2 artifacts for fixing. By design, the final model gives a very digital-looking result and does not do a good job of retaining textures as the style of TMNT 2003 is all flats and gradients.",
     "date": "2022-08-24",
     "architecture": "esrgan",

--- a/data/models/2x-DigitalFilmV5-Lite.json
+++ b/data/models/2x-DigitalFilmV5-Lite.json
@@ -2,9 +2,7 @@
     "name": "DigitalFilmV5 Lite",
     "author": "optimusprimal",
     "license": "WTFPL",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Cel Animation\nPurpose: Traditional Animation\n\nUpscaling Dragon Ball Z DBox DVD's. - grainy sources. It keeps some grain, but also doing some cleaning, sharpening, and fixing.",
     "date": "2021-02-19",
     "architecture": "esrgan",

--- a/data/models/2x-DigitalFlim-SuperUltraCompact.json
+++ b/data/models/2x-DigitalFlim-SuperUltraCompact.json
@@ -2,9 +2,7 @@
     "name": "DigitalFlim SuperUltraCompact",
     "author": "zarxrax",
     "license": "WTFPL",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Digital Animation\nPurpose: Animation\n\nThis was trained on the dataset that OptimusPrimal used for his DigitalFilm models. This model cleans up the image removing some noise while upscaling. This model is very fast, running around 200x the speed of a standard ESRGAN model on my system. This is primarily a proof of concept for how fast Real-ESRGAN models can get while still producing nice results.",
     "date": "2022-05-14",
     "architecture": "compact",

--- a/data/models/2x-DigitoonLite.json
+++ b/data/models/2x-DigitoonLite.json
@@ -2,9 +2,7 @@
     "name": "Digitoon Lite",
     "author": "saurusx",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Digital Animation\nPurpose: Digital Animation\n\nMeant as a versatile model for upscaling high detail digital anime and cartoons. Has debanding, MPEG-2 correction, and halo reduction. Trained to handle both 4:3 and 16:9 DVD material with equal efficacy. Will retain a lot of textures except for the really high freq stuff.",
     "date": "2022-07-05",
     "architecture": "esrgan",

--- a/data/models/2x-ESRGAN.json
+++ b/data/models/2x-ESRGAN.json
@@ -2,9 +2,7 @@
     "name": "2xESRGAN",
     "author": "victorca25",
     "license": "Apache-2.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\nPretrained: RRDB_ESRGAN_x4.pth\n\n",
     "date": "2019-07-06",
     "architecture": "esrgan",

--- a/data/models/2x-Faithful-Lite.json
+++ b/data/models/2x-Faithful-Lite.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Pixel Art\n\nA \"lite\" model version of my Faithful model",

--- a/data/models/2x-Faithful.json
+++ b/data/models/2x-Faithful.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art",

--- a/data/models/2x-FaithfulSPSR.json
+++ b/data/models/2x-FaithfulSPSR.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Pixel art\n\nMainly just a test for SPSR. Seems to work better than the original 2xFaithful32_1316 that I used as a pretrained, even though it uses the same dataset.",

--- a/data/models/2x-FakeFaith-Lite.json
+++ b/data/models/2x-FakeFaith-Lite.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Pixel Art\n\nAn attempt at recreating the \"faithful\" style without using the faithful dataset -- aka keeping the \"pixel art\" style of pixel art.",

--- a/data/models/2x-Futsuu-Anime.json
+++ b/data/models/2x-Futsuu-Anime.json
@@ -3,7 +3,6 @@
     "author": "zarxrax",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-GT-evA.json
+++ b/data/models/2x-GT-evA.json
@@ -3,7 +3,6 @@
     "author": "eva-01",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-Gen5-Alpha.json
+++ b/data/models/2x-Gen5-Alpha.json
@@ -2,9 +2,7 @@
     "name": "Gen5 Alpha",
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Alphas\nPurpose: Pixel Art with Tranparency / Alpha Channel\n\n",
     "date": "2021-02-03",
     "architecture": "esrgan",

--- a/data/models/2x-KcjpunkAnime-2-0-Lite.json
+++ b/data/models/2x-KcjpunkAnime-2-0-Lite.json
@@ -2,9 +2,7 @@
     "name": "KcjpunkAnime 2.0 Lite",
     "author": "kcjpunk",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Digital Animation\nPurpose: Digital Animation\nPretrained: This is my first attempt to make Light model so I started with 2x version. This model is much faster and give better results than my previous one.\n\nUp-scaling Digital Animation",
     "date": "2021-03-23",
     "architecture": "esrgan",

--- a/data/models/2x-KemonoScale-v2.json
+++ b/data/models/2x-KemonoScale-v2.json
@@ -3,7 +3,6 @@
     "author": "ezogaming",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-LD-Anime-Compact.json
+++ b/data/models/2x-LD-Anime-Compact.json
@@ -6,7 +6,6 @@
     ],
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-LD-Anime-Skr-v1-0.json
+++ b/data/models/2x-LD-Anime-Skr-v1-0.json
@@ -3,7 +3,6 @@
     "author": "skr",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-Loyaldk-Giroro.json
+++ b/data/models/2x-Loyaldk-Giroro.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-Loyaldk-Keroro.json
+++ b/data/models/2x-Loyaldk-Keroro.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-Loyaldk-Kororo.json
+++ b/data/models/2x-Loyaldk-Kororo.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-Loyaldk-LitePonyV1-0.json
+++ b/data/models/2x-Loyaldk-LitePonyV1-0.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-Loyaldk-LitePonyV2-0.json
+++ b/data/models/2x-Loyaldk-LitePonyV2-0.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-Loyaldk-MediumPonyV2-0.json
+++ b/data/models/2x-Loyaldk-MediumPonyV2-0.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-Loyaldk-SuperPonyV1-0.json
+++ b/data/models/2x-Loyaldk-SuperPonyV1-0.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-Loyaldk-SuperPonyV2-0.json
+++ b/data/models/2x-Loyaldk-SuperPonyV2-0.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-MangaScaleV3.json
+++ b/data/models/2x-MangaScaleV3.json
@@ -3,7 +3,6 @@
     "author": "bunzero",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "manga"
     ],
     "description": "To upscale manga including halftones, instead of trying to smooth them out.",

--- a/data/models/2x-NMKD-YandereNeo.json
+++ b/data/models/2x-NMKD-YandereNeo.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-PSNR.json
+++ b/data/models/2x-PSNR.json
@@ -2,9 +2,7 @@
     "name": "2x PSNR Pretrained Model",
     "author": "blueamulet",
     "license": "Apache-2.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\nPretrained: RRDB_PSNR_x4.pth\n\nThe original RRDB_PSNR_x4.pth model converted to 1x, 2x, 8x and 16x scales, intended to be used as pretrained models for new models at those scales. These are compatible with victor's 4xESRGAN.pth conversions",
     "date": "2020-04-20",
     "architecture": "esrgan",

--- a/data/models/2x-SBS11-RRDB.json
+++ b/data/models/2x-SBS11-RRDB.json
@@ -2,9 +2,7 @@
     "name": "SBS11 RRDB",
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Discriminators\nPurpose: Animation\n\nnone",
     "date": "2020-12-03",
     "architecture": "sofvsr",

--- a/data/models/2x-SHARP-ANIME-V1.json
+++ b/data/models/2x-SHARP-ANIME-V1.json
@@ -3,7 +3,6 @@
     "author": "solidd93110",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-SHARP-ANIME-V2.json
+++ b/data/models/2x-SHARP-ANIME-V2.json
@@ -3,7 +3,6 @@
     "author": "solidd93110",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-SuperUltraCompact-Pretrain.json
+++ b/data/models/2x-SuperUltraCompact-Pretrain.json
@@ -2,9 +2,7 @@
     "name": "SuperUltraCompact Pretrain",
     "author": "zarxrax",
     "license": "WTFPL",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\n\nThis is a collection of pretrained models for Real-ESRGAN's Compact architecture. There are 1x, 2x, and 4x models, as well as 1x and 2x \"UltraCompact\" and \"SuperUltraCompact\" models (think of these as the equivalent to ESRGAN \"lite\" models). By using these are pretrains for your models, you can ensure that your models are able to be interpolated with other Compact models that were trained from these. These pretrains are compatible with most existing compact models.",
     "date": "2022-07-31",
     "architecture": "compact",

--- a/data/models/2x-SwatKats.json
+++ b/data/models/2x-SwatKats.json
@@ -3,7 +3,6 @@
     "author": "saurusx",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-UltraCompact-Pretrain.json
+++ b/data/models/2x-UltraCompact-Pretrain.json
@@ -2,9 +2,7 @@
     "name": "UltraCompact Pretrain",
     "author": "zarxrax",
     "license": "WTFPL",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\n\nThis is a collection of pretrained models for Real-ESRGAN's Compact architecture. There are 1x, 2x, and 4x models, as well as 1x and 2x \"UltraCompact\" and \"SuperUltraCompact\" models (think of these as the equivalent to ESRGAN \"lite\" models). By using these are pretrains for your models, you can ensure that your models are able to be interpolated with other Compact models that were trained from these. These pretrains are compatible with most existing compact models.",
     "date": "2022-07-31",
     "architecture": "compact",

--- a/data/models/2x-UniScale-CartoonRestore-lite.json
+++ b/data/models/2x-UniScale-CartoonRestore-lite.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-VHS-upscale-and-denoise-Film.json
+++ b/data/models/2x-VHS-upscale-and-denoise-Film.json
@@ -3,7 +3,7 @@
     "author": "itewreed",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: VHS Tapes\nPurpose: VHS\n\nVHS captures of Film material, but may work on VHS recorded native SD-TV material as well. Also useable for cleaned up source material",
     "date": "2021-03-28",

--- a/data/models/2x-VimeoScale-Unet.json
+++ b/data/models/2x-VimeoScale-Unet.json
@@ -2,9 +2,7 @@
     "name": "VimeoScale Unet",
     "author": "sazoji",
     "license": "CC-BY-SA-4.0",
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Discriminators\nPurpose: Upscaling video content\n\nThis model is meant to surpass VEAI 2x while being efficient to run quickly with fp16. The real-esrgan/BSRGAN augmentation and Unet should help with videos where the resolution is not ideal and can reconstruct details without effecting blurs in most cases. This model SHOULD run faster than real-esrgan while matching the resolving and enabling some multiframe feature extraction. No major denoising/compression/blurring effects (or artifacts) should be found.",
     "date": "2021-09-09",
     "architecture": "sofvsr",

--- a/data/models/2x-Waifaux-NL3-SRResNet.json
+++ b/data/models/2x-Waifaux-NL3-SRResNet.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-Waifaux-NL3-SuperLite.json
+++ b/data/models/2x-Waifaux-NL3-SuperLite.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-anifilm-compact.json
+++ b/data/models/2x-anifilm-compact.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-cainREALTIME.json
+++ b/data/models/2x-cainREALTIME.json
@@ -2,9 +2,7 @@
     "name": "cainREALTIME",
     "author": "hubert",
     "license": "MIT",
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained SOFVSR Models\nPurpose: RL videos - interpolation\nArchitecture: CAIN (CAIN 1 Group)\n\nTrained mostly on abba music videos",
     "date": "2021-07-13",
     "architecture": "cain",

--- a/data/models/2x-cainliteanime.json
+++ b/data/models/2x-cainliteanime.json
@@ -2,9 +2,7 @@
     "name": "cainliteanime",
     "author": "hubert",
     "license": "MIT",
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained SOFVSR Models\nPurpose: Anime - interpolation\n\n",
     "date": "2021-08-06",
     "architecture": "cain",

--- a/data/models/2x-cvpv6.json
+++ b/data/models/2x-cvpv6.json
@@ -2,9 +2,7 @@
     "name": "cvpv6",
     "author": "hubert",
     "license": "MIT",
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained SOFVSR Models\nPurpose: Anime - interpolation\n\n",
     "date": "2021-09-21",
     "architecture": "cain",

--- a/data/models/2x-explodV1.json
+++ b/data/models/2x-explodV1.json
@@ -2,9 +2,7 @@
     "name": "explodV1",
     "author": "hubert",
     "license": "BSD-3-Clause",
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained SOFVSR Models\nPurpose: Animethemes\n\nI think one of sharpest models for anime\n\nPlz don't steal without credits, k thx.",
     "date": "2022-07-29",
     "architecture": "cain-yuv",

--- a/data/models/2x-fidelbd-pokemodel.json
+++ b/data/models/2x-fidelbd-pokemodel.json
@@ -3,7 +3,6 @@
     "author": "neo-raws",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-pokemodel-lite.json
+++ b/data/models/2x-pokemodel-lite.json
@@ -3,7 +3,6 @@
     "author": "neo-raws",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-rvpV1.json
+++ b/data/models/2x-rvpV1.json
@@ -2,9 +2,7 @@
     "name": "rvpV1",
     "author": "sudo",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained SOFVSR Models\nPurpose: Video Frame Interpolation for anime openings\nPretrained: My ~~first~~ (ok technically second) attempt to create a video frame interpolation model and I like how it turned out. To use it, you can either use https://gitlab.com/hubert.sontowski2007/cainapp, https://github.com/styler00dollar/Colab-CAIN or the bot in [Game Upscale] (model called rvpv1 there, just use --model rvpv1). Some demo videos in pcloud, but you need to download them. The web player seems to playback in low fps. The architecture is mainly the same to the original CAIN, but i modified the padding to be zero padding instead. ``.pt`` means JIT model, `.pth`, means normal pytorch model. Architecture file is in pcloud as well. And no, no cupscale or flowframes.",
     "date": "2021-09-14",
     "architecture": "cain",

--- a/data/models/2x-sudo-RealESRGAN-Dropout.json
+++ b/data/models/2x-sudo-RealESRGAN-Dropout.json
@@ -3,7 +3,6 @@
     "author": "sudo",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-sudo-RealESRGAN.json
+++ b/data/models/2x-sudo-RealESRGAN.json
@@ -3,7 +3,6 @@
     "author": "sudo",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-sudo-UltraCompact.json
+++ b/data/models/2x-sudo-UltraCompact.json
@@ -3,7 +3,6 @@
     "author": "sudo",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/2x-sudo-rife4-testV1.json
+++ b/data/models/2x-sudo-rife4-testV1.json
@@ -2,9 +2,7 @@
     "name": "sudo rife4 testV1 scale1",
     "author": "sudo",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained SOFVSR Models\nPurpose: Animation interpolation\n\nI never really mentioned it in model-releases prior since I think not too many care about interpolation here, but I trained a rife4 model for animation a some months ago, which is better than rife4 and rife4.2 imo. Thought I should also mention it here as well. I also converted it into ncnn. (Nihuis rife ncnn models are only exported with the fastest mode and not the best quality. I exported ncnn models for the most important quality settings. Due to different export/quality settings, there are multiple models. For that reason alone, my ncnn models are much better too, since nihui only exported the fastest one.) My https://github.com/styler00dollar/VSGAN-tensorrt-docker also has the rife ncnn extention, which can use VMAF, dedup, scene detection and so on, which I would recommend. My models are in that extention as well, just select model 10, 11 or 12 and use the dev docker. That test video is done with 2x framerate, enbemble True and FastMode False, combined with scene detection and dedup stuff, tta False. Towards the best quality rife can do. Plz don't steal without credits, k thx.",
     "date": "2022-06-25",
     "architecture": "rife",

--- a/data/models/3x-Video-TSSM-RRDB.json
+++ b/data/models/3x-Video-TSSM-RRDB.json
@@ -2,9 +2,7 @@
     "name": "Video TSSM RRDB",
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Discriminators\nPurpose: Animation\n\nnone",
     "date": "2020-11-25",
     "architecture": "sofvsr",

--- a/data/models/3x-Video-TSSM.json
+++ b/data/models/3x-Video-TSSM.json
@@ -2,9 +2,7 @@
     "name": "Video TSSM",
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Discriminators\nPurpose: Animation\n\nnone",
     "date": "2020-11-17",
     "architecture": "sofvsr",

--- a/data/models/4x-1ch-Alpha-Lite.json
+++ b/data/models/4x-1ch-Alpha-Lite.json
@@ -2,9 +2,7 @@
     "name": "1ch-Alpha Lite",
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Alphas\nPurpose: Alpha\n\nObsoleted by Joey's Fork - Alpha channels of PNGs",
     "date": "2020-12-15",
     "architecture": "esrgan",

--- a/data/models/4x-2C2-ESRGAN-Nomos2K.json
+++ b/data/models/4x-2C2-ESRGAN-Nomos2K.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "MIT",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "Technically my previous experiment was the pretrained model, but for all intents and purposes this was trained from scratch. Description: Pretrained model for the new architecture modification I made. You can read more about it in the github README. Basically it makes smaller ESRGAN models that theoretically can produce the same level of quality. NOTE: THIS WILL NOT WORK IN CUPSCALE, IEU, OR CHAINNER (yet)! You have to use my fork to use it for now.",

--- a/data/models/4x-AbeScale.json
+++ b/data/models/4x-AbeScale.json
@@ -3,7 +3,6 @@
     "author": "mitch",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-American-Dad-2.json
+++ b/data/models/4x-American-Dad-2.json
@@ -3,7 +3,6 @@
     "author": "pheonix",
     "license": null,
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-AnimeSharp-lite.json
+++ b/data/models/4x-AnimeSharp-lite.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-AnimeSharp.json
+++ b/data/models/4x-AnimeSharp.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-ArtStation1337-Bloom.json
+++ b/data/models/4x-ArtStation1337-Bloom.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Digital Art/People\nPretrained: Mainly for digital art, but can be used to upscale pixel art.",

--- a/data/models/4x-ArtStation1337-Dedither-v2.json
+++ b/data/models/4x-ArtStation1337-Dedither-v2.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Digital Art/People\nPretrained: Mainly for digital art, but can be used to upscale pixel art.",

--- a/data/models/4x-ArtStation1337-Dedither.json
+++ b/data/models/4x-ArtStation1337-Dedither.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Digital Art/People\nPretrained: Mainly for digital art, but can be used to upscale pixel art.",

--- a/data/models/4x-ArtStation1337-Diffuse.json
+++ b/data/models/4x-ArtStation1337-Diffuse.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Digital Art/People\nPretrained: Mainly for digital art, but can be used to upscale pixel art.",

--- a/data/models/4x-ArtStation1337-v2.json
+++ b/data/models/4x-ArtStation1337-v2.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Digital Art/People\nPretrained: Mainly for digital art, but can be used to upscale pixel art.",

--- a/data/models/4x-ArtStation1337.json
+++ b/data/models/4x-ArtStation1337.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Digital Art/People\nPretrained: Mainly for digital art, but can be used to upscale pixel art.",

--- a/data/models/4x-BS-Deviance.json
+++ b/data/models/4x-BS-Deviance.json
@@ -3,7 +3,6 @@
     "author": "blackscout",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Art\n\nThis model upscales Digital Drawings. It was trained on random drawings found on DeviantArt. Mostly Landscape and Scenery and Illustrations of Characters. It does fairly well and works on many different styles.",

--- a/data/models/4x-BS-DevianceMIP.json
+++ b/data/models/4x-BS-DevianceMIP.json
@@ -3,7 +3,6 @@
     "author": "blackscout",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Art\n\nupscales Digital Drawings. It was trained on random drawings found on DeviantArt. Mostly Landscape and Scenery and Illustrations of Characters. It does fairly well and works on many different styles.",

--- a/data/models/4x-BS-SbeveHarvey.json
+++ b/data/models/4x-BS-SbeveHarvey.json
@@ -3,7 +3,6 @@
     "author": "blackscout",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "faces",
         "face-upscaling"
     ],

--- a/data/models/4x-BS-ScreenBooster-SPSR.json
+++ b/data/models/4x-BS-ScreenBooster-SPSR.json
@@ -2,9 +2,7 @@
     "name": "BS_ScreenBooster_SPSR",
     "author": "blackscout",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Game Screenshots\nPurpose: CGI\n\nThis model is designed to upscale game screenshots (3D Games) by 4 times. The SPSR version is an improvement over the ESRGAN based V2.",
     "date": "2020-07-18",
     "architecture": "spsr",

--- a/data/models/4x-BigFArt-Bang1.json
+++ b/data/models/4x-BigFArt-Bang1.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nLarger-scaled pixels to digital painting",

--- a/data/models/4x-BigFArt-Base.json
+++ b/data/models/4x-BigFArt-Base.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nLarger-scaled pixels to digital painting",

--- a/data/models/4x-BigFArt-Blend.json
+++ b/data/models/4x-BigFArt-Blend.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nLarger-scaled pixels to digital painting",

--- a/data/models/4x-BigFArt-Detail.json
+++ b/data/models/4x-BigFArt-Detail.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nLarger-scaled pixels to digital painting",

--- a/data/models/4x-BigFArt-Fine.json
+++ b/data/models/4x-BigFArt-Fine.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nLarger-scaled pixels to digital painting",

--- a/data/models/4x-BigFArt.json
+++ b/data/models/4x-BigFArt.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nLarger-scaled pixels to digital painting",

--- a/data/models/4x-BigFace-V3-Blend.json
+++ b/data/models/4x-BigFace-V3-Blend.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "faces",
         "face-upscaling"
     ],

--- a/data/models/4x-BigFace-V3-Clear.json
+++ b/data/models/4x-BigFace-V3-Clear.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "faces",
         "face-upscaling"
     ],

--- a/data/models/4x-BigFace-v3.json
+++ b/data/models/4x-BigFace-v3.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "faces",
         "face-upscaling"
     ],

--- a/data/models/4x-BigFace.json
+++ b/data/models/4x-BigFace.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": null,
     "tags": [
-        "image",
         "faces",
         "face-upscaling"
     ],

--- a/data/models/4x-BooruGan-600k.json
+++ b/data/models/4x-BooruGan-600k.json
@@ -3,7 +3,6 @@
     "author": "tal",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-BooruGan-650k.json
+++ b/data/models/4x-BooruGan-650k.json
@@ -3,7 +3,6 @@
     "author": "tal",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Box.json
+++ b/data/models/4x-Box.json
@@ -3,7 +3,6 @@
     "author": "buildist",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "photo"
     ],
     "description": "Category: Realistic Photos\nPurpose: Realistic Photos\n\nRRDB_ESRGAN_x4 replacement for stuff that's supposed to look realistic.",

--- a/data/models/4x-Cat-Patch.json
+++ b/data/models/4x-Cat-Patch.json
@@ -2,9 +2,7 @@
     "name": "Cat_Patch",
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Cats\nPurpose: Cats",
     "date": null,
     "architecture": "esrgan",

--- a/data/models/4x-Comic-Book.json
+++ b/data/models/4x-Comic-Book.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Compact-Pretrain.json
+++ b/data/models/4x-Compact-Pretrain.json
@@ -2,9 +2,7 @@
     "name": "Compact Pretrain",
     "author": "zarxrax",
     "license": "WTFPL",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\n\nThis is a collection of pretrained models for Real-ESRGAN's Compact architecture. There are 1x, 2x, and 4x models, as well as 1x and 2x \"UltraCompact\" and \"SuperUltraCompact\" models (think of these as the equivalent to ESRGAN \"lite\" models). By using these are pretrains for your models, you can ensure that your models are able to be interpolated with other Compact models that were trained from these. These pretrains are compatible with most existing compact models.",
     "date": "2022-07-31",
     "architecture": "compact",

--- a/data/models/4x-CountryRoads.json
+++ b/data/models/4x-CountryRoads.json
@@ -3,7 +3,6 @@
     "author": "ezogaming",
     "license": "WTFPL",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "Streets with dense foliage in the background. Outdoor scenes.",

--- a/data/models/4x-DeCompress-Strong.json
+++ b/data/models/4x-DeCompress-Strong.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG (works on many compression formats)\n\nUSE 4x-UltraSharp INSTEAD - This is UniScaleV2, but intended for images with compression. Seems to work best on realistic images.",

--- a/data/models/4x-DeCompress.json
+++ b/data/models/4x-DeCompress.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG (works on many compression formats)\n\nUSE 4x-UltraSharp INSTEAD - This is UniScaleV2, but intended for images with compression. Seems to work best on realistic images.",

--- a/data/models/4x-DeIndeo.json
+++ b/data/models/4x-DeIndeo.json
@@ -3,7 +3,7 @@
     "author": "wild-west-quest",
     "license": "WTFPL",
     "tags": [
-        "video"
+        "video-frame"
     ],
     "description": "Category: Video Compression\nPurpose: Indeo Compression Artifacts",
     "date": null,

--- a/data/models/4x-Deoldify.json
+++ b/data/models/4x-Deoldify.json
@@ -3,7 +3,6 @@
     "author": "rastrum",
     "license": "CC0-1.0",
     "tags": [
-        "image",
         "colorization"
     ],
     "description": "Purpose: Photos\n\nOld black and white photo restoration.",

--- a/data/models/4x-DigiPaint.json
+++ b/data/models/4x-DigiPaint.json
@@ -2,9 +2,7 @@
     "name": "DigiPaint",
     "author": "rastrum",
     "license": "CC0-1.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Drawings\nPurpose: Art\n\nDigital Art Upscaler",
     "date": "2019-09-07",
     "architecture": "esrgan",

--- a/data/models/4x-DigitalFake-2-1.json
+++ b/data/models/4x-DigitalFake-2-1.json
@@ -2,9 +2,7 @@
     "name": "DigitalFake 2.1",
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Digital Animation\nPurpose: Digital Animation\n\nReplica of DigitalFrames 2.1 but interpolatable",
     "date": "2021-02-18",
     "architecture": "esrgan",

--- a/data/models/4x-ESRGAN.json
+++ b/data/models/4x-ESRGAN.json
@@ -2,9 +2,7 @@
     "name": "4xESRGAN",
     "author": "xinntao",
     "license": "Apache-2.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\nPretrained: RRDB_ESRGAN_x4.pth\n\n",
     "date": "2019-07-06",
     "architecture": "esrgan",

--- a/data/models/4x-FArtFace.json
+++ b/data/models/4x-FArtFace.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "faces",
         "face-upscaling"
     ],

--- a/data/models/4x-FSDedither-Manga.json
+++ b/data/models/4x-FSDedither-Manga.json
@@ -3,7 +3,6 @@
     "author": "jacob",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "dedither"
     ],
     "description": "Cartoons/pixel art/other non-realistic stuff with dithering",

--- a/data/models/4x-FSDedither-Riven.json
+++ b/data/models/4x-FSDedither-Riven.json
@@ -3,7 +3,6 @@
     "author": "jacob",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "dedither"
     ],
     "description": "Fine-tuned 4xFSDedither to upscale images from the game Riven, but should be better in general, particularly on ordered dithering. I adjusted the dataset to have a better variety of dithering parameters, and turned up the HFEN and pixel loss to get better details and color restoration with less noise.",

--- a/data/models/4x-FSDedither.json
+++ b/data/models/4x-FSDedither.json
@@ -3,7 +3,6 @@
     "author": "jacob",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "dedither"
     ],
     "description": "For photos/realistic images, but worth trying on other images that have reduced colors and dithering along with fine details. Trained using the ESRGAN-FS code (https://github.com/ManuelFritsche/real-world-sr/tree/master/esrgan-fs/codes) for better details compared to plain ESRGAN.",

--- a/data/models/4x-FSMangaV2.json
+++ b/data/models/4x-FSMangaV2.json
@@ -3,7 +3,6 @@
     "author": "jacob",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "manga"
     ],
     "description": "Manga-style images with or without dithering - cartoons, maybe pixel art, etc",

--- a/data/models/4x-Fabric-Alt.json
+++ b/data/models/4x-Fabric-Alt.json
@@ -2,9 +2,7 @@
     "name": "Fabric-Alt",
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Fabric/Cloth\nPurpose: Fabric\n\nThis model set upscales fabric or cloth textures (works on cats too!). The Alt model is just an earlier iteration version. It may work better on some images.The images need to be minimally compressed or passed through a decompression model first. It works with DDS compression though.",
     "date": "2021-09-15",
     "architecture": "esrgan",

--- a/data/models/4x-Fabric.json
+++ b/data/models/4x-Fabric.json
@@ -2,9 +2,7 @@
     "name": "Fabric",
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Fabric/Cloth\nPurpose: Fabric\n\nThis model set upscales fabric or cloth textures (works on cats too!). The Alt model is just an earlier iteration version. It may work better on some images.The images need to be minimally compressed or passed through a decompression model first. It works with DDS compression though.",
     "date": "2021-09-15",
     "architecture": "esrgan",

--- a/data/models/4x-Face-Ality-V1.json
+++ b/data/models/4x-Face-Ality-V1.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "faces",
         "face-upscaling"
     ],

--- a/data/models/4x-Face-Focus.json
+++ b/data/models/4x-Face-Focus.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "faces",
         "face-upscaling"
     ],

--- a/data/models/4x-Faces-04-N.json
+++ b/data/models/4x-Faces-04-N.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "faces",
         "face-upscaling"
     ],

--- a/data/models/4x-Falcon-Fanart.json
+++ b/data/models/4x-Falcon-Fanart.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Fallout-Weapons-V2.json
+++ b/data/models/4x-Fallout-Weapons-V2.json
@@ -3,7 +3,6 @@
     "author": "bob",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nVideo game textures, mostly metal rusty, clean or painted",

--- a/data/models/4x-Fallout-Weapons.json
+++ b/data/models/4x-Fallout-Weapons.json
@@ -3,7 +3,6 @@
     "author": "bob",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nVideo game textures, mostly metal rusty, clean or painted",

--- a/data/models/4x-Fatal-Anime.json
+++ b/data/models/4x-Fatal-Anime.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Fatal-Pixels.json
+++ b/data/models/4x-Fatal-Pixels.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Pixel Art/Sprites",

--- a/data/models/4x-FatalimiX.json
+++ b/data/models/4x-FatalimiX.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Fatality-MK2.json
+++ b/data/models/4x-Fatality-MK2.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Pixel Art/Sprites\nPretrained: A previously attempted MK2",

--- a/data/models/4x-Fatality.json
+++ b/data/models/4x-Fatality.json
@@ -3,7 +3,6 @@
     "author": "twittman",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Pixel Art/Sprites\n\nUpscales medium resolution Sprites, dithered or undithered, can also upscale manga/anime and gameboy camera images.",

--- a/data/models/4x-FatePlus-lite.json
+++ b/data/models/4x-FatePlus-lite.json
@@ -2,9 +2,7 @@
     "name": "FatePlus-lite",
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Game Screenshots\nPurpose: Anime PSP games, Fate Extra\n\nThis model was trained as a favor to Demon and the Fate Extra community. It leaves a nice grain on the images and upscales lines and details accurately without looking odd. This model works on most anime-style PSP games. Enjoy! It works best on content with dithering and quantization. NOTICE: I have included both NCNN and ONNX models to make upscaling easier if you rely on either of these. For NCNN, there's two versions. One is FP16 and the other is FP32. FP16 works best on RTX GPUs. Choose FP32 if in doubt about compatibility, or if FP16 doesn't work for you. To use ONNX, download chaiNNer and upscale through there with the ONNX nodes.",
     "date": "2022-07-03",
     "architecture": "esrgan",

--- a/data/models/4x-FireAlpha.json
+++ b/data/models/4x-FireAlpha.json
@@ -2,9 +2,7 @@
     "name": "FireAlpha",
     "author": "blueamulet",
     "license": "CC-BY-NC-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Alphas\nPurpose: Alpha (4 channel)\n\n",
     "date": "2019-11-12",
     "architecture": "esrgan",

--- a/data/models/4x-Forest.json
+++ b/data/models/4x-Forest.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nWood / Leaves",

--- a/data/models/4x-FuzzyBox.json
+++ b/data/models/4x-FuzzyBox.json
@@ -3,7 +3,6 @@
     "author": "blueamulet",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "Photographs, Artwork, Textures, Anything really - Tried out a new pixel loss idea based on ensuring the HR downscaled matches the LR. Colors are pretty good as well as edges, but generated details seem slightly fuzzy hence the name.",

--- a/data/models/4x-GameAI-1-0.json
+++ b/data/models/4x-GameAI-1-0.json
@@ -2,9 +2,7 @@
     "name": "GameAI 1.0",
     "author": "tal",
     "license": "WTFPL",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Game Screenshots\nPurpose: PS2 textures, cartoonish and realistic game textures.\n\nThis model is intended to mainly handle PS2 compression and a mixture of Realistic and cartoonish textures, it's not meant to be used for very low resolution textures such as item icons.",
     "date": "2022-02-27",
     "architecture": "esrgan",

--- a/data/models/4x-GameAI-2-0.json
+++ b/data/models/4x-GameAI-2-0.json
@@ -2,9 +2,7 @@
     "name": "GameAI 2.0",
     "author": "tal",
     "license": "WTFPL",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Game Screenshots\nPurpose: PS2 textures, cartoonish and realistic game textures.\n\nThis model is intended to mainly handle PS2 compression and a mixture of Realistic and cartoonish textures, it's not meant to be used for very low resolution textures such as item icons.",
     "date": "2022-02-27",
     "architecture": "esrgan",

--- a/data/models/4x-Ground.json
+++ b/data/models/4x-Ground.json
@@ -2,9 +2,7 @@
     "name": "Ground",
     "author": "tldr-coder",
     "license": "WTFPL",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Foliage/Ground\nPurpose: Upscales ground textures",
     "date": "2021-06-23",
     "architecture": "esrgan",

--- a/data/models/4x-HDCube.json
+++ b/data/models/4x-HDCube.json
@@ -3,7 +3,6 @@
     "author": "venomalia",
     "license": "CC0-1.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Gamecube and Wii textures.\n\nGamecube and Wii textures (mainly DXT and 8bit color compression). Is good for preserving fine details without affecting the original style too much, it is not suitable for pixel art, small icons and text under 16 pixel.",

--- a/data/models/4x-HDCube3.json
+++ b/data/models/4x-HDCube3.json
@@ -3,7 +3,6 @@
     "author": "venomalia",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Gamecube and Wii textures.\nPretrained: 4x_HDcube2\n\nIt can be used for all image formats supported by Gamecube and Wii hardware and can remove its typical artifacts like CMPR Block Compression (DXT1 algorithm, also known as BC1), color palette errors, color reduction up to 8bit color depth and 1bit alpha depth.",

--- a/data/models/4x-HellinaCel.json
+++ b/data/models/4x-HellinaCel.json
@@ -2,9 +2,7 @@
     "name": "HellinaCel",
     "author": "vgdckeroro",
     "license": "WTFPL",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Cel Animation\nPurpose: Traditional Animation\n\nA rougher alternative to 4xCelFrames with a focus on realistic looking cels over nice looking cels. It's trained on DetoriationFrames LRs, so if you give it an image straight from the source it will go twice as hard on it. This can be used to your advantage, though. I recommend cleaning it up before running DetoriationFrames, or else it will come out rough.",
     "date": "2021-03-21",
     "architecture": "esrgan",

--- a/data/models/4x-Jaypeg90.json
+++ b/data/models/4x-Jaypeg90.json
@@ -3,7 +3,6 @@
     "author": "jacob",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: JPEG compression\n\nPhotos/realistic 3D with JPEG compression, quality 85-95 and 4:2:0 chroma subsampling. - Created for Myst3 images, since all have 4:2:0 chroma subsampling and existing JPEG models did not give good results. Favors smoothing over over-sharpening.",

--- a/data/models/4x-KCJPUNK-1.json
+++ b/data/models/4x-KCJPUNK-1.json
@@ -2,9 +2,7 @@
     "name": "KCJPUNK",
     "author": "kcjpunk",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Digital Animation\nPurpose: Digital Animation\n\nUp-scaling Digital Animation",
     "date": "2021-03-23",
     "architecture": "esrgan",

--- a/data/models/4x-LADDIER1.json
+++ b/data/models/4x-LADDIER1.json
@@ -3,7 +3,6 @@
     "author": "alexander-syring",
     "license": null,
     "tags": [
-        "image",
         "denoise"
     ],
     "description": "Remove noise, grain, box blur, lens blur and gaussian blur and increase overall image quality.",

--- a/data/models/4x-Lady0101.json
+++ b/data/models/4x-Lady0101.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": null,
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Pixel Art/Paintings\n\nUpscale pixel art/paintings to digital painting style",

--- a/data/models/4x-Link.json
+++ b/data/models/4x-Link.json
@@ -2,9 +2,7 @@
     "name": "Link",
     "author": "fielran",
     "license": "GPL-3.0-only",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Game Screenshots\nPurpose: Chainmail game textures. Alternatively, it can be used to turn plain images into chainmail.\n\nA highly generative model for chainmail game textures. Works fairly well on items without visible chainmail texture (ie just a grey area) or items with clear chainmail texture, less well on items with present but poorly defined chainmail texture. I'm not 100% happy with it but it is still an improvement over existing models in enough situations to be worth releasing.",
     "date": "2022-10-06",
     "architecture": "esrgan",

--- a/data/models/4x-Lollypop.json
+++ b/data/models/4x-Lollypop.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "A universal model, that is aimed at prerendered images, but handles realistic faces, manga, pixel art and dedithering as well. Trained using the patchgan discriminator, with cx loss, cutmixup and frequency separation, it produces good results with a slight grain due to patchgan, with some sharpening using cutmixup.",

--- a/data/models/4x-Loyaldk-Giroro.json
+++ b/data/models/4x-Loyaldk-Giroro.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Loyaldk-Keroro.json
+++ b/data/models/4x-Loyaldk-Keroro.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Loyaldk-Kororo.json
+++ b/data/models/4x-Loyaldk-Kororo.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Loyaldk-LitePonyV2-0.json
+++ b/data/models/4x-Loyaldk-LitePonyV2-0.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Loyaldk-MediumPonyV2-0.json
+++ b/data/models/4x-Loyaldk-MediumPonyV2-0.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Loyaldk-SuperPonyV2-0.json
+++ b/data/models/4x-Loyaldk-SuperPonyV2-0.json
@@ -3,7 +3,6 @@
     "author": "chasemmd",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Manga109Attempt.json
+++ b/data/models/4x-Manga109Attempt.json
@@ -3,7 +3,6 @@
     "author": "kingdomakrillic",
     "license": "CC-BY-4.0",
     "tags": [
-        "image",
         "anime",
         "manga"
     ],

--- a/data/models/4x-Map.json
+++ b/data/models/4x-Map.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nMap / Old Paper with text",

--- a/data/models/4x-MeguUp.json
+++ b/data/models/4x-MeguUp.json
@@ -3,7 +3,6 @@
     "author": "katoumegumi",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-MinecraftAlphaUpscaler-with-Good-data.json
+++ b/data/models/4x-MinecraftAlphaUpscaler-with-Good-data.json
@@ -2,9 +2,7 @@
     "name": "MinecraftAlphaUpscaler with Good data",
     "author": "washed-up",
     "license": "GPL-3.0-only",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Game Screenshots\nPurpose: Upscaling pack.png\n\nDesigned to upscale one specific minecraft screenshot. Results on dissimilar screenshots may be poor.",
     "date": "2020-01-29",
     "architecture": "esrgan",

--- a/data/models/4x-Minepack.json
+++ b/data/models/4x-Minepack.json
@@ -2,9 +2,7 @@
     "name": "Minepack",
     "author": "blackscout",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Game Screenshots\nPurpose: Upscaling pack.png.pth\n\nUpscales Minecraft screenshots by 4x. May suffer from haloing, weird patterns on blocks and JPEG-like artifacts.",
     "date": "2020-01-26",
     "architecture": "esrgan",

--- a/data/models/4x-Misc.json
+++ b/data/models/4x-Misc.json
@@ -3,7 +3,6 @@
     "author": "alsa",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "photo"
     ],
     "description": "Category: Realistic Photos\nPurpose: General Upscaler\nPretrained: Manga109Attempt\n\nThe Misc model is trained on various pictures shot by myself (Alsa), including bricks, stone, dirt, grass, plants, wood, bark, metal and a few others.",

--- a/data/models/4x-Morrowind-2-0.json
+++ b/data/models/4x-Morrowind-2-0.json
@@ -3,7 +3,6 @@
     "author": "mkultra",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nMorrowind Mod Textures",

--- a/data/models/4x-Morrowind-Mixed.json
+++ b/data/models/4x-Morrowind-Mixed.json
@@ -3,7 +3,6 @@
     "author": "mkultra",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nMorrowind Mod Textures",

--- a/data/models/4x-NMKD-PatchySharp.json
+++ b/data/models/4x-NMKD-PatchySharp.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "image",
         "restoration"
     ],
     "description": "Category: JPEG Artifacts\nPurpose: Art/CGI\n\nUpscaler for clean images or images with compression artifacts (jpeg quality >75) - Produces very sharp lines/edges due to NN-Filtered HR images. Proven to produce very, very good results on drawings (sharp lines) and CGI, but should also work pretty well for real-world images.",

--- a/data/models/4x-NMKD-Siax-CX.json
+++ b/data/models/4x-NMKD-Siax-CX.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "Universal upscaler for clean and slightly compressed images (JPEG quality 75 or better)",

--- a/data/models/4x-NMKD-Superscale.json
+++ b/data/models/4x-NMKD-Superscale.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "image",
         "photo"
     ],
     "description": "Category: Realistic Photos\nPurpose: Clean Real-World Images\n\nUpscaling of realistic images/photos with noise and compression artifacts",

--- a/data/models/4x-NMKD-UltraYandere-Lite.json
+++ b/data/models/4x-NMKD-UltraYandere-Lite.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-NMKD-UltraYandere.json
+++ b/data/models/4x-NMKD-UltraYandere.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-NMKD-YandereNeo-Superlite.json
+++ b/data/models/4x-NMKD-YandereNeo-Superlite.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-NMKD-YandereNeo-XL.json
+++ b/data/models/4x-NMKD-YandereNeo-XL.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-NMKD-YandereNeo.json
+++ b/data/models/4x-NMKD-YandereNeo.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-NXbrz.json
+++ b/data/models/4x-NXbrz.json
@@ -3,7 +3,6 @@
     "author": "archerpolation",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nBasic pixel art upscaling, for people who want a more simpler style and lightweight pixel art upscaling model.",

--- a/data/models/4x-Nickelback.json
+++ b/data/models/4x-Nickelback.json
@@ -3,7 +3,6 @@
     "author": "blackscout",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "photo"
     ],
     "description": "Category: Realistic Photos\nPurpose: Realistic Photos\n\nthis model aims to improve further on what has been achieved by the regular 4xESRGAN and also 4xBox. It can upscale most pictures/photos (granted they are clean enough) without destroying as much detail as the aforementioned models. It generates less moiré like patterns and keeps details without oversharpening or blurring the image too much.",

--- a/data/models/4x-NickelbackFS.json
+++ b/data/models/4x-NickelbackFS.json
@@ -3,7 +3,6 @@
     "author": "blackscout",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "photo"
     ],
     "description": "Category: Realistic Photos\nPurpose: Realistic Photos\n\nThis model aims to improve further on what has been achieved by the old Nickelback which was an improvement attempt over 4xESRGAN and also 4xBox. It can upscale most pictures/photos (granted they are clean enough) without destroying as much detail as Box and basic ESRGAN.",

--- a/data/models/4x-Nickelfront.json
+++ b/data/models/4x-Nickelfront.json
@@ -2,9 +2,7 @@
     "name": "Nickelfront",
     "author": "blackscout",
     "license": "GPL-3.0-only",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Coins\nPurpose: Coins\n\nUpscale coins. That's it. If you were mad at me because Nickelback doesn't make any sense. Now you have the perfect solution to your problems. If you want to upscale nickels or anything with similar texture made out of metal, now you can. It works pretty well for a joke.",
     "date": "2020-02-13",
     "architecture": "esrgan",

--- a/data/models/4x-OLDIES-ALTERNATIVE-FINAL.json
+++ b/data/models/4x-OLDIES-ALTERNATIVE-FINAL.json
@@ -3,7 +3,6 @@
     "author": "solidd93110",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-OLDIESFINAL.json
+++ b/data/models/4x-OLDIESFINAL.json
@@ -3,7 +3,6 @@
     "author": "solidd93110",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-PSNR.json
+++ b/data/models/4x-PSNR.json
@@ -2,9 +2,7 @@
     "name": "4x PSNR Pretrained Model",
     "author": "blueamulet",
     "license": "Apache-2.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\nPretrained: RRDB_PSNR_x4.pth\n\nThe original RRDB_PSNR_x4.pth model converted to 1x, 2x, 8x and 16x scales, intended to be used as pretrained models for new models at those scales. These are compatible with victor's 4xESRGAN.pth conversions",
     "date": "2020-04-20",
     "architecture": "esrgan",

--- a/data/models/4x-PackCraft-v4.json
+++ b/data/models/4x-PackCraft-v4.json
@@ -2,9 +2,7 @@
     "name": "PackCraft v4",
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Game Screenshots\nPurpose: Upscaling pack.png\n\nDesigned to upscale one specific minecraft screenshot. Results on dissimilar screenshots may be poor.",
     "date": "2020-09-05",
     "architecture": "esrgan",

--- a/data/models/4x-PixelPerfectV4.json
+++ b/data/models/4x-PixelPerfectV4.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Pixel Art/Sprites\n\nSprite Upscaler",

--- a/data/models/4x-PocketMonsters-Alpha.json
+++ b/data/models/4x-PocketMonsters-Alpha.json
@@ -2,9 +2,7 @@
     "name": "PocketMonsters-Alpha",
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Alphas\nPurpose: Pixel Art with Tranparency / Alpha Channel\n\nupscaling pixel art with alpha channels that should perform better than any other. It should work well on both cartoon and 3D styled content.",
     "date": "2021-02-04",
     "architecture": "esrgan",

--- a/data/models/4x-REDSVAL-7f-RRDB-Lite.json
+++ b/data/models/4x-REDSVAL-7f-RRDB-Lite.json
@@ -2,9 +2,7 @@
     "name": "REDSVAL-7f-RRDB Lite",
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Discriminators\nPurpose: IRL videos\n\nnone",
     "date": "2020-12-03",
     "architecture": "sofvsr",

--- a/data/models/4x-RRDB-G-ResNet-D.json
+++ b/data/models/4x-RRDB-G-ResNet-D.json
@@ -2,9 +2,7 @@
     "name": "RRDB-G_ResNet-D (Both G and D)",
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Discriminators\nPurpose: Pretrained\n\nClean bicubic downscales / Pretrained models (G/D)",
     "date": "2021-01-17",
     "architecture": "esrgan",

--- a/data/models/4x-RealisticRescaler.json
+++ b/data/models/4x-RealisticRescaler.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "photo"
     ],
     "description": "Category: Realistic Photos\nPurpose: Realistic Photos\n\nThis model was made to upscale realistic low-res textures that are compressed by either JPEG or BC1. From my testing, this works rather well on realistic GameCube textures such as the ones from Shrek Extra Large and the board textures from Mario Party 4. This model could also work on some real life images, especially the ones that are taken outdoors.",

--- a/data/models/4x-Rebout-Blend.json
+++ b/data/models/4x-Rebout-Blend.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Pixel Art/Sprites",

--- a/data/models/4x-Rebout.json
+++ b/data/models/4x-Rebout.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Pixel Art/Sprites\n\nFor upscaling character sprites",

--- a/data/models/4x-Rek-s-Effeks-Photoanime-v2.json
+++ b/data/models/4x-Rek-s-Effeks-Photoanime-v2.json
@@ -2,9 +2,7 @@
     "name": "Rek's Effeks Photoanime v2",
     "author": "rek",
     "license": "GPL-3.0-only",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Images\nPurpose: Stylization\n\nPhoto stylization from JPEGs. Trained on images upscaled by ISO Denoise v2 -> DeJPEG Fatality PlusULTRA -> NMKD Yan2. Essentially a combination of that model chain into one. Use if you're looking for a stylized output, not photo quality.",
     "date": "2020-10-17",
     "architecture": "esrgan",

--- a/data/models/4x-Remacri.json
+++ b/data/models/4x-Remacri.json
@@ -3,7 +3,6 @@
     "author": "foolhardy",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "Pretrained: none - interpolated\n\nA creation of BSRGAN with more details and less smoothing, made by interpolating IRL models such as Siax, Superscale, Superscale Artisoft, Pixel Perfect, etc. This was, things like skin and other details don't become mushy and blurry.",

--- a/data/models/4x-SGI.json
+++ b/data/models/4x-SGI.json
@@ -2,9 +2,7 @@
     "name": "SGI",
     "author": "chrisnonyminus",
     "license": "GPL-3.0-only",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: CGI\nPurpose: CGI\n\nUpscaling and dedithering pre-rendered sprites, images and textures made in the 90s. Basically vintage CGI.",
     "date": "2020-12-17",
     "architecture": "esrgan",

--- a/data/models/4x-SOFVSR-REDS-F3-V1.json
+++ b/data/models/4x-SOFVSR-REDS-F3-V1.json
@@ -2,9 +2,7 @@
     "name": "SOFVSR_REDS_F3 V1",
     "author": "sunseille",
     "license": "WTFPL",
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Discriminators\nPurpose: IRL videos\n\nupscale IRL videos. Use not recommended by creator",
     "date": "2021-02-26",
     "architecture": "sofvsr",

--- a/data/models/4x-ScreenBooster-V2.json
+++ b/data/models/4x-ScreenBooster-V2.json
@@ -2,9 +2,7 @@
     "name": "ScreenBooster V2",
     "author": "blackscout",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Game Screenshots\nPurpose: CGI\n\nGame Screenshots",
     "date": "2020-01-29",
     "architecture": "esrgan",

--- a/data/models/4x-Skyrim-Alpha.json
+++ b/data/models/4x-Skyrim-Alpha.json
@@ -2,9 +2,7 @@
     "name": "Skyrim Alpha",
     "author": "deorder",
     "license": "CC0-1.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Alphas\nPurpose: Pixel Art with Tranparency / Alpha Channel",
     "date": null,
     "architecture": "esrgan",

--- a/data/models/4x-Skyrim-Armory.json
+++ b/data/models/4x-Skyrim-Armory.json
@@ -3,7 +3,6 @@
     "author": "alsa",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures/equipment\n\n",

--- a/data/models/4x-Skyrim-Misc.json
+++ b/data/models/4x-Skyrim-Misc.json
@@ -3,7 +3,6 @@
     "author": "deorder",
     "license": "CC0-1.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nSkyrim Diffuse Textures",

--- a/data/models/4x-SkyrimTex-v1-Strong.json
+++ b/data/models/4x-SkyrimTex-v1-Strong.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nThis model set upscales most Skyrim textures. I hope it helps 🙂 The base model (2.1) works well on stone, wood, metals, and most other textures. The Fabric model is a 50/50 interpolation with a stronger iteration of this model and my Fabric model. As you can tell by the name, it's intended for Fabric textures. If you want to upscale Alpha textures, use a model dedicated to it. There's an INFO file in the folder, it just explains the extra models",

--- a/data/models/4x-SkyrimTex-v1.json
+++ b/data/models/4x-SkyrimTex-v1.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nThis model set upscales most Skyrim textures. I hope it helps 🙂 The base model (2.1) works well on stone, wood, metals, and most other textures. The Fabric model is a 50/50 interpolation with a stronger iteration of this model and my Fabric model. As you can tell by the name, it's intended for Fabric textures. If you want to upscale Alpha textures, use a model dedicated to it. There's an INFO file in the folder, it just explains the extra models",

--- a/data/models/4x-SkyrimTex-v2-1.json
+++ b/data/models/4x-SkyrimTex-v2-1.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nThis model set upscales most Skyrim textures. I hope it helps 🙂 The base model (2.1) works well on stone, wood, metals, and most other textures. The Fabric model is a 50/50 interpolation with a stronger iteration of this model and my Fabric model. As you can tell by the name, it's intended for Fabric textures. If you want to upscale Alpha textures, use a model dedicated to it. There's an INFO file in the folder, it just explains the extra models",

--- a/data/models/4x-SkyrimTex-v2-Fabric.json
+++ b/data/models/4x-SkyrimTex-v2-Fabric.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nThis model set upscales most Skyrim textures. I hope it helps 🙂 The base model (2.1) works well on stone, wood, metals, and most other textures. The Fabric model is a 50/50 interpolation with a stronger iteration of this model and my Fabric model. As you can tell by the name, it's intended for Fabric textures. If you want to upscale Alpha textures, use a model dedicated to it. There's an INFO file in the folder, it just explains the extra models",

--- a/data/models/4x-SkyrimTex-v2.json
+++ b/data/models/4x-SkyrimTex-v2.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nThis model set upscales most Skyrim textures. I hope it helps 🙂 The base model (2.1) works well on stone, wood, metals, and most other textures. The Fabric model is a 50/50 interpolation with a stronger iteration of this model and my Fabric model. As you can tell by the name, it's intended for Fabric textures. If you want to upscale Alpha textures, use a model dedicated to it. There's an INFO file in the folder, it just explains the extra models",

--- a/data/models/4x-SmolFace-Clean.json
+++ b/data/models/4x-SmolFace-Clean.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": null,
     "tags": [
-        "image",
         "faces",
         "face-upscaling"
     ],

--- a/data/models/4x-SmolFace.json
+++ b/data/models/4x-SmolFace.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "faces",
         "face-upscaling"
     ],

--- a/data/models/4x-SmoothRealism.json
+++ b/data/models/4x-SmoothRealism.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nPixel art, rocky/grainy textures? Quantization smoothing, adding detail.",

--- a/data/models/4x-Sol-Levante-NTSC2HD.json
+++ b/data/models/4x-Sol-Levante-NTSC2HD.json
@@ -3,7 +3,6 @@
     "author": "pheonix",
     "license": "Unlicense",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-SpongeBob-CEL-2-HD-PHOENiX.json
+++ b/data/models/4x-SpongeBob-CEL-2-HD-PHOENiX.json
@@ -3,7 +3,6 @@
     "author": "pheonix",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-SpongeBob-Reloaded-SWAG.json
+++ b/data/models/4x-SpongeBob-Reloaded-SWAG.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-SpongeBob-Reloaded.json
+++ b/data/models/4x-SpongeBob-Reloaded.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-SpongeBob.json
+++ b/data/models/4x-SpongeBob.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Spongebob-v6-De-Quantize.json
+++ b/data/models/4x-Spongebob-v6-De-Quantize.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Spongebob-v6-Deblur.json
+++ b/data/models/4x-Spongebob-v6-Deblur.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Spongebob-v6.json
+++ b/data/models/4x-Spongebob-v6.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Struzan.json
+++ b/data/models/4x-Struzan.json
@@ -3,7 +3,6 @@
     "author": "laserschwert",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Art\n\nUpscaling airbrush/pencil-based artwork",

--- a/data/models/4x-ThiefGold.json
+++ b/data/models/4x-ThiefGold.json
@@ -3,7 +3,6 @@
     "author": "akven",
     "license": null,
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nVarious game textures. Primary wood, metal, stone",

--- a/data/models/4x-ThiefGoldMod.json
+++ b/data/models/4x-ThiefGoldMod.json
@@ -3,7 +3,6 @@
     "author": "akven",
     "license": null,
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures\n\nVersion of the previous model but based on Manga109 pretrained model and with slightly different dataset. Sometimes gives better results especially for wood and metal, sometimes worse. Sometime generates the same dotted artifacts on very bright/white images.",

--- a/data/models/4x-Training4Melozard-Anime.json
+++ b/data/models/4x-Training4Melozard-Anime.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-Trixie.json
+++ b/data/models/4x-Trixie.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Faces / Game Textures\n\ncharacter textures for star wars games, including the heroes, rebels, sith and imperial. Plus a few main aliens…Why called trixie? Because jar jars big adventure would be too long of a name… This also provides good upscale for face textures for general purpose as well as basic star wars",

--- a/data/models/4x-UltraFArt-v3-Fine.json
+++ b/data/models/4x-UltraFArt-v3-Fine.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Art\n\nIllustrations with with larger shaped features (?).",

--- a/data/models/4x-UltraFArt-v3-Photo.json
+++ b/data/models/4x-UltraFArt-v3-Photo.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Art\n\nIllustrations with with larger shaped features (?).",

--- a/data/models/4x-UltraFArt-v3-Smooth.json
+++ b/data/models/4x-UltraFArt-v3-Smooth.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Art\n\nIllustrations with with larger shaped features (?).",

--- a/data/models/4x-UltraFArt-v3.json
+++ b/data/models/4x-UltraFArt-v3.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Art\n\nIllustrations with with larger shaped features (?).",

--- a/data/models/4x-UltraSharp.json
+++ b/data/models/4x-UltraSharp.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "Pretrained: 4xESRGAN\n\nThis is my best model yet! It generates lots and lots of detail and leaves a nice texture on images. It works on most images, whether compressed or not. It does work best on JPEG compression though, as that's mostly what it was trained on. It has the ability to restore highly compressed images as well! If you want a more balanced output, check out the UltraMix Collection down below. It's a bunch of interpolated models based around UltraSharp and my other models",

--- a/data/models/4x-UniScale-Balanced.json
+++ b/data/models/4x-UniScale-Balanced.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "UniScale strikes a nice balance between sharpness and realism. This model can upscale almost anything well. It was originally intended to upscale game textures, but was expanded into a universal upscaler. Interp is these two models interpolated.",

--- a/data/models/4x-UniScale-Restore.json
+++ b/data/models/4x-UniScale-Restore.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "UniScale_Restore has strong compression removal that helps with restoring heavily compressed or noisy images. It is intended to compete with BSRGAN. Trained with BSRGAN_Resize and Combo_Noise in traiNNer.",

--- a/data/models/4x-UniScale-Strong.json
+++ b/data/models/4x-UniScale-Strong.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "UniScale strikes a nice balance between sharpness and realism. This model can upscale almost anything well. It was originally intended to upscale game textures, but was expanded into a universal upscaler. Interp is these two models interpolated.",

--- a/data/models/4x-UniScaleNR-Balanced.json
+++ b/data/models/4x-UniScaleNR-Balanced.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "Version of UniScale trained with camera noise injection (NR = Noise Removal). This model removes noise from images while upscaling.",

--- a/data/models/4x-UniScaleNR-Strong.json
+++ b/data/models/4x-UniScaleNR-Strong.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "Version of UniScale trained with camera noise injection (NR = Noise Removal). This model removes noise from images while upscaling.",

--- a/data/models/4x-UniScaleV2-Moderate.json
+++ b/data/models/4x-UniScaleV2-Moderate.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "These models work great on game textures when interpolated 50/50 with UniScale_Restore, and work amazingly on uncompressed images. DO NOT USE FOR COMPRESSED IMAGES, use the original UniScale or UltraSharp for that.",

--- a/data/models/4x-UniScaleV2-Sharp.json
+++ b/data/models/4x-UniScaleV2-Sharp.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "These models work great on game textures when interpolated 50/50 with UniScale_Restore, and work amazingly on uncompressed images. DO NOT USE FOR COMPRESSED IMAGES, use the original UniScale or UltraSharp for that.",

--- a/data/models/4x-UniScaleV2-Soft.json
+++ b/data/models/4x-UniScaleV2-Soft.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "These models work great on game textures when interpolated 50/50 with UniScale_Restore, and work amazingly on uncompressed images. DO NOT USE FOR COMPRESSED IMAGES, use the original UniScale or UltraSharp for that.",

--- a/data/models/4x-UniversalUpscalerV2-Neutral.json
+++ b/data/models/4x-UniversalUpscalerV2-Neutral.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "General Upscaler",

--- a/data/models/4x-UniversalUpscalerV2-Sharp.json
+++ b/data/models/4x-UniversalUpscalerV2-Sharp.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "General Upscaler",

--- a/data/models/4x-UniversalUpscalerV2-Sharper.json
+++ b/data/models/4x-UniversalUpscalerV2-Sharper.json
@@ -3,7 +3,6 @@
     "author": "mutin-choler",
     "license": "WTFPL",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "General Upscaler",

--- a/data/models/4x-VESRGAN-G.json
+++ b/data/models/4x-VESRGAN-G.json
@@ -2,9 +2,7 @@
     "name": "VESRGAN_G",
     "author": "victorca25",
     "license": null,
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained SOFVSR Models\nPurpose: \n\nTrained on REDS' size dataset",
     "date": null,
     "architecture": "sofvsr",

--- a/data/models/4x-Valar.json
+++ b/data/models/4x-Valar.json
@@ -3,7 +3,6 @@
     "author": "musl",
     "license": "CC0-1.0",
     "tags": [
-        "image",
         "photo"
     ],
     "description": "Category: Realistic Photos\nPurpose: Realistic Photos\n\nMeant as an experiment to test latest techniques implemented on traiNNer, including: AdaTarget, KernelGAN, UNet discriminator, nESRGAN+ arch, noise patches, camera noise, isotropic/anisotropic/sinc blur, frequency separation, contextual loss, mixup, clipL1 pixel loss, AdamP optimizer, etc. The config file is provided on the download link above. I encourage everybody to mirror the model, distribute and modify it in anywway you want.",

--- a/data/models/4x-VimeoScale.json
+++ b/data/models/4x-VimeoScale.json
@@ -2,9 +2,7 @@
     "name": "VimeoScale",
     "author": "sazoji",
     "license": "CC-BY-SA-4.0",
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Discriminators\nPurpose: Upscaling IRL video content\n\nThis model is one of the longest I have trained and tuned, includes some noise training but this is not intended for deblocking/decompression. Combined with https://github.com/JoeyBallentine/Video-Inference 's fp16 mode, this should handle most SD and 720p content at or faster than ESRGAN, with a significant bump in quality.",
     "date": "2021-10-08",
     "architecture": "sofvsr",

--- a/data/models/4x-VolArt.json
+++ b/data/models/4x-VolArt.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures/Art\n\nThis model upscales artwork for the game Volfoss (2001). The model peaked in quality very quickly. The NR model removes most noise, but has the downside of removing transparent portions. Use the main model in most cases.",

--- a/data/models/4x-VolArtNR.json
+++ b/data/models/4x-VolArtNR.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "game-textures"
     ],
     "description": "Category: Video Game Textures\nPurpose: Game textures/Art\n\nThis model upscales artwork for the game Volfoss (2001). The model peaked in quality very quickly. The NR model removes most noise, but has the downside of removing transparent portions. Use the main model in most cases.",

--- a/data/models/4x-WaifuGAN-v3.json
+++ b/data/models/4x-WaifuGAN-v3.json
@@ -2,9 +2,7 @@
     "name": "WaifuGAN v3",
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: CGI\nPurpose: CGI\n\nUpscaling CG-painted anime with variable outlines.",
     "date": "2019-07-12",
     "architecture": "esrgan",

--- a/data/models/4x-anifilm-compact.json
+++ b/data/models/4x-anifilm-compact.json
@@ -3,7 +3,6 @@
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-detoon-alt.json
+++ b/data/models/4x-detoon-alt.json
@@ -2,9 +2,7 @@
     "name": "detoon alt",
     "author": "lyonhrt",
     "license": null,
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: DeToon\nPurpose: Detooning\n\nA toon to realistic shading style model to wiki under drawings",
     "date": "2019-06-24",
     "architecture": "esrgan",

--- a/data/models/4x-detoon.json
+++ b/data/models/4x-detoon.json
@@ -2,9 +2,7 @@
     "name": "detoon",
     "author": "lyonhrt",
     "license": null,
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: DeToon\nPurpose: Detooning\n\nA toon to realistic shading style model to wiki under drawings",
     "date": "2019-06-24",
     "architecture": "esrgan",

--- a/data/models/4x-deviantPixelHD.json
+++ b/data/models/4x-deviantPixelHD.json
@@ -3,7 +3,6 @@
     "author": "raulsangonzalo",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nSimilar to Manga109, can be used as a general digital upscaler as well as with pixel art",

--- a/data/models/4x-escale.json
+++ b/data/models/4x-escale.json
@@ -3,7 +3,6 @@
     "author": "katoumegumi",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-eula-anifilm-v1.json
+++ b/data/models/4x-eula-anifilm-v1.json
@@ -3,7 +3,6 @@
     "author": "eula",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-eula-digimanga-bw-v1.json
+++ b/data/models/4x-eula-digimanga-bw-v1.json
@@ -3,7 +3,6 @@
     "author": "eula",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "manga"
     ],
     "description": "Black and white digital manga with halftones.",

--- a/data/models/4x-eula-digimanga-bw-v2-nc1.json
+++ b/data/models/4x-eula-digimanga-bw-v2-nc1.json
@@ -3,7 +3,6 @@
     "author": "eula",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "manga"
     ],
     "description": "Vast improvement over v1 in low frequency detail; moiré and artifacting reduced significantly and less random noise from JPEG artefacts in the input. Also now only works on 1 channel images, so it runs slightly faster on average and resulting images are much smaller but it might not work on some ESRGAN implementations, I personally recommend using chaiNNer. v1 may still be better in some edge cases.\n\nThere's also a supplementary 1x model that denoises very low quality LRs and smooths halftones so the image works better with the 4x model. Only trained it to help build the dataset and it's useless for already decent-ish LRs but may help you in some situations.",

--- a/data/models/4x-muy4-035-1.json
+++ b/data/models/4x-muy4-035-1.json
@@ -3,7 +3,6 @@
     "author": "katoumegumi",
     "license": "WTFPL",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/4x-realesrgan-x4minus.json
+++ b/data/models/4x-realesrgan-x4minus.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "WTFPL",
     "tags": [
-        "image",
         "general-upscaler"
     ],
     "description": "Basically realesrgan-x4plus without the degradation training. Supposed to help retain more details, but unfortunately due to the dataset (I think) still blurs details adjacent to other objects.",

--- a/data/models/4x-scalenx.json
+++ b/data/models/4x-scalenx.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nScalenx style pixel art upscaler",

--- a/data/models/4x-video-G.json
+++ b/data/models/4x-video-G.json
@@ -2,9 +2,7 @@
     "name": "video_G",
     "author": "victorca25",
     "license": null,
-    "tags": [
-        "video"
-    ],
+    "tags": [],
     "description": "Category: Pretrained SOFVSR Models\nPurpose: \n\nTrained on REDS' size dataset",
     "date": null,
     "architecture": "sofvsr",

--- a/data/models/4x-xbrz-dd.json
+++ b/data/models/4x-xbrz-dd.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nxbrz plus dedithering style pixel-art upscaling model to wiki under specialised",

--- a/data/models/4x-xbrz.json
+++ b/data/models/4x-xbrz.json
@@ -3,7 +3,6 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nXbrz style pixel art upscaler",

--- a/data/models/8x-Arzenal-v1-1.json
+++ b/data/models/8x-Arzenal-v1-1.json
@@ -3,7 +3,6 @@
     "author": "computerk",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nSmooth general pixel art, Minecraft textures",

--- a/data/models/8x-BoyMeBob-Redux.json
+++ b/data/models/8x-BoyMeBob-Redux.json
@@ -3,7 +3,6 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "anime",
         "cartoon"
     ],

--- a/data/models/8x-ESRGAN.json
+++ b/data/models/8x-ESRGAN.json
@@ -2,9 +2,7 @@
     "name": "8xESRGAN",
     "author": "victorca25",
     "license": "Apache-2.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\nPretrained: RRDB_ESRGAN_x4.pth\n\n",
     "date": "2019-07-06",
     "architecture": "esrgan",

--- a/data/models/8x-HugePaint.json
+++ b/data/models/8x-HugePaint.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Digital Illustrations\n\nTrained on a variety of images from ArtStation",

--- a/data/models/8x-HugePeeps-v1.json
+++ b/data/models/8x-HugePeeps-v1.json
@@ -3,7 +3,6 @@
     "author": "dinjerr",
     "license": "CC-BY-NC-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\nPurpose: Art/People\n\nPainted humans",

--- a/data/models/8x-MS-Unpainter-De-Dither.json
+++ b/data/models/8x-MS-Unpainter-De-Dither.json
@@ -3,7 +3,6 @@
     "author": "foolhardy",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nLow-resolution MS Paint drawings, general pixel art, and general dithered pixel art, all kinds of pixel art",

--- a/data/models/8x-MS-Unpainter.json
+++ b/data/models/8x-MS-Unpainter.json
@@ -3,7 +3,6 @@
     "author": "foolhardy",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "image",
         "pixel-art"
     ],
     "description": "Category: Art/Pixel Art\n\nLow-resolution MS Paint drawings, general pixel art, and general dithered pixel art, all kinds of pixel art",

--- a/data/models/8x-NMKD-Typescale.json
+++ b/data/models/8x-NMKD-Typescale.json
@@ -3,7 +3,6 @@
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
-        "image",
         "text"
     ],
     "description": "Low-resolution text/typography and symbols",

--- a/data/models/8x-PSNR.json
+++ b/data/models/8x-PSNR.json
@@ -2,9 +2,7 @@
     "name": "8x PSNR Pretrained Model",
     "author": "blueamulet",
     "license": "Apache-2.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Pretrained Models\nPurpose: Pretrained\nPretrained: RRDB_PSNR_x4.pth\n\nThe original RRDB_PSNR_x4.pth model converted to 1x, 2x, 8x and 16x scales, intended to be used as pretrained models for new models at those scales. These are compatible with victor's 4xESRGAN.pth conversions",
     "date": "2020-04-20",
     "architecture": "esrgan",

--- a/data/models/8x-Sphax-Alpha-NN.json
+++ b/data/models/8x-Sphax-Alpha-NN.json
@@ -2,9 +2,7 @@
     "name": "Sphax Alpha NN",
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
-    "tags": [
-        "image"
-    ],
+    "tags": [],
     "description": "Category: Alphas\nPurpose: Pixel Art with Tranparency / Alpha Channel\n\nReplica of sphax with transparency",
     "date": "2021-02-04",
     "architecture": "esrgan",

--- a/data/models/8x-TGHQFace8x.json
+++ b/data/models/8x-TGHQFace8x.json
@@ -3,7 +3,6 @@
     "author": "tg",
     "license": "GPL-3.0-only",
     "tags": [
-        "image",
         "faces",
         "face-upscaling"
     ],

--- a/data/tag-categories.json
+++ b/data/tag-categories.json
@@ -14,7 +14,7 @@
             "photo",
             "pixel-art",
             "text",
-            "video"
+            "video-frame"
         ]
     },
     "purpose": {

--- a/data/tag-categories.json
+++ b/data/tag-categories.json
@@ -13,7 +13,8 @@
             "manga",
             "photo",
             "pixel-art",
-            "text"
+            "text",
+            "video"
         ]
     },
     "purpose": {
@@ -88,9 +89,9 @@
         "order": 5,
         "simple": false,
         "tags": [
-            "audio",
-            "image",
-            "video"
+            "input:audio",
+            "input:image",
+            "input:video"
         ]
     },
     "color": {

--- a/data/tags.json
+++ b/data/tags.json
@@ -7,10 +7,6 @@
         "name": "Anti-aliasing",
         "description": ""
     },
-    "audio": {
-        "name": "Audio",
-        "description": ""
-    },
     "cartoon": {
         "name": "Cartoon",
         "description": ""
@@ -57,10 +53,6 @@
     },
     "general-upscaler": {
         "name": "General Upscaler",
-        "description": ""
-    },
-    "image": {
-        "name": "Image",
         "description": ""
     },
     "inpainting": {
@@ -150,6 +142,18 @@
     "color:4": {
         "name": "RGBA",
         "description": "The model upscales images with transparency."
+    },
+    "input:audio": {
+        "name": "Audio",
+        "description": ""
+    },
+    "input:image": {
+        "name": "Image",
+        "description": ""
+    },
+    "input:video": {
+        "name": "Video",
+        "description": ""
     },
     "license:by": {
         "name": "Credit",

--- a/data/tags.json
+++ b/data/tags.json
@@ -79,8 +79,8 @@
         "name": "Text",
         "description": ""
     },
-    "video": {
-        "name": "Video",
+    "video-frame": {
+        "name": "Video Frame",
         "description": ""
     },
     "arch:2c2-esrgan": {

--- a/src/lib/derive-tags.ts
+++ b/src/lib/derive-tags.ts
@@ -89,6 +89,12 @@ export const deriveTags = lazyWithWeakKey((model: Model): readonly TagId[] => {
     // architecture
     tags.push(`arch:${model.architecture}`);
 
+    // input
+    const arch = STATIC_ARCH_DATA.get(model.architecture);
+    if (arch) {
+        tags.push(`input:${arch.input}`);
+    }
+
     // platform
     tags.push(...getPlatformTags(model));
 

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -79,9 +79,11 @@ export interface TagCategory {
 }
 
 export type Platform = 'pytorch' | 'onnx' | 'ncnn';
+export type InputType = 'image' | 'video' | 'audio';
 
 export interface Arch {
     name: string;
+    input: InputType;
     compatiblePlatforms: Platform[];
 }
 


### PR DESCRIPTION
Image, audio, and video are new derived tags.

I only left the old `video` tag for image models that upscale video frames.