### PR TITLE
Added edit-only helper tags

### DIFF
--- a/data/tag-categories.json
+++ b/data/tag-categories.json
@@ -122,5 +122,18 @@
             "license:no-license",
             "license:unknown"
         ]
+    },
+    "helpers": {
+        "name": "Helpers",
+        "description": "A collections of helper tags that mark missing data or models that are interesting for maintainers.",
+        "order": 8,
+        "simple": false,
+        "editOnly": true,
+        "tags": [
+            "helper:needs-date",
+            "helper:needs-description",
+            "helper:invalid-scale",
+            "helper:invalid-channels"
+        ]
     }
 }

--- a/data/tags.json
+++ b/data/tags.json
@@ -155,6 +155,22 @@
         "name": "RGBA",
         "description": "The model upscales images with transparency."
     },
+    "helper:invalid-channels": {
+        "name": "Invalid channels",
+        "description": "The number of input or output channels of the model is not valid."
+    },
+    "helper:invalid-scale": {
+        "name": "Invalid scale",
+        "description": "The scale of the model is not valid."
+    },
+    "helper:needs-date": {
+        "name": "Needs date",
+        "description": "The model has no publish date."
+    },
+    "helper:needs-description": {
+        "name": "Needs description",
+        "description": "The model has no description."
+    },
     "input:audio": {
         "name": "Audio",
         "description": ""

--- a/src/lib/derive-tags.ts
+++ b/src/lib/derive-tags.ts
@@ -98,6 +98,20 @@ export const deriveTags = lazyWithWeakKey((model: Model): readonly TagId[] => {
     // platform
     tags.push(...getPlatformTags(model));
 
+    // helpers
+    if (!model.date) {
+        tags.push('helper:needs-date');
+    }
+    if (!model.description) {
+        tags.push('helper:needs-description');
+    }
+    if (typeof model.scale !== 'number') {
+        tags.push('helper:invalid-scale');
+    }
+    if (typeof model.inputChannels !== 'number' || typeof model.outputChannels !== 'number') {
+        tags.push('helper:invalid-channels');
+    }
+
     // sort tags to make sure that their order doesn't matter
     tags.sort();
     return tags as TagId[];

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -75,6 +75,12 @@ export interface TagCategory {
     order: number;
     /** Whether the tags of this category are part of the simple tag selector. */
     simple: boolean;
+    /**
+     * Whether this category is only to be displayed in edit mode.
+     *
+     * @default false
+     */
+    editOnly?: boolean;
     tags: TagId[];
 }
 


### PR DESCRIPTION
This adds helper tags. They are intended to flag models that are points of interest for maintainers. Helper tags are only visible in edit mode.

![image](https://user-images.githubusercontent.com/20878432/229631960-54926a4d-a34f-4828-b5dd-8b7bb7ea2925.png)
