### PR TITLE
Improvements to editable users

### DIFF
--- a/src/elements/components/editable-users.tsx
+++ b/src/elements/components/editable-users.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BsPersonFillAdd } from 'react-icons/bs';
 import { MdRemoveCircle } from 'react-icons/md';
 import { useUsers } from '../../lib/hooks/use-users';
+import { joinList } from '../../lib/react-util';
 import { UserId } from '../../lib/schema';
 import { Link } from './link';
 
@@ -15,66 +16,69 @@ export function EditableUsers({ users, onChange, readonly }: EditableUsersProps)
     const { userData } = useUsers();
     const [randomUser] = userData.keys();
 
-    return (
-        <div className="flex flex-row flex-wrap gap-2">
-            <strong className="m-0 flex flex-row flex-wrap gap-2 text-lg text-accent-600 dark:text-accent-500">
-                {users.map((userId, index) => {
-                    if (!readonly && onChange) {
+    if (readonly || !onChange) {
+        return (
+            <>
+                {'by '}
+                {joinList(
+                    users.map((userId) => {
                         return (
-                            <div
-                                className="flex flex-row gap-2"
-                                key={`${userId} ${index}`}
+                            <Link
+                                className="text-lg font-bold text-accent-600 dark:text-accent-400"
+                                href={`/users/${userId}`}
+                                key={userId}
                             >
-                                <select
-                                    value={userId}
-                                    onChange={(event) => {
-                                        const newUsers = [...users];
-                                        newUsers[index] = event.target.value as UserId;
-                                        onChange(newUsers);
-                                    }}
-                                >
-                                    {[...userData].map(([userId, user]) => (
-                                        <option
-                                            key={userId}
-                                            value={userId}
-                                        >
-                                            {user.name}
-                                        </option>
-                                    ))}
-                                </select>
-                                {index > 0 && (
-                                    <button
-                                        onClick={() => {
-                                            const newUsers = [...users];
-                                            newUsers.splice(index, 1);
-                                            onChange(newUsers);
-                                        }}
-                                    >
-                                        <MdRemoveCircle />
-                                    </button>
-                                )}
-                            </div>
+                                {userData.get(userId)?.name ?? `unknown user:${userId}`}
+                            </Link>
                         );
-                    }
-                    return (
-                        <Link
-                            href={`/users/${userId}`}
-                            key={userId}
-                        >
-                            {userData.get(userId)?.name ?? `unknown user:${userId}`}
-                        </Link>
-                    );
-                })}
-                {!readonly && onChange && (
-                    <button
-                        onClick={() => {
-                            onChange([...users, randomUser]);
-                        }}
-                    >
-                        <BsPersonFillAdd />
-                    </button>
+                    })
                 )}
-            </strong>
+            </>
+        );
+    }
+
+    return (
+        <div className="flex flex-row flex-wrap gap-2 text-lg">
+            {users.map((userId, index) => {
+                return (
+                    <div
+                        className="flex flex-row gap-1"
+                        key={`${userId} ${index}`}
+                    >
+                        <select
+                            value={userId}
+                            onChange={(event) => {
+                                const newUsers = [...users];
+                                newUsers[index] = event.target.value as UserId;
+                                onChange(newUsers);
+                            }}
+                        >
+                            {[...userData].map(([userId, user]) => (
+                                <option
+                                    key={userId}
+                                    value={userId}
+                                >
+                                    {user.name}
+                                </option>
+                            ))}
+                        </select>
+                        {index > 0 && (
+                            <button
+                                onClick={() => {
+                                    const newUsers = [...users];
+                                    newUsers.splice(index, 1);
+                                    onChange(newUsers);
+                                }}
+                            >
+                                <MdRemoveCircle />
+                            </button>
+                        )}
+                    </div>
+                );
+            })}
+            <button onClick={() => onChange([...users, randomUser])}>
+                <BsPersonFillAdd />
+            </button>
         </div>
     );
 }

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -96,8 +96,7 @@ export default function Page({ modelId, modelData }: Props) {
                                         onChange={(value) => updateModelProperty('name', value)}
                                     />
                                 </h1>
-                                <div className="m-0 flex w-full max-w-full flex-row gap-2">
-                                    by{' '}
+                                <div>
                                     <EditableUsers
                                         readonly={!editMode}
                                         users={authors}


### PR DESCRIPTION
Changes:
- Use the same link color as model card.
- Use `joinList` to join multiple authors, just like model card.
- Make the difference between edit and non-edit mode more obvious. 

![image](https://user-images.githubusercontent.com/20878432/229533612-a64917a4-e983-46dd-aa4e-265be9a2aa84.png)
![image](https://user-images.githubusercontent.com/20878432/229533705-a8304822-5421-46ae-a885-6e49af3ef2dc.png)
