### PR TITLE
Added data for 2C2-ESRGAN model

### DIFF
--- a/data/models/4x-2C2-ESRGAN-Nomos2K.json
+++ b/data/models/4x-2C2-ESRGAN-Nomos2K.json
@@ -3,15 +3,18 @@
     "author": "joey",
     "license": "MIT",
     "tags": [
-        "general-upscaler"
+        "pretrained"
     ],
-    "description": "Technically my previous experiment was the pretrained model, but for all intents and purposes this was trained from scratch. Description: Pretrained model for the new architecture modification I made. You can read more about it in the github README. Basically it makes smaller ESRGAN models that theoretically can produce the same level of quality. NOTE: THIS WILL NOT WORK IN CUPSCALE, IEU, OR CHAINNER (yet)! You have to use my fork to use it for now.",
+    "description": "Technically my previous experiment was the pretrained model, but for all intents and purposes this was trained from scratch. Description: Pretrained model for the new architecture modification I made. You can read more about it in the [GitHub README](https://github.com/joeyballentine/2C2-ESRGAN). Basically it makes smaller ESRGAN models that theoretically can produce the same level of quality.\n\n**NOTE:** THIS WILL NOT WORK IN CUPSCALE or IEU! You have to use chaiNNer or my fork to use it for now.",
     "date": "2022-04-20",
     "architecture": "2c2-esrgan",
-    "size": null,
+    "size": [
+        "64nf",
+        "23nb"
+    ],
     "scale": 4,
-    "inputChannels": null,
-    "outputChannels": null,
+    "inputChannels": 3,
+    "outputChannels": 3,
     "resources": [
         {
             "platform": "pytorch",


### PR DESCRIPTION
I added the missing model data since chainner can now read this model. I also updated the description and gave the "Pretrained" tag instead of "General upscaler".