### PR TITLE
Memo model card

### DIFF
--- a/src/elements/components/model-card.tsx
+++ b/src/elements/components/model-card.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import { useArchitectures } from '../../lib/hooks/use-architectures';
 import { useUpdateModel } from '../../lib/hooks/use-update-model';
 import { useUsers } from '../../lib/hooks/use-users';
@@ -15,7 +15,8 @@ interface ModelCardProps {
     model: Model;
 }
 
-export const ModelCard = ({ id, model }: ModelCardProps) => {
+// eslint-disable-next-line react/display-name
+export const ModelCard = memo(({ id, model }: ModelCardProps) => {
     const { userData } = useUsers();
     const { archData } = useArchitectures();
 
@@ -78,7 +79,7 @@ export const ModelCard = ({ id, model }: ModelCardProps) => {
             </div>
         </div>
     );
-};
+});
 
 function fixDescription(description: string, scale: number): string {
     const lines = description.split('\n');


### PR DESCRIPTION
Model cards are quite expensive in edit mode, which can cause noticeable lag. Memo-ing them stops this lag.