### PR TITLE
Editable tags

### DIFF
--- a/src/elements/components/editable-tags.module.scss
+++ b/src/elements/components/editable-tags.module.scss
@@ -1,0 +1,46 @@
+.tags {
+    display: flex;
+    flex-flow: row wrap;
+    gap: 0.25rem;
+}
+
+.tag,
+.editButton,
+.menuItem {
+    border-radius: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    font: inherit;
+    font-weight: 500;
+    border: none;
+}
+
+.editButton {
+    cursor: pointer;
+}
+
+.editContainer {
+    padding: 0.5rem 0.75rem;
+
+    h3 {
+        margin: 0.5rem 0;
+    }
+
+    h3:first-child {
+        margin-top: 0;
+    }
+
+    button {
+        margin-right: 0.25rem;
+        margin-bottom: 0.25rem;
+    }
+}
+
+.menuItem {
+    cursor: pointer;
+
+    &[aria-disabled] {
+        opacity: 0.5;
+        user-select: none;
+        cursor: default;
+    }
+}

--- a/src/elements/components/editable-tags.tsx
+++ b/src/elements/components/editable-tags.tsx
@@ -1,0 +1,134 @@
+import { Popover, Transition } from '@headlessui/react';
+import { Fragment, useEffect, useState } from 'react';
+import { BsChevronDown } from 'react-icons/bs';
+import { useTags } from '../../lib/hooks/use-tags';
+import { TagId } from '../../lib/schema';
+import { compareTagId, isDerivedTags } from '../../lib/util';
+import style from './editable-tags.module.scss';
+
+export interface EditableTagsProps {
+    tags: readonly TagId[];
+    onChange?: (value: TagId[]) => void;
+    readonly?: boolean;
+}
+export function EditableTags({ tags, onChange, readonly }: EditableTagsProps) {
+    const { tagData } = useTags();
+
+    return (
+        <div className={style.tags}>
+            {!readonly && onChange && (
+                <EditTags
+                    tags={tags}
+                    onChange={onChange}
+                />
+            )}
+            {tags.map((tagId) => (
+                <div
+                    className={`${style.tag} bg-gray-200 text-xs text-gray-800 dark:bg-gray-700 dark:text-gray-100`}
+                    key={tagId}
+                >
+                    {tagData.get(tagId)?.name ?? `unknown tag:${tagId}`}
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function EditTags({ tags, onChange }: { tags: readonly TagId[]; onChange: (value: TagId[]) => void }) {
+    const { tagData, categoryOrder } = useTags();
+
+    const [currentTags, setCurrentTags] = useState(tags);
+    useEffect(() => {
+        setCurrentTags(tags);
+    }, [tags]);
+    useEffect(() => {
+        if (currentTags !== tags && currentTags.join('\n') !== tags.join('\n')) {
+            const timerId = setTimeout(() => {
+                onChange([...currentTags]);
+            }, 1000);
+            return () => clearTimeout(timerId);
+        }
+    }, [currentTags, tags, onChange]);
+
+    const [position, setPosition] = useState<'left' | 'right'>('left');
+    const updatePosition = (element: HTMLElement): void => {
+        console.log(element);
+        const buttonX = element.getBoundingClientRect().x;
+        const viewportWidth = document.documentElement.clientWidth;
+        setPosition(buttonX + 400 < viewportWidth ? 'left' : 'right');
+    };
+
+    return (
+        <Popover
+            as="div"
+            className="relative inline-block text-left"
+        >
+            <Popover.Button
+                className={`${style.editButton} bg-gray-200 text-xs text-gray-800 dark:bg-gray-700 dark:text-gray-100`}
+                onClick={(e: React.MouseEvent<HTMLButtonElement>) => updatePosition(e.currentTarget)}
+                onFocus={(e: React.FocusEvent<HTMLButtonElement>) => updatePosition(e.currentTarget)}
+            >
+                <BsChevronDown className="w-full" />
+            </Popover.Button>
+            <Transition
+                as={Fragment}
+                enter="transition ease-out duration-100"
+                enterFrom="transform opacity-0 scale-95"
+                enterTo="transform opacity-100 scale-100"
+                leave="transition ease-in duration-75"
+                leaveFrom="transform opacity-100 scale-100"
+                leaveTo="transform opacity-0 scale-95"
+            >
+                <Popover.Panel
+                    className={`absolute z-50 mt-2 w-96 origin-top-right divide-y divide-gray-100 rounded-lg bg-fade-100 text-sm shadow-lg focus:outline-none dark:bg-black ${
+                        position === 'left' ? 'left-0' : 'right-0'
+                    }`}
+                >
+                    <div className={style.editContainer}>
+                        {categoryOrder.map(([categoryId, category]) => {
+                            const manual = category.tags.filter((tagId) => !isDerivedTags(tagId));
+                            if (manual.length === 0) {
+                                return <Fragment key={categoryId} />;
+                            }
+
+                            return (
+                                <>
+                                    <h3>{category.name}</h3>
+                                    <div>
+                                        {manual.map((tagId) => {
+                                            const tag = tagData.get(tagId);
+                                            const selected = currentTags.includes(tagId);
+
+                                            return (
+                                                <button
+                                                    className={`${style.menuItem} text-xs ${
+                                                        selected
+                                                            ? 'bg-accent-500 text-white dark:bg-accent-600'
+                                                            : 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-100'
+                                                    }`}
+                                                    data-selected={selected ? '' : undefined}
+                                                    key={tagId}
+                                                    onClick={() => {
+                                                        let newTags;
+                                                        if (selected) {
+                                                            newTags = currentTags.filter((t) => t !== tagId);
+                                                        } else {
+                                                            newTags = [...currentTags, tagId].sort(compareTagId);
+                                                        }
+                                                        setCurrentTags(newTags);
+                                                    }}
+                                                >
+                                                    {tag?.name ?? `unknown tag: ${tagId}`}
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </>
+                            );
+                        })}
+                    </div>
+                </Popover.Panel>
+            </Transition>
+        </Popover>
+    );
+}

--- a/src/elements/components/editable-tags.tsx
+++ b/src/elements/components/editable-tags.tsx
@@ -52,7 +52,6 @@ function EditTags({ tags, onChange }: { tags: readonly TagId[]; onChange: (value
 
     const [position, setPosition] = useState<'left' | 'right'>('left');
     const updatePosition = (element: HTMLElement): void => {
-        console.log(element);
         const buttonX = element.getBoundingClientRect().x;
         const viewportWidth = document.documentElement.clientWidth;
         setPosition(buttonX + 400 < viewportWidth ? 'left' : 'right');
@@ -92,7 +91,7 @@ function EditTags({ tags, onChange }: { tags: readonly TagId[]; onChange: (value
                             }
 
                             return (
-                                <>
+                                <Fragment key={categoryId}>
                                     <h3>{category.name}</h3>
                                     <div>
                                         {manual.map((tagId) => {
@@ -123,7 +122,7 @@ function EditTags({ tags, onChange }: { tags: readonly TagId[]; onChange: (value
                                             );
                                         })}
                                     </div>
-                                </>
+                                </Fragment>
                             );
                         })}
                     </div>

--- a/src/elements/components/model-card.module.scss
+++ b/src/elements/components/model-card.module.scss
@@ -1,7 +1,6 @@
 .modelCard {
     position: relative;
     height: 350px;
-    overflow: hidden;
     border-radius: 0.5rem;
     border-width: 1px;
     border-style: solid;

--- a/src/elements/components/model-card.module.scss
+++ b/src/elements/components/model-card.module.scss
@@ -29,6 +29,16 @@
         background: url('https://picsum.photos/512/312');
         background-size: cover;
         background-position: center;
+        border-radius: 0.5rem 0.5rem 0 0;
+    }
+
+    .details {
+        position: relative;
+        left: 0;
+        bottom: 0;
+        right: 0;
+        padding: 0.75rem;
+        padding-top: 0.5rem;
     }
 
     .tagBase {

--- a/src/elements/components/model-card.tsx
+++ b/src/elements/components/model-card.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { useArchitectures } from '../../lib/hooks/use-architectures';
-import { useTags } from '../../lib/hooks/use-tags';
+import { useUpdateModel } from '../../lib/hooks/use-update-model';
 import { useUsers } from '../../lib/hooks/use-users';
+import { useWebApi } from '../../lib/hooks/use-web-api';
 import { joinList } from '../../lib/react-util';
 import { Model, ModelId } from '../../lib/schema';
 import { asArray } from '../../lib/util';
+import { EditableTags } from './editable-tags';
 import { Link } from './link';
 import style from './model-card.module.scss';
 
@@ -14,9 +16,11 @@ interface ModelCardProps {
 }
 
 export const ModelCard = ({ id, model }: ModelCardProps) => {
-    const { tagData } = useTags();
     const { userData } = useUsers();
     const { archData } = useArchitectures();
+
+    const { webApi, editMode } = useWebApi();
+    const { updateModelProperty } = useUpdateModel(webApi, id);
 
     const description = fixDescription(model.description, model.scale);
 
@@ -61,10 +65,12 @@ export const ModelCard = ({ id, model }: ModelCardProps) => {
                     <div className="mb-1 py-1 text-sm text-gray-600 line-clamp-3 dark:text-gray-400">{description}</div>
 
                     {/* Tags */}
-                    <div className="flex flex-row flex-wrap gap-1">
-                        {model.tags.map((tagId) => (
-                            <RegularTag key={tagId}>{tagData.get(tagId)?.name ?? `unknown tag:${tagId}`}</RegularTag>
-                        ))}
+                    <div className="flex flex-row flex-wrap gap-1 text-xs">
+                        <EditableTags
+                            readonly={!editMode}
+                            tags={model.tags}
+                            onChange={(tags) => updateModelProperty('tags', tags)}
+                        />
                     </div>
                 </div>
             </div>
@@ -104,12 +110,4 @@ function fixDescription(description: string, scale: number): string {
 
 function AccentTag({ children }: React.PropsWithChildren<unknown>) {
     return <div className={`${style.tagBase} bg-accent-600 text-sm text-gray-100`}>{children}</div>;
-}
-
-function RegularTag({ children }: React.PropsWithChildren<unknown>) {
-    return (
-        <div className={`${style.tagBase} bg-gray-200 text-xs text-gray-800 dark:bg-gray-700 dark:text-gray-100`}>
-            {children}
-        </div>
-    );
 }

--- a/src/elements/components/model-card.tsx
+++ b/src/elements/components/model-card.tsx
@@ -25,7 +25,9 @@ export const ModelCard = ({ id, model }: ModelCardProps) => {
     const description = fixDescription(model.description, model.scale);
 
     return (
-        <div className={`${style.modelCard} border-gray-300 shadow-lg hover:shadow-xl dark:border-gray-700 `}>
+        <div
+            className={`${style.modelCard} border-gray-300 bg-white shadow-lg hover:shadow-xl dark:border-gray-700 dark:bg-fade-900`}
+        >
             <div className={style.inner}>
                 {/* Arch tag on image */}
                 <div className={style.topTags}>
@@ -39,7 +41,7 @@ export const ModelCard = ({ id, model }: ModelCardProps) => {
                     tabIndex={-1}
                 />
 
-                <div className="relative inset-x-0 bottom-0 bg-white p-3 pt-2 dark:bg-fade-900">
+                <div className={style.details}>
                     <Link
                         className="block text-xl font-bold text-gray-800 dark:text-gray-100"
                         href={`/models/${id}`}

--- a/src/lib/hooks/use-update-model.ts
+++ b/src/lib/hooks/use-update-model.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { DBApi } from '../data-api';
+import { Model, ModelId } from '../schema';
+import { noop } from '../util';
+
+export interface UseUpdateModel {
+    updateModelProperty: <K extends keyof Model>(key: K, value: Model[K]) => void;
+}
+
+export function useUpdateModel(webApi: DBApi | undefined, modelId: ModelId): UseUpdateModel {
+    const updateModelProperty = useMemo<UseUpdateModel['updateModelProperty']>(() => {
+        if (!webApi) return noop;
+        return <K extends keyof Model>(key: K, value: Model[K]) => {
+            const fn = async () => {
+                const model = await webApi.models.get(modelId);
+                model[key] = value;
+                await webApi.models.update([[modelId, model]]);
+            };
+            fn().catch((e) => console.error(e));
+        };
+    }, [webApi, modelId]);
+
+    return { updateModelProperty };
+}

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -1,17 +1,19 @@
 import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import { ParsedUrlQuery } from 'querystring';
-import React, { useCallback } from 'react';
+import React from 'react';
 import { BsFillTrashFill } from 'react-icons/bs';
 import { DownloadButton } from '../../elements/components/download-button';
 import { EditableIntegerLabel, EditableLabel } from '../../elements/components/editable-label';
 import { EditableMarkdownContainer } from '../../elements/components/editable-markdown';
+import { EditableTags } from '../../elements/components/editable-tags';
 import { EditableUsers } from '../../elements/components/editable-users';
 import { ImageCarousel } from '../../elements/components/image-carousel';
 import { HeadCommon } from '../../elements/head-common';
 import { PageContainer } from '../../elements/page';
 import { useArchitectures } from '../../lib/hooks/use-architectures';
 import { useCurrent } from '../../lib/hooks/use-current';
+import { useUpdateModel } from '../../lib/hooks/use-update-model';
 import { useUsers } from '../../lib/hooks/use-users';
 import { useWebApi } from '../../lib/hooks/use-web-api';
 import { ArchId, Model, ModelId, Resource } from '../../lib/schema';
@@ -60,13 +62,7 @@ export default function Page({ modelId, modelData }: Props) {
 
     const archName = archData.get(model.architecture)?.name ?? 'unknown';
 
-    const updateModelProperty = useCallback(
-        <K extends keyof Model>(key: K, value: Model[K]) => {
-            const newModel: Model = { ...model, [key]: value };
-            webApi?.models.update([[modelId, newModel]]).catch((e) => console.error(e));
-        },
-        [webApi, modelId, model]
-    );
+    const { updateModelProperty } = useUpdateModel(webApi, modelId);
 
     return (
         <>
@@ -159,10 +155,10 @@ export default function Page({ modelId, modelData }: Props) {
                             })}
                         </div>
 
-                        <div className="relative table-auto overflow-hidden rounded-lg border-fade-700">
-                            <table className="w-full border-collapse overflow-hidden rounded-lg border-fade-700 text-left text-sm text-gray-500 dark:text-gray-400 ">
-                                <tbody className="overflow-hidden  rounded-lg ">
-                                    <tr className=" ">
+                        <div className="relative table-auto rounded-lg border-fade-700">
+                            <table className="w-full border-collapse rounded-lg border-fade-700 text-left text-sm text-gray-500 dark:text-gray-400 ">
+                                <tbody className="rounded-lg">
+                                    <tr>
                                         <th
                                             className="whitespace-nowrap bg-fade-100 px-6 py-4 font-medium text-gray-900 dark:bg-fade-800 dark:text-white"
                                             scope="row"
@@ -191,7 +187,7 @@ export default function Page({ modelId, modelData }: Props) {
                                             )}
                                         </td>
                                     </tr>
-                                    <tr className="">
+                                    <tr>
                                         <th
                                             className="whitespace-nowrap bg-fade-100 px-6 py-4 font-medium text-fade-900 dark:bg-fade-800 dark:text-white"
                                             scope="row"
@@ -209,7 +205,7 @@ export default function Page({ modelId, modelData }: Props) {
                                         </td>
                                     </tr>
                                     {model.size && (
-                                        <tr className="">
+                                        <tr>
                                             <th
                                                 className="whitespace-nowrap bg-fade-100 px-6 py-4 font-medium text-fade-900 dark:bg-fade-800 dark:text-white"
                                                 scope="row"
@@ -219,16 +215,22 @@ export default function Page({ modelId, modelData }: Props) {
                                             <td className="px-6 py-4">{renderTags(model.size)}</td>
                                         </tr>
                                     )}
-                                    <tr className="">
+                                    <tr>
                                         <th
                                             className="whitespace-nowrap bg-fade-100 px-6 py-4 font-medium text-gray-900 dark:bg-fade-800 dark:text-white"
                                             scope="row"
                                         >
                                             Tags
                                         </th>
-                                        <td className="px-6 py-4">{renderTags(model.tags)}</td>
+                                        <td className="px-6 py-4">
+                                            <EditableTags
+                                                readonly={!editMode}
+                                                tags={model.tags}
+                                                onChange={(tags) => updateModelProperty('tags', tags)}
+                                            />
+                                        </td>
                                     </tr>
-                                    <tr className="">
+                                    <tr>
                                         <th
                                             className="whitespace-nowrap bg-fade-100 px-6 py-4 font-medium text-gray-900 dark:bg-fade-800 dark:text-white"
                                             scope="row"
@@ -294,10 +296,7 @@ export default function Page({ modelId, modelData }: Props) {
                                         .sort()
                                         .map(([key, value]) => {
                                             return (
-                                                <tr
-                                                    className=""
-                                                    key={key}
-                                                >
+                                                <tr key={key}>
                                                     <th
                                                         className="whitespace-nowrap bg-fade-100 px-6 py-4 font-medium capitalize text-fade-900 dark:bg-fade-800 dark:text-white"
                                                         scope="row"

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -103,6 +103,13 @@ export default function Page({ modelId, modelData }: Props) {
                                     />
                                 </div>
                             </div>
+                            <div className="mt-2 text-xs">
+                                <EditableTags
+                                    readonly={!editMode}
+                                    tags={model.tags}
+                                    onChange={(tags) => updateModelProperty('tags', tags)}
+                                />
+                            </div>
                             <div className="py-4">
                                 <EditableMarkdownContainer
                                     markdown={modelData.description}
@@ -215,21 +222,6 @@ export default function Page({ modelId, modelData }: Props) {
                                             <td className="px-6 py-4">{renderTags(model.size)}</td>
                                         </tr>
                                     )}
-                                    <tr>
-                                        <th
-                                            className="whitespace-nowrap bg-fade-100 px-6 py-4 font-medium text-gray-900 dark:bg-fade-800 dark:text-white"
-                                            scope="row"
-                                        >
-                                            Tags
-                                        </th>
-                                        <td className="px-6 py-4">
-                                            <EditableTags
-                                                readonly={!editMode}
-                                                tags={model.tags}
-                                                onChange={(tags) => updateModelProperty('tags', tags)}
-                                            />
-                                        </td>
-                                    </tr>
                                     <tr>
                                         <th
                                             className="whitespace-nowrap bg-fade-100 px-6 py-4 font-medium text-gray-900 dark:bg-fade-800 dark:text-white"


### PR DESCRIPTION
This PR adds a component for editable tags. It's basically a pop over that allows you to quickly add/remove tags by simply clicking them. I also moved tags in model pages to be more consistent with model cards.

![image](https://user-images.githubusercontent.com/20878432/229527938-b139a9c6-505b-4c44-b5dd-18e9773fca81.png)
![image](https://user-images.githubusercontent.com/20878432/229527864-28f473e2-2d80-4f27-b6f3-dc6db1ffaecf.png)

Model cards also allow editing tags, which means that we can edit tags directly from the search page.

![image](https://user-images.githubusercontent.com/20878432/229528249-834b1415-73ca-48c5-bb43-8cd52b720d93.png)
