### PR TITLE
Removed `@next/font`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@headlessui/react": "^1.7.9",
         "@headlessui/tailwindcss": "^0.1.2",
-        "@next/font": "13.1.5",
         "@tailwindcss/line-clamp": "^0.4.2",
         "chokidar": "^3.5.3",
         "chroma-js": "^2.4.2",
@@ -3281,11 +3280,6 @@
       "dependencies": {
         "glob": "7.1.7"
       }
-    },
-    "node_modules/@next/font": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.1.5.tgz",
-      "integrity": "sha512-6M5R6yC3JkdJiqo/YJxDp6+0vDn0smXOAzl8uHt4qmDS2u53ji/19K0HM51d+5kg8xntDi+N2hw7YjaU9inkNA=="
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "13.2.5-canary.22",
@@ -20949,11 +20943,6 @@
       "requires": {
         "glob": "7.1.7"
       }
-    },
-    "@next/font": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.1.5.tgz",
-      "integrity": "sha512-6M5R6yC3JkdJiqo/YJxDp6+0vDn0smXOAzl8uHt4qmDS2u53ji/19K0HM51d+5kg8xntDi+N2hw7YjaU9inkNA=="
     },
     "@next/swc-darwin-arm64": {
       "version": "13.2.5-canary.22",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@headlessui/react": "^1.7.9",
     "@headlessui/tailwindcss": "^0.1.2",
-    "@next/font": "13.1.5",
     "@tailwindcss/line-clamp": "^0.4.2",
     "chokidar": "^3.5.3",
     "chroma-js": "^2.4.2",


### PR DESCRIPTION
`@next/font` is deprecated in favor of `next/font`. We weren't using `@next/font` anyway, so nothing is lost.