### PR TITLE
Fixed change ID implementation & better errors for API routes

### DIFF
--- a/src/lib/server/api-impl.ts
+++ b/src/lib/server/api-impl.ts
@@ -23,7 +23,13 @@ export function handleJsonApi<Id, Value>(collection: CollectionApi<Id, Value>) {
             const resJson: JsonResponse<Id, Value> = { data: await handler(reqJson.method, reqJson.data) };
             res.status(200).json(resJson);
         } catch (err) {
-            res.status(500).json({ error: String(err) });
+            console.error(err);
+
+            let message = String(err);
+            if (err instanceof Error) {
+                message += `\n${String(err.stack)}`;
+            }
+            res.status(500).json({ error: message });
         }
     };
 }

--- a/src/lib/server/file-data.ts
+++ b/src/lib/server/file-data.ts
@@ -112,7 +112,7 @@ async function mutateModels(mutate: (model: Model) => boolean | void): Promise<v
 }
 
 function renameObjectKey<K extends string>(o: Record<K, unknown>, from: K, to: K): void {
-    if (hasOwn(o, from)) {
+    if (!hasOwn(o, from)) {
         throw new Error(`Cannot change id ${from} because it does not exist`);
     }
     if (hasOwn(o, to)) {


### PR DESCRIPTION
Changes:
1. Fixed the condition for changing the IDs of every collection except for models.
2. Better errors in API routes. We will now log errors (revolutionary) and send the full error stack back to the frontend.