### PR TITLE
More efficient `useModels`

### DIFF
--- a/src/lib/hooks/use-models.ts
+++ b/src/lib/hooks/use-models.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Model, ModelId } from '../schema';
 import { typedEntries } from '../util';
 import { addUpdateListener, getWebApi, startListeningForUpdates } from '../web-api';
@@ -8,8 +8,27 @@ export interface UseModels {
 }
 
 export function useModels(models: Readonly<Record<ModelId, Model>>): UseModels {
-    const staticData = useMemo(() => new Map(typedEntries(models)), [models]);
-    const [dynamicData, setDynamicData] = useState<ReadonlyMap<ModelId, Model>>();
+    const staticData: ReadonlyMap<ModelId, Model> = useMemo(() => new Map(typedEntries(models)), [models]);
+    const [data, setData] = useState(staticData);
+
+    const update = useCallback((value: ReadonlyMap<ModelId, Model>): void => {
+        setData((prev) => {
+            if (prev === value) return prev;
+
+            const newData = new Map();
+            for (const [id, model] of value) {
+                const old = prev.get(id);
+                if (old && areEqual(old, model)) {
+                    newData.set(id, old);
+                } else {
+                    newData.set(id, model);
+                }
+            }
+            return newData;
+        });
+    }, []);
+
+    useEffect(() => update(staticData), [update, staticData]);
 
     useEffect(() => {
         startListeningForUpdates();
@@ -18,11 +37,15 @@ export function useModels(models: Readonly<Record<ModelId, Model>>): UseModels {
                 .then(async (webApi) => {
                     if (!webApi) return;
                     const models = await webApi.models.getAll();
-                    setDynamicData(models);
+                    update(models);
                 })
                 .catch((e) => console.error(e));
         });
-    }, []);
+    }, [update]);
 
-    return { modelData: dynamicData ?? staticData };
+    return { modelData: data };
+}
+
+function areEqual(a: Model, b: Model): boolean {
+    return JSON.stringify(a) === JSON.stringify(b);
 }


### PR DESCRIPTION
This makes `useModel` slightly more efficient by diffing with the previous models. This enables memoizing for unchanged models.