### PR TITLE
Added file size for MS Unpainter models

### DIFF
--- a/data/models/8x-MS-Unpainter-De-Dither.json
+++ b/data/models/8x-MS-Unpainter-De-Dither.json
@@ -17,7 +17,7 @@
         {
             "platform": "pytorch",
             "type": "pth",
-            "size": null,
+            "size": 67173423,
             "sha256": null,
             "urls": [
                 "https://u.pcloud.link/publink/show?code=kZPTiBXZPnCIVsFUmrpu4NY1sKfKw8Pyw6rk"

--- a/data/models/8x-MS-Unpainter.json
+++ b/data/models/8x-MS-Unpainter.json
@@ -16,7 +16,7 @@
         {
             "platform": "pytorch",
             "type": "pth",
-            "size": null,
+            "size": 67173423,
             "sha256": null,
             "urls": [
                 "https://u.pcloud.link/publink/show?code=kZPTiBXZPnCIVsFUmrpu4NY1sKfKw8Pyw6rk"


### PR DESCRIPTION
While I can't download those models, pcloud still has this information on the page, just invisible. Just open dev console and print the global variable `publinkData`.