### PR TITLE
Added sample images from old model db

### DIFF
--- a/data/models/1x-AnimeUndeint-Compact.json
+++ b/data/models/1x-AnimeUndeint-Compact.json
@@ -29,5 +29,26 @@
             ]
         }
     ],
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/c9978a74-32ee-478b-b228-10744521fc21.jpg",
+            "SR": "https://imgsli.com/i/c90377d5-287d-4f1c-ab4c-96267bfaa04e.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a611b9a9-422f-44ed-882a-3ada8f478625.jpg",
+            "SR": "https://imgsli.com/i/83e9600a-a8ee-4f2b-96e7-f42dc7e5ab12.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/be1717a7-d70b-4e52-b04c-4b2b04901b4d.jpg",
+            "SR": "https://imgsli.com/i/7c22ba75-01ca-407a-98b9-16e27ad6de55.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/07f02f1c-f082-4d44-bd3b-6a6cbf79c48b.jpg",
+            "SR": "https://imgsli.com/i/12aa0959-36db-49a1-8a0c-e58f99226395.jpg"
+        }
+    ]
 }

--- a/data/models/1x-ArtClarity.json
+++ b/data/models/1x-ArtClarity.json
@@ -7,7 +7,7 @@
         "denoise",
         "pixel-art"
     ],
-    "description": "Pretrained: 4xPSNR\n\nTexture retaining denoiser and sharpener for digital artwork",
+    "description": "Pretrained: 4xPSNR\n\nTexture retaining denoiser and sharpener for digital artwork\n\nSample images: https://1drv.ms/u/s!Aip-EMByJHY28xKFp93VIGydNsoN?e=vN2WYh",
     "date": "2021-08-05",
     "architecture": "esrgan",
     "size": [

--- a/data/models/1x-BCGone-Smooth.json
+++ b/data/models/1x-BCGone-Smooth.json
@@ -34,5 +34,11 @@
     "trainingOTF": false,
     "dataset": "Images from DIV2K and random anime drawings",
     "pretrainedModelG": "1x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/34bdb4fb-522b-4045-bd2a-1a936bec98c5.jpg",
+            "SR": "https://imgsli.com/i/a9428e7e-08f7-4a85-9638-8c532a4a9bc6.jpg"
+        }
+    ]
 }

--- a/data/models/1x-Bandage-Smooth.json
+++ b/data/models/1x-Bandage-Smooth.json
@@ -5,7 +5,7 @@
     "tags": [
         "debanding"
     ],
-    "description": "Attempts to remove the damages done by color banding. For this model, I downscaled all of the HR images to make their pixel size closer to 1000x1000 using the Box filter and then downscaled them again by 50% using the Point filter. Afterwards, I applied 64-bit color banding to every image in the dataset.",
+    "description": "Attempts to remove the damages done by color banding. For this model, I downscaled all of the HR images to make their pixel size closer to 1000x1000 using the Box filter and then downscaled them again by 50% using the Point filter. Afterwards, I applied 64-bit color banding to every image in the dataset.\n\nComparisons with other models: https://imgsli.com/NTA1NTk",
     "date": "2021-04-16",
     "architecture": "esrgan",
     "size": [
@@ -34,5 +34,11 @@
     "dataset": "Random anime images",
     "datasetSize": 550,
     "pretrainedModelG": "1x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/4e7d08da-751b-43a2-9557-548fd43e08da.jpg",
+            "SR": "https://imgsli.com/i/ee76c2cb-8231-4b6f-a4ef-19fc6b4a9a48.jpg"
+        }
+    ]
 }

--- a/data/models/1x-BleedOut-Compact.json
+++ b/data/models/1x-BleedOut-Compact.json
@@ -29,5 +29,76 @@
             ]
         }
     ],
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/55edf1f5-ec2d-4192-9679-dea81337ff1c.jpg",
+            "SR": "https://imgsli.com/i/b8f60379-832f-4720-bba6-a87660679fc5.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/05e621c5-1822-498d-9b87-d473d046b615.jpg",
+            "SR": "https://imgsli.com/i/10a3bc15-3a24-4584-a42c-5a9cdc3faabb.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/570acf48-36cd-4921-bb6e-255f0febeadb.jpg",
+            "SR": "https://imgsli.com/i/cda396b7-d70a-408b-bd66-40134f4b0296.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/45822e7a-0292-4537-8107-c3d063199245.jpg",
+            "SR": "https://imgsli.com/i/027fd378-c6ea-4bc7-af3e-28066c487315.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/f9d2ae10-b797-4287-b2b9-be58b4cf7d1c.jpg",
+            "SR": "https://imgsli.com/i/2a235e42-b027-4d47-bbec-cb8e38512de8.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/41090a0f-bd5f-4351-ade6-78ef11f65c40.jpg",
+            "SR": "https://imgsli.com/i/6e636992-7fb3-45b5-903a-14c7d7385cbc.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1cf148e7-91e6-45b4-ae7b-eb27f08a843b.jpg",
+            "SR": "https://imgsli.com/i/7af4cc56-f38c-4b02-82ea-750d7156c340.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a9ce9a33-31a9-4fba-a05a-e4e28de3efd5.jpg",
+            "SR": "https://imgsli.com/i/07700804-f31a-4466-b8dd-5fa56b99eae6.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ab3a2f41-b62a-4685-968b-fe85f5034c2a.jpg",
+            "SR": "https://imgsli.com/i/58ff9b77-1091-4d26-9ba5-8124fe7591c8.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/90c733a5-55d1-4c2f-8e50-af8f478a08e5.jpg",
+            "SR": "https://imgsli.com/i/dc16346e-20b3-43c5-8cc9-85b14255b843.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/9a9bf78d-7a30-4dbd-b76d-18ac930f4260.jpg",
+            "SR": "https://imgsli.com/i/ea28ada2-6e33-48f0-a387-ce5ceb4f2d15.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/4c9ce4eb-f34b-42ba-a103-282291cf66bd.jpg",
+            "SR": "https://imgsli.com/i/5eaa8e3d-abc8-4bef-b0f4-a377220e35b3.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ac7d02b6-c4a7-48e0-afb3-2f9d89f4f8d3.jpg",
+            "SR": "https://imgsli.com/i/2d9aeac9-ce07-4e25-b2c1-cd8719b2a83e.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/8cbbfb56-512c-4ef0-bcdd-23fe3c926af8.jpg",
+            "SR": "https://imgsli.com/i/cfb8501b-8144-455b-b3d0-a1d409a3a838.jpg"
+        }
+    ]
 }

--- a/data/models/1x-BroadcastToStudioLite.json
+++ b/data/models/1x-BroadcastToStudioLite.json
@@ -33,5 +33,56 @@
     "trainingHRSize": 128,
     "dataset": "DVD",
     "datasetSize": 3418,
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/0d56beb6-5e51-4d51-87df-3a5563d993e9.jpg",
+            "SR": "https://imgsli.com/i/942fc401-cf4c-4611-bf24-441984b10a6a.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/40cad094-ec25-4cf1-bf50-2e8c74e98206.jpg",
+            "SR": "https://imgsli.com/i/b197890a-ac6c-4071-bf4c-f8af488d9408.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/5e970a53-6e1c-429c-b767-7ac01de50dc2.jpg",
+            "SR": "https://imgsli.com/i/d2a2dee1-d2ad-40ad-aa66-5b2b7adb5362.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6e59596f-efd0-4bf4-b1da-362fe5241a83.jpg",
+            "SR": "https://imgsli.com/i/e42d0cdb-99eb-4a9d-9746-15896c6af6ac.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/37d2ae35-0bf6-4d67-9d76-75bc3fde06bc.jpg",
+            "SR": "https://imgsli.com/i/d8791c57-0573-4d65-8956-be2b5b9922b1.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/88aba67b-fb58-4590-8b0f-e8fa3e143c14.jpg",
+            "SR": "https://imgsli.com/i/c01b230b-5cbb-4dcd-b118-362861fb33e3.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/caa9fdfe-a0d2-4c70-989d-2d2e795df633.jpg",
+            "SR": "https://imgsli.com/i/ea9fce11-6ce4-4d6a-b735-b5dc8acedad9.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/d0a60877-acc0-448d-9def-de622775f2e5.jpg",
+            "SR": "https://imgsli.com/i/cf93e0ce-cc99-4bbe-8188-0905c817f316.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/f880f569-d3aa-4067-9520-6399b2c237ad.jpg",
+            "SR": "https://imgsli.com/i/5f2c6c41-4c31-4b86-a603-b61bd6880970.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b2f9ec77-64e9-41c0-a7e0-414e1ef591cb.jpg",
+            "SR": "https://imgsli.com/i/15f54cb3-90f5-4294-a82d-d5f4742ec473.jpg"
+        }
+    ]
 }

--- a/data/models/1x-DEDXT.json
+++ b/data/models/1x-DEDXT.json
@@ -35,5 +35,10 @@
     "dataset": "Textures from paladins",
     "datasetSize": 150,
     "pretrainedModelG": "1x-BCGone-DetailedV2-40-60",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/947116367205793882/cmp.png"
+        }
+    ]
 }

--- a/data/models/1x-DXTDecompressor-Source-V3.json
+++ b/data/models/1x-DXTDecompressor-Source-V3.json
@@ -34,5 +34,26 @@
     "trainingHRSize": 64,
     "dataset": "Uncompressed textures from various Source Engine games (https://github.com/JosephtheKP/sourceengine_tga_archive) and some data provided by friends",
     "pretrainedModelG": "1x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/941eafbf-3700-4237-a920-945468e44d32.jpg",
+            "SR": "https://imgsli.com/i/afa44d1b-df34-4452-a9a3-b319d2d2d2b9.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1ab17ff7-45c4-45df-9b01-a141960e4c0d.jpg",
+            "SR": "https://imgsli.com/i/5edf1bd5-3db7-455d-b53e-7379676e37e3.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/5dbfe90f-c5c8-4eb1-991a-1aa330a7aba7.jpg",
+            "SR": "https://imgsli.com/i/d643388f-9ddc-4cd6-9330-4e46c839b20a.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/22938fff-332a-4486-a641-2db5bad646df.jpg",
+            "SR": "https://imgsli.com/i/cb72acbf-640c-4ee2-bba0-7a9ac3928bf9.jpg"
+        }
+    ]
 }

--- a/data/models/1x-DXTless-SourceEngine.json
+++ b/data/models/1x-DXTless-SourceEngine.json
@@ -32,5 +32,26 @@
     "dataset": "Mostly TF2 textures with some misc stuff in, artificially expanded.",
     "datasetSize": 473,
     "pretrainedModelG": "1x-SaiyaJin-DeJpeg",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/96989c53-cdea-4ab4-886c-22719a681df7.jpg",
+            "SR": "https://imgsli.com/i/e5d42a20-aa43-4a5e-b30a-54ce97eed1b2.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3f051d2d-2d0b-4148-b57e-11d703497c6f.jpg",
+            "SR": "https://imgsli.com/i/ca9975e7-5fc4-48e4-934f-4396df3773e1.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/98fd2602-efbf-419b-8568-89670c4f1509.jpg",
+            "SR": "https://imgsli.com/i/5ec4ed88-99e2-421b-986f-3badce9ba2b7.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/f5d0692c-d3c0-44e6-8085-e9da7119d0a2.jpg",
+            "SR": "https://imgsli.com/i/33759c90-c367-4cd1-8cd4-f51973137094.jpg"
+        }
+    ]
 }

--- a/data/models/1x-DeBink-Lite.json
+++ b/data/models/1x-DeBink-Lite.json
@@ -27,5 +27,10 @@
             ]
         }
     ],
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/903415274521374750/904129653374078976/XB_Demo_Mov-85600_G.mp4"
+        }
+    ]
 }

--- a/data/models/1x-DeEdge.json
+++ b/data/models/1x-DeEdge.json
@@ -5,7 +5,7 @@
     "tags": [
         "dehalo"
     ],
-    "description": "Halo Removal",
+    "description": "Halo Removal + edge removal. This model softens edges without blurring other parts of the image.\n\nComparison and use case: https://imgsli.com/MjgxMDU",
     "date": "2020-11-03",
     "architecture": "esrgan",
     "size": [
@@ -33,5 +33,11 @@
     "trainingOTF": false,
     "dataset": "Images from DIV2K and random anime drawings",
     "pretrainedModelG": "1x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ce7660b4-2324-40a2-8e47-1a671654321e.jpg",
+            "SR": "https://imgsli.com/i/1409bc04-010f-45f2-b652-e7939b0446fc.jpg"
+        }
+    ]
 }

--- a/data/models/1x-DeRoqBeta-lite.json
+++ b/data/models/1x-DeRoqBeta-lite.json
@@ -27,5 +27,10 @@
             ]
         }
     ],
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1001671437293207672/1658887461.0522466.png"
+        }
+    ]
 }

--- a/data/models/1x-DitherDeleterV2-Smooth.json
+++ b/data/models/1x-DitherDeleterV2-Smooth.json
@@ -34,5 +34,11 @@
     "dataset": "Random anime images",
     "datasetSize": 300,
     "pretrainedModelG": "1x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/e4133059-5fc0-45d0-b72c-6a1253fb0986.jpg",
+            "SR": "https://imgsli.com/i/0bf5bb2d-ad6a-4320-b550-ad88c3c60ff3.jpg"
+        }
+    ]
 }

--- a/data/models/1x-DitherDeleterV3-Smooth.json
+++ b/data/models/1x-DitherDeleterV3-Smooth.json
@@ -5,7 +5,7 @@
     "tags": [
         "dedither"
     ],
-    "description": "Attempts to remove the damages done by dithering. For this model, I downscaled all of the HR images to make their pixel size closer to 1000x1000 using the Box filter and then downscaled them again by 50% using the Point filter. Afterwards, I applied 32-bit Riemersma to every image in the dataset.",
+    "description": "Attempts to remove the damages done by dithering. For this model, I downscaled all of the HR images to make their pixel size closer to 1000x1000 using the Box filter and then downscaled them again by 50% using the Point filter. Afterwards, I applied 32-bit Riemersma to every image in the dataset.\n\nhttps://imgsli.com/NTA5MjU/0/1",
     "date": "2021-04-18",
     "architecture": "esrgan",
     "size": [
@@ -34,5 +34,11 @@
     "dataset": "Random anime images",
     "datasetSize": 550,
     "pretrainedModelG": "1x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1f381ae7-1d40-4dc8-a3b0-15a353702aa0.jpg",
+            "SR": "https://imgsli.com/i/e52b698b-5d34-4f08-a3d8-bdab93ba51c4.jpg"
+        }
+    ]
 }

--- a/data/models/1x-Dotzilla-Compact.json
+++ b/data/models/1x-Dotzilla-Compact.json
@@ -34,5 +34,36 @@
     "dataset": "Blue Submarine No. 6 Toonami version aligned to the 2016 Discotek DVD release made up about half of the dataset. The remainder was hand selected frames from a variety of animated series cleaned up with Avisynth.",
     "datasetSize": 177,
     "pretrainedModelG": "1x-Compact-Pretrain",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/792a20d2-8dff-4317-ab37-16ace592b1fd.jpg",
+            "SR": "https://imgsli.com/i/9b1c7e9f-f4a9-4e60-a05f-e85a6829ba8d.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/e001c5d1-721d-465e-8992-88a668ebe510.jpg",
+            "SR": "https://imgsli.com/i/06bb46ed-fc4a-4495-812b-bb3aa00e0778.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/35471bf8-b8a3-4de4-ace3-fceccdc8590b.jpg",
+            "SR": "https://imgsli.com/i/7d3b0287-4aab-422c-9e27-097db995794b.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/733e689a-e62f-4390-8547-f01098123676.jpg",
+            "SR": "https://imgsli.com/i/b0035811-d9f5-4727-8258-d1d93b208471.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/2c0b5582-6d4a-4bbc-a13b-57e1f974971e.jpg",
+            "SR": "https://imgsli.com/i/97ffd3af-3626-4159-8f0c-2ec6714d0f68.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/261549c2-c5a3-40fb-88c8-2a561c45454e.jpg",
+            "SR": "https://imgsli.com/i/d3d7ccc5-b440-499e-8450-8715957e96b7.jpg"
+        }
+    ]
 }

--- a/data/models/1x-Epsilon-one-compact.json
+++ b/data/models/1x-Epsilon-one-compact.json
@@ -37,5 +37,96 @@
     "trainingOTF": false,
     "dataset": "frames from remastered 80s-90s anime",
     "pretrainedModelG": "1x-Compact-Pretrain",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/9337b6f0-51d7-4d34-aaf7-1c2d8c35a41c.jpg",
+            "SR": "https://imgsli.com/i/cd2c69b1-db99-491f-8265-55f594e65a3a.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/f15d8203-d5f9-49d3-a5ea-d53700474707.jpg",
+            "SR": "https://imgsli.com/i/188ba776-3d6e-480c-babb-e47be6592973.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/78be3129-513c-4bb4-bbd4-58daa4ad7452.jpg",
+            "SR": "https://imgsli.com/i/96db5c18-c733-45fc-855c-1d60cc880ed0.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/c6bdf99c-20eb-44b9-b16e-c6a32daabf43.jpg",
+            "SR": "https://imgsli.com/i/e93a06c7-893d-4e2e-b2cc-a427482f2aac.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/bbe220f7-24bb-4ff8-84eb-ac0d1bf6ee16.jpg",
+            "SR": "https://imgsli.com/i/bdc19e31-5a4a-4d53-9475-dc50d396644b.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3dd62a30-50b0-41c9-a29b-8382eae3dacc.jpg",
+            "SR": "https://imgsli.com/i/41744eb2-93ae-4b01-868d-b781752764d9.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/604319be-ea24-4a3c-97b3-f576324bb9b2.jpg",
+            "SR": "https://imgsli.com/i/3517cd13-58b0-41ab-83fb-56feb1d25421.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/dfb19e12-f42a-4bec-9836-9700aa8906e3.jpg",
+            "SR": "https://imgsli.com/i/062c2a1b-d069-47f0-a95a-62ca0f6f31b7.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/70c4ed4c-295e-4710-888d-0014b0f83c12.jpg",
+            "SR": "https://imgsli.com/i/085a349f-2568-48fb-a1c6-33adead3f13f.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/61ccdab9-f978-4577-8a7f-939400a08e7a.jpg",
+            "SR": "https://imgsli.com/i/c899724b-bb87-4025-bf3f-24c4aca27c32.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/7e9ee335-b74c-4672-babf-371b24a59155.jpg",
+            "SR": "https://imgsli.com/i/1a9b5c4b-8597-4948-b7da-dd8422f56d86.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/185b3f53-b39d-4fa2-b61e-f2fe19ec8362.jpg",
+            "SR": "https://imgsli.com/i/13651893-2ecb-4a93-8390-a346aba5657b.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/15e0ff90-27dc-46c8-aedf-c20ff8bd530e.jpg",
+            "SR": "https://imgsli.com/i/7095fa7a-cd3e-45de-bf5d-c41f760e01d9.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/7ee23dd8-a6cb-40a9-a6c7-78557da8e87b.jpg",
+            "SR": "https://imgsli.com/i/7eb8a1a0-1395-4dde-9802-f2e9f27dd002.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/4f6e06c0-579b-4584-8c6d-53c4f8f6af41.jpg",
+            "SR": "https://imgsli.com/i/2859ef09-9b53-45cb-89ee-722803190c45.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b610e4ee-e5bb-4812-a3ad-dbac8f05d0e0.jpg",
+            "SR": "https://imgsli.com/i/4ed1e48d-16d8-4305-b72d-98bcc42430bc.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ebcf0f2b-ffd8-45d6-9be2-ffe0bc564df6.jpg",
+            "SR": "https://imgsli.com/i/ca4761da-8d3a-4b98-89a8-18ec04575428.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/999e397d-2cff-4aca-a414-d1b1a342bf6b.jpg",
+            "SR": "https://imgsli.com/i/2115a313-71f0-4f28-8fe0-deebf5290eaa.jpg"
+        }
+    ]
 }

--- a/data/models/1x-Fatality-DeBlur.json
+++ b/data/models/1x-Fatality-DeBlur.json
@@ -33,5 +33,26 @@
     "trainingHRSize": 128,
     "dataset": "Mix of anime, manga, and photos",
     "datasetSize": 41000,
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a306d854-f2f7-4cc6-9bd4-7c63974bdc20.jpg",
+            "SR": "https://imgsli.com/i/459c5ad5-1124-4719-a887-35c312965ffa.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/f5bd5da4-fd08-415d-ae93-0095624a1dd5.jpg",
+            "SR": "https://imgsli.com/i/fa05c379-22a1-41df-84e5-6734495a0d20.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3d2847a6-94fd-4c75-824a-2a834411e61b.jpg",
+            "SR": "https://imgsli.com/i/3ba125e6-cd91-46f3-8528-471bbb95c26a.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/fa25ba2f-2de5-492c-8275-6ad12c1dd781.jpg",
+            "SR": "https://imgsli.com/i/0a2b72b8-07a2-4f0d-baa3-deedba74e955.jpg"
+        }
+    ]
 }

--- a/data/models/1x-Filmify4K-v2.json
+++ b/data/models/1x-Filmify4K-v2.json
@@ -33,5 +33,26 @@
     "dataset": "Still frames from the 4K Blu-Ray of Lawrence of Arabia, downscaled to 1080p and upscaled with Gaia-HQ for the LRs",
     "datasetSize": 8200,
     "pretrainedModelG": "1x-UnResize-V3",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "SR": "https://imgsli.com/i/536a70bf-943f-4fac-935c-e2a2731b71db.jpg",
+            "LR": "https://imgsli.com/i/fd400ae5-046c-441b-940c-0c182413ec8b.jpg"
+        },
+        {
+            "type": "paired",
+            "SR": "https://imgsli.com/i/94947ca9-4b9b-4e36-a4cf-4efdd326fca7.jpg",
+            "LR": "https://imgsli.com/i/88f57b42-b771-47c1-8e2d-81a6c81c5b15.jpg"
+        },
+        {
+            "type": "paired",
+            "SR": "https://imgsli.com/i/b82a21ac-56fa-4cf9-94f7-4abd46845382.jpg",
+            "LR": "https://imgsli.com/i/8bfb99af-4467-447a-b9b7-d9b5600ae92e.jpg"
+        },
+        {
+            "type": "paired",
+            "SR": "https://imgsli.com/i/7c4179d5-bf68-4f97-b596-e34c4254020d.jpg",
+            "LR": "https://imgsli.com/i/663b6444-f29f-4949-ae95-d8c9eeb03456.jpg"
+        }
+    ]
 }

--- a/data/models/1x-Focus.json
+++ b/data/models/1x-Focus.json
@@ -32,5 +32,18 @@
     "dataset": "The UniScale Dataset + My Fabric dataset",
     "datasetSize": 3067,
     "pretrainedModelG": "1x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/893483065664483338/893483645803847690/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/893483065664483338/893497416207188028/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/893483065664483338/893483280895193118/unknown.png"
+        }
+    ]
 }

--- a/data/models/1x-Ghibli-Grain.json
+++ b/data/models/1x-Ghibli-Grain.json
@@ -31,5 +31,51 @@
     "trainingHRSize": 1280,
     "dataset": "Images from Kiki's Delivery Service Hayao Miyazaki collectors edition",
     "datasetSize": 10000,
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/32RHqjLT.png",
+            "SR": "https://i.slow.pics/RF2QHsCs.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3e4d7198-3a4a-4358-945e-ed1e75e55242.jpg",
+            "SR": "https://imgsli.com/i/6f8fd9bd-03e6-4b68-bdfd-dc2ecc719d88.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/61e87558-0ecd-4fb8-87fc-d80d4274417b.jpg",
+            "SR": "https://imgsli.com/i/65ff421d-3af6-439b-bdc9-1d8006aabeb1.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/0e527fd3-79f1-4c42-b4fe-e49cb671b7e7.jpg",
+            "SR": "https://imgsli.com/i/2c8a2c3a-e2e2-4e91-9b24-7ca1b55167eb.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/7a0b06d7-f15a-4381-80cc-db65c2cf63e0.jpg",
+            "SR": "https://imgsli.com/i/b5fa2ea2-d8c9-4a0e-a526-9dfafc7cf05d.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/04176360-50b4-4dd3-849e-ac69f210bd69.jpg",
+            "SR": "https://imgsli.com/i/3e8fbfb9-785e-495e-8b87-af5ad56bd01b.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a3cde42a-e05b-463d-a001-47c67d09f73e.jpg",
+            "SR": "https://imgsli.com/i/a44b71a1-16b5-42c4-b3ef-68a7700e95cc.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/7d35ef1b-1eaf-414a-b838-5f2982ebbeb8.jpg",
+            "SR": "https://imgsli.com/i/44647a99-5ce3-459d-9783-ed213e7f8c4a.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/aa060aeb-0b53-492f-bb8f-e77cc0fad3ea.jpg",
+            "SR": "https://imgsli.com/i/c9828750-af38-435a-bd8e-ba257a2d1838.jpg"
+        }
+    ]
 }

--- a/data/models/1x-HurrDeblur-SuperUltraCompact.json
+++ b/data/models/1x-HurrDeblur-SuperUltraCompact.json
@@ -30,5 +30,26 @@
             ]
         }
     ],
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a306d854-f2f7-4cc6-9bd4-7c63974bdc20.jpg",
+            "SR": "https://imgsli.com/i/b6a76b13-5e6d-4dac-87f7-8a9e8d56fc3b.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/f5bd5da4-fd08-415d-ae93-0095624a1dd5.jpg",
+            "SR": "https://imgsli.com/i/78eba200-0f19-45e5-af30-ecf0bfd722c0.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3d2847a6-94fd-4c75-824a-2a834411e61b.jpg",
+            "SR": "https://imgsli.com/i/6911691a-04a7-4c4b-a547-b0bf7f0a2cb4.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/fa25ba2f-2de5-492c-8275-6ad12c1dd781.jpg",
+            "SR": "https://imgsli.com/i/1b5e5bd2-3577-4420-aacb-71920b674b13.jpg"
+        }
+    ]
 }

--- a/data/models/1x-ITF-SkinDiffDDS-v1.json
+++ b/data/models/1x-ITF-SkinDiffDDS-v1.json
@@ -39,5 +39,21 @@
     "dataset": "Custom",
     "datasetSize": 870,
     "pretrainedModelG": "1x-BC1-smooth2",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/97c3fb52-1637-463b-b35f-9f0ef20d5c9f.jpg",
+            "SR": "https://imgsli.com/i/30ee14e0-ea74-41d7-add6-6b7e4e6b4fb7.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/c78937cd-dccd-4de2-8627-4666e9c9b12f.jpg",
+            "SR": "https://imgsli.com/i/72771a70-e179-4dd3-89a9-6aff7ce915d0.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/4ac876c6-4c74-470e-884c-486e73d12cfe.jpg",
+            "SR": "https://imgsli.com/i/8a767967-d37c-486f-9127-42fafad1c54f.jpg"
+        }
+    ]
 }

--- a/data/models/1x-JPG-00-20.json
+++ b/data/models/1x-JPG-00-20.json
@@ -6,7 +6,7 @@
         "jpeg",
         "restoration"
     ],
-    "description": "Pretrained: Trained on Custom (CC0 Textures)",
+    "description": "Pretrained: Trained on Custom (CC0 Textures)\n\nGallery with sample images: https://drive.google.com/open?id=1HWokMsUwsR_Mw-NOJgc8OdS8mkdIje_C",
     "date": "2019-08-06",
     "architecture": "esrgan",
     "size": [

--- a/data/models/1x-JPG-20-40.json
+++ b/data/models/1x-JPG-20-40.json
@@ -6,7 +6,7 @@
         "jpeg",
         "restoration"
     ],
-    "description": "Pretrained: Trained on Custom (CC0 Textures)",
+    "description": "Pretrained: Trained on Custom (CC0 Textures)\n\nGallery with sample images: https://drive.google.com/open?id=1HWokMsUwsR_Mw-NOJgc8OdS8mkdIje_C",
     "date": "2019-08-01",
     "architecture": "esrgan",
     "size": [

--- a/data/models/1x-JPG-40-60.json
+++ b/data/models/1x-JPG-40-60.json
@@ -6,7 +6,7 @@
         "jpeg",
         "restoration"
     ],
-    "description": "Pretrained: Trained on Custom (CC0 Textures)",
+    "description": "Pretrained: Trained on Custom (CC0 Textures)\n\nGallery with sample images: https://drive.google.com/open?id=1HWokMsUwsR_Mw-NOJgc8OdS8mkdIje_C",
     "date": "2019-08-01",
     "architecture": "esrgan",
     "size": [

--- a/data/models/1x-JPG-60-80.json
+++ b/data/models/1x-JPG-60-80.json
@@ -6,7 +6,7 @@
         "jpeg",
         "restoration"
     ],
-    "description": "Pretrained: Trained on Custom (CC0 Textures)",
+    "description": "Pretrained: Trained on Custom (CC0 Textures)\n\nGallery with sample images: https://drive.google.com/open?id=1HWokMsUwsR_Mw-NOJgc8OdS8mkdIje_C",
     "date": "2019-08-01",
     "architecture": "esrgan",
     "size": [

--- a/data/models/1x-JPG-80-100.json
+++ b/data/models/1x-JPG-80-100.json
@@ -6,7 +6,7 @@
         "jpeg",
         "restoration"
     ],
-    "description": "Pretrained: Trained on Custom (CC0 Textures)",
+    "description": "Pretrained: Trained on Custom (CC0 Textures)\n\nGallery with sample images: https://drive.google.com/open?id=1HWokMsUwsR_Mw-NOJgc8OdS8mkdIje_C",
     "date": "2019-08-01",
     "architecture": "esrgan",
     "size": [

--- a/data/models/1x-Kim2091-DeJpeg-v0.json
+++ b/data/models/1x-Kim2091-DeJpeg-v0.json
@@ -30,5 +30,14 @@
     ],
     "trainingIterations": 230000,
     "dataset": "Custom JPEG dataset",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/903415274521374750/1041539960672632832/1668392853.8196685.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/903415274521374750/1041540021175463956/1668392885.0326388.png"
+        }
+    ]
 }

--- a/data/models/1x-MangaJPEGLQ.json
+++ b/data/models/1x-MangaJPEGLQ.json
@@ -33,5 +33,10 @@
     "trainingBatchSize": 5,
     "trainingHRSize": 64,
     "dataset": "Expanded self curated custom manga dataset",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/855269193762865152/Example_LQ_Input-comparison.png"
+        }
+    ]
 }

--- a/data/models/1x-NMKD-YandereInpaint.json
+++ b/data/models/1x-NMKD-YandereInpaint.json
@@ -27,5 +27,25 @@
         }
     ],
     "trainingIterations": 375000,
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://icecube-eu-286.icedrive.io/download?p=M3HvpEBXcC9z4VRuKnwlc_0m_eYVePVZVLQMq4R0CqTPq66Dm49CPdKpn2uahnRI6BKJOnmHFddCEQLsNVz3hJ2x9LCo9LGrwPSskmD31w2u2HGit_ih_Z0KmQY_fZYbJPikwHyBIcLww9eSG5w9PoYdQOq1aAbDLDxy29.qdkZAkPxysEAnt8p90W0KL0f_muSWPWpeQOMSiY56hBik8g--",
+            "thumbnail": "https://icecube-eu-286.icedrive.io/thumbnail?p=KZnaB3klpgKv0f49yDs59BlaJl8e_lBzf6wbhH3Gl7UKQbRwqWYuxxCBER01hFuyt.9xWbZkbzIjSDpS_zi.QvK6OJ6HgLglYnv45wJ0oWp4iN3IHlDyCn8p0gt2ur_h"
+        },
+        {
+            "type": "standalone",
+            "url": "https://icecube-eu-286.icedrive.io/download?p=M3HvpEBXcC9z4VRuKnwlc_0m_eYVePVZVLQMq4R0CqQ2Asuh9cmF2eKvYOVmvBbE6BKJOnmHFddCEQLsNVz3hLsKxNJuRgUI1wFWrvv.0JHIV9Z8yKB7p0xoJbgYC7aFlTRImZBUFlXZyAFkbAFJnYYdQOq1aAbDLDxy29.qdkZAkPxysEAnt8p90W0KL0f_yvCcb9lR6n_M1f3BrB97_w--",
+            "thumbnail": "https://icecube-eu-286.icedrive.io/thumbnail?p=kSP2ZFXucfhNDqV0m0ZC3H1I.FF10ZG8QiVbfPke39BqAP03WeqOvd3j.2tkBCKmPBhrrLts.YQkX4EKudGEkPK6OJ6HgLglYnv45wJ0oWp4iN3IHlDyCn8p0gt2ur_h"
+        },
+        {
+            "type": "standalone",
+            "url": "https://icecube-eu-286.icedrive.io/download?p=M3HvpEBXcC9z4VRuKnwlc_0m_eYVePVZVLQMq4R0CqR3QCDCfPE_2slY2j7GvJLv6BKJOnmHFddCEQLsNVz3hCy3EF.WNurD.1gb4vfAJf4xcXtv0LDhn3ibVyMKcEk67OHkYvM5wz_2knOgNLNhvYYdQOq1aAbDLDxy29.qdkZAkPxysEAnt8p90W0KL0f_ACih35_rfJJOh.N0qCjoNA--",
+            "thumbnail": "https://icecube-eu-286.icedrive.io/thumbnail?p=B8VDvq2L2lJLz5nNC2tS_nmc.2Y4SoCsiasAf9HFntGt0vl6uLO5b8AD3joj0ejdqJAiRZ9i5VfaC7ip1NvxHfK6OJ6HgLglYnv45wJ0oWp4iN3IHlDyCn8p0gt2ur_h"
+        },
+        {
+            "type": "standalone",
+            "url": "https://icecube-eu-286.icedrive.io/download?p=TZKrzhXJb_pSXfJYPeHlxFEQNRq7lj1NUlQb_WM1c6cOPR8NTDLBxTX34mLscx3UB.2EQkV2AjhbopISfrZQakFWwg9lsYtqHvDO0zGXZScB.Sby5bxejCreYki69bGNQGFqhJE2ADJQF0hFe8HkGrZhZEeuOn0CcqqLtJKnZUfPQjKKk6Amo2C7E_780.SxQs.mMQw1FVidHTfoaWMAlg--"
+        }
+    ]
 }

--- a/data/models/1x-PixelSharpen.json
+++ b/data/models/1x-PixelSharpen.json
@@ -35,5 +35,21 @@
     "dataset": "PixelJoint pixel art",
     "datasetSize": 186,
     "pretrainedModelG": "1x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ee304a7e-3c3f-47ba-807b-1deb6efe1559.jpg",
+            "SR": "https://imgsli.com/i/fabc6321-fd2b-4df3-89f9-b0488d3cbe89.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/66b0307c-3da1-4948-9bfc-9900d36b08af.jpg",
+            "SR": "https://imgsli.com/i/9e069afb-a7fd-41a4-8c8e-8f6b3d43337c.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a8a4448c-ecba-47d3-987c-3c0829e99815.jpg",
+            "SR": "https://imgsli.com/i/7a2bbca6-74f9-4f7f-aafd-b237ae42d9b6.jpg"
+        }
+    ]
 }

--- a/data/models/1x-Plants.json
+++ b/data/models/1x-Plants.json
@@ -31,5 +31,21 @@
     "dataset": "plant.zip from OutdoorSceneTrain_v2 upscaled 200% with Preserve Details 2.0",
     "datasetSize": 1036,
     "pretrainedModelG": "1x-NMKD-h264Texturize",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/fe2bacc5-2204-42bc-b3a0-efb8ff1244c9.jpg",
+            "SR": "https://imgsli.com/i/9606ac90-201f-423c-813f-f8fcf0dd93ad.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/05ebf10a-5e01-4b90-80ea-18b624a65bbf.jpg",
+            "SR": "https://imgsli.com/i/afebc5b0-f86a-4c46-b552-29457de4b95a.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/878daac4-a0fe-4c0e-9a82-0d62106f0027.jpg",
+            "SR": "https://imgsli.com/i/2ed9bee1-0822-454f-a824-acf627a05523.jpg"
+        }
+    ]
 }

--- a/data/models/1x-ReFocus-Cleanly.json
+++ b/data/models/1x-ReFocus-Cleanly.json
@@ -29,5 +29,26 @@
     ],
     "dataset": "Anime, manga, and photos",
     "pretrainedModelG": "1x-ReFocus-V3",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a306d854-f2f7-4cc6-9bd4-7c63974bdc20.jpg",
+            "SR": "https://imgsli.com/i/b97a3468-6546-476f-94a9-56bd00c4a329.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/f5bd5da4-fd08-415d-ae93-0095624a1dd5.jpg",
+            "SR": "https://imgsli.com/i/d1a498b2-481b-45b2-af4e-7d642d3f2493.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3d2847a6-94fd-4c75-824a-2a834411e61b.jpg",
+            "SR": "https://imgsli.com/i/b200abd6-802d-42bf-be59-302a3556560d.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/fa25ba2f-2de5-492c-8275-6ad12c1dd781.jpg",
+            "SR": "https://imgsli.com/i/30fe6ca6-4fc0-4c1c-a1a8-5b9c2a63f0e7.jpg"
+        }
+    ]
 }

--- a/data/models/1x-RedImage.json
+++ b/data/models/1x-RedImage.json
@@ -25,5 +25,10 @@
         }
     ],
     "pretrainedModelG": "1x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/5O74rRL.png"
+        }
+    ]
 }

--- a/data/models/1x-RoQ-nRoll.json
+++ b/data/models/1x-RoQ-nRoll.json
@@ -31,5 +31,23 @@
     "trainingHRSize": 32,
     "dataset": "Custom Dataset compressed with RoQ through ffmpeg. Consists of: Just Cause 3, Fallout 76, and Forza Horizon 3",
     "pretrainedModelG": "1x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/911838608879677440/912086092755374200/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/911838608879677440/912084886792314880/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/911838608879677440/912085213859954788/unknown.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/256e40e5-7f93-42b3-9307-f3cf6e769874.jpg",
+            "SR": "https://imgsli.com/i/15daa99a-860d-4f03-9a08-bd36717bd7c1.jpg"
+        }
+    ]
 }

--- a/data/models/1x-SheeepIt.json
+++ b/data/models/1x-SheeepIt.json
@@ -32,5 +32,22 @@
     "trainingHRSize": 96,
     "dataset": "Sheeep release frames and production frames from tenpence in Animation Upscale",
     "datasetSize": 4,
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/903415274521374750/999820017652740176/1658446060.8526323.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/903415274521374750/999821036583391292/1658446301.0955725.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/903415274521374750/999821212718993478/1658446346.8536465.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/903415274521374750/999820756043169803/1658446237.0734627.png"
+        }
+    ]
 }

--- a/data/models/1x-SwatKatsLite.json
+++ b/data/models/1x-SwatKatsLite.json
@@ -34,5 +34,11 @@
     "dataset": "WEB-DL",
     "datasetSize": 5000,
     "pretrainedModelG": "2x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "SR": "https://i.slow.pics/LLmkr1DB.png",
+            "LR": "https://i.slow.pics/PE8sMfOS.png"
+        }
+    ]
 }

--- a/data/models/1x-ToonVHS.json
+++ b/data/models/1x-ToonVHS.json
@@ -7,7 +7,7 @@
         "cartoon",
         "video-frame"
     ],
-    "description": "Category: VHS Tapes\nPurpose: VHS\n\nBest when used on cartoons, it can work on anime. Due to the dataset it does struggle a bit with orange colors and grainy dark spots. This model is meant to be used to clean up the image before using it on a 2x or 4x model.",
+    "description": "Category: VHS Tapes\nPurpose: VHS\n\nBest when used on cartoons, it can work on anime. Due to the dataset it does struggle a bit with orange colors and grainy dark spots. This model is meant to be used to clean up the image before using it on a 2x or 4x model. Example with 2x-BIGOLDIES https://imgsli.com/OTQ0NjM/1/0.",
     "date": "2022-02-06",
     "architecture": "esrgan",
     "size": [
@@ -35,5 +35,26 @@
     "dataset": "An old Cartoon Network VHS Tape upload.",
     "datasetSize": 44,
     "pretrainedModelG": "1x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6ff6089f-83d5-44cc-802b-88322a7c347b.jpg",
+            "SR": "https://imgsli.com/i/8e1e77e6-1407-4d4e-b9cf-b34e89c31884.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3eab369a-22ef-4c8b-b609-bdcf5fd54292.jpg",
+            "SR": "https://imgsli.com/i/4051fb52-7a4f-4d1c-9c35-eda3240cf668.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ec520de0-7402-4c45-a440-50bb181ddec0.jpg",
+            "SR": "https://imgsli.com/i/1c3d0a30-a17f-4503-b88d-c40c6d09bf36.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/2202e52d-b038-4277-8164-0848fbcd6c13.jpg",
+            "SR": "https://imgsli.com/i/b127fc5d-31dc-411d-a54c-3e9694ebf773.jpg"
+        }
+    ]
 }

--- a/data/models/1x-VHS-Sharpen.json
+++ b/data/models/1x-VHS-Sharpen.json
@@ -33,5 +33,26 @@
     "dataset": "4K Blu-Ray movie stills, de-grained and downscaled, and ran through a VCR onto a VHS.",
     "datasetSize": 9384,
     "pretrainedModelG": "1x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/794bbcf3-ad79-48fc-9dda-79bcde6cbadf.jpg",
+            "SR": "https://imgsli.com/i/d842fa32-49de-4d29-81d0-c956b28b087d.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/547f1212-d4a1-4c5f-9844-63d861da6d77.jpg",
+            "SR": "https://imgsli.com/i/7d29ea73-fa59-4e13-8a2d-2a6c51723914.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/98020a65-72b6-4659-b624-f77d64afe189.jpg",
+            "SR": "https://imgsli.com/i/8a6ee8b1-b81e-4514-965e-719b0fc78bb6.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/01d783c0-3141-4a06-ab2c-33e11e1f1498.jpg",
+            "SR": "https://imgsli.com/i/876844ad-356e-46bf-aecf-391fd9c9f03c.jpg"
+        }
+    ]
 }

--- a/data/models/1x-sudo-inpaint-PartialConv2D.json
+++ b/data/models/1x-sudo-inpaint-PartialConv2D.json
@@ -33,5 +33,10 @@
     "trainingOTF": false,
     "dataset": "Full res yande.re images",
     "datasetSize": 9147,
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://edef1.pcloud.com/D4ZhwsKk7ZIA6bT7ZZZ8KH1o7Z3VZZnl0ZXZOyQRZaZZZQOu7ZFhcBkz5jsCBI82KOB0ThAjWd6E4k/th-1333687702-1800x952.png"
+        }
+    ]
 }

--- a/data/models/2x-ATLA-KORRA.json
+++ b/data/models/2x-ATLA-KORRA.json
@@ -35,5 +35,61 @@
     "dataset": "The Legend of Korra first episode DVD frames and BluRay frames.",
     "datasetSize": 436,
     "pretrainedModelG": "2x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/c1b70573-7c10-4fa3-a35e-aa70bd1a3599.jpg",
+            "SR": "https://imgsli.com/i/a36f8683-eed3-41fd-937d-a05f4a632d2b.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ca1198f0-2de0-4b80-b879-2d06d74fe6f1.jpg",
+            "SR": "https://imgsli.com/i/fd7d857c-23a3-4ee5-a535-897fc51ef2fb.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/643a791e-8a00-4223-b258-bd8bd97109b1.jpg",
+            "SR": "https://imgsli.com/i/7ff71adb-63c0-4591-b61e-d40d1aa323cd.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/29f1e986-e70d-4402-bad8-1fa987e50297.jpg",
+            "SR": "https://imgsli.com/i/5d9317df-891a-4eb0-b681-69859af18efa.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/505349cb-2ae8-4aef-9237-db70df6318ce.jpg",
+            "SR": "https://imgsli.com/i/c5968bac-0d36-4e6b-a1bf-cd5de8bfd732.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/859cbab3-c85e-497e-8844-c528b30a778d.jpg",
+            "SR": "https://imgsli.com/i/ec2467ab-9147-4232-b3c7-af6e502292d0.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/e902c078-446a-4773-96ef-479dad9d3cee.jpg",
+            "SR": "https://imgsli.com/i/f284edee-b23f-476b-824a-7744f167c9ec.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/cab143a5-4f90-494e-9071-eaaa3de8f684.jpg",
+            "SR": "https://imgsli.com/i/2d0bacdb-de74-4375-8e44-391538385260.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/56c769d1-b750-4c7c-96f0-505cf2b5bcfc.jpg",
+            "SR": "https://imgsli.com/i/50cb4ee5-9110-4721-90e8-9cf3398784bb.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/cb21dc58-d6f2-4ba7-9674-24f967b80502.jpg",
+            "SR": "https://imgsli.com/i/24129fed-4d46-4107-942c-6de1468ab747.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/684ce8ab-c394-49ea-bde6-15f1b66bb487.jpg",
+            "SR": "https://imgsli.com/i/e511df3a-d9f3-4e3b-b953-932c80917579.jpg"
+        }
+    ]
 }

--- a/data/models/2x-AnimeClassics-UltraLite.json
+++ b/data/models/2x-AnimeClassics-UltraLite.json
@@ -36,5 +36,26 @@
     "dataset": "Blu-ray Remaster HRs/Generated LRs, and DVD Sources",
     "datasetSize": 4222,
     "pretrainedModelG": "2x-DigitalFilmV5-Lite",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/67ffbc84-2cda-413e-a8b2-0f63575f0568.jpg",
+            "SR": "https://imgsli.com/i/1d6dc4c6-c9bf-4c72-8384-e8ca83805783.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ed82e35f-dfa3-46d5-93f6-5185287f8424.jpg",
+            "SR": "https://imgsli.com/i/bbdc7811-caf4-4a3f-95e0-1444d9133f24.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a188099f-203a-4744-9726-d2fe7bf1fa9c.jpg",
+            "SR": "https://imgsli.com/i/1241a4ae-2186-431e-ac8d-f4d83fcdeff9.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/059bf992-daf7-4ec5-902e-c56812d28976.jpg",
+            "SR": "https://imgsli.com/i/c19f75b9-322c-445b-a917-08c75476ed5b.jpg"
+        }
+    ]
 }

--- a/data/models/2x-BIGOLDIES.json
+++ b/data/models/2x-BIGOLDIES.json
@@ -38,5 +38,11 @@
     "dataset": "LR from severals dvd anime and HR from bluray anime",
     "datasetSize": 2300,
     "pretrainedModelG": "2x-PSNR",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/efa5b8a8-e6be-4a46-901f-1fc7a27d43f4.jpg",
+            "SR": "https://imgsli.com/i/ac9b067e-b28a-49d2-85b6-7a7219fc4a9b.jpg"
+        }
+    ]
 }

--- a/data/models/2x-Bubble-AnimeScale-Compact-v1.json
+++ b/data/models/2x-Bubble-AnimeScale-Compact-v1.json
@@ -35,5 +35,21 @@
     "trainingOTF": false,
     "dataset": "SFW and NSFW anime frames that were sourced from Blu Ray discs and high bitrate Web releases. These were then degraded with various different methods.",
     "datasetSize": 1845,
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/9ee71bd5-6dc3-42fc-8415-2265b2fd02ca.jpg",
+            "SR": "https://imgsli.com/i/ac8e804a-3833-4d4b-8db1-8877c0ce3ae5.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/149fe145-36fe-4df0-81ab-20fd6c33a922.jpg",
+            "SR": "https://imgsli.com/i/8958fab1-38e5-46ad-aee5-4f8715948e32.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b3133b2f-1896-45b4-9149-f5dfd4ab1d34.jpg",
+            "SR": "https://imgsli.com/i/4000a5da-18d4-4f1a-bfff-1170dccd1ce1.jpg"
+        }
+    ]
 }

--- a/data/models/2x-Bubble-AnimeScale-SwinIR-Small-v1.json
+++ b/data/models/2x-Bubble-AnimeScale-SwinIR-Small-v1.json
@@ -36,5 +36,21 @@
     "trainingOTF": false,
     "dataset": "SFW and NSFW anime frames that were sourced from Blu Ray discs. These were then degraded with various different methods.",
     "datasetSize": 1042,
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/91b42308-150c-4115-8e99-463f07bf704b.jpg",
+            "SR": "https://imgsli.com/i/2203a3ca-7b66-4353-83b6-ac5411e547cd.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/f19bd668-41cf-4f2e-9355-ec852a9febfd.jpg",
+            "SR": "https://imgsli.com/i/b14824c3-4b94-47d0-8b8b-421bf084c0ca.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/298ce01b-deb0-4f69-ac1d-2dfd88ba5a9e.jpg",
+            "SR": "https://imgsli.com/i/6aa16dc3-e7ad-47a3-ae75-7a2729dc0095.jpg"
+        }
+    ]
 }

--- a/data/models/2x-CGIMaster-v1.json
+++ b/data/models/2x-CGIMaster-v1.json
@@ -32,5 +32,11 @@
     "dataset": "Full frames of Dragon Prince as HQ and for LR frames compressed with YouTube compression",
     "datasetSize": 1800,
     "pretrainedModelG": "2x-SHARP-ANIME-V2",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a520a071-c4fa-48dc-8331-ea87d8a46b3c.jpg",
+            "SR": "https://imgsli.com/i/3c24239e-34e3-44b8-8ddf-4a9dbcfe5bce.jpg"
+        }
+    ]
 }

--- a/data/models/2x-DigiGradients-Lite.json
+++ b/data/models/2x-DigiGradients-Lite.json
@@ -31,5 +31,16 @@
     "trainingBatchSize": 4,
     "trainingHRSize": 128,
     "dataset": "Images from The Batman (series) HD WEB-DL.",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/2c12ce46-c1a5-4f01-a0f9-83b738d5f4da.jpg",
+            "SR": "https://imgsli.com/i/76b634ab-fce6-4e07-a1f4-92ccfdad9527.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/5bc77ea7-20d7-4d03-bf0f-c29187e8f58c.jpg",
+            "SR": "https://imgsli.com/i/a52394da-ec58-4a1c-8061-523310645505.jpg"
+        }
+    ]
 }

--- a/data/models/2x-DigitalFilmV5-Lite.json
+++ b/data/models/2x-DigitalFilmV5-Lite.json
@@ -31,5 +31,36 @@
     "trainingHRSize": 256,
     "dataset": "DB/DBZ/DBGT Dragon Box DVD frames, upscaled with various models such as DigitalFrames2.0, FilmFrames677k, SharpAnimeV2, and manually edited to only show the best parts of each model. I call it image stacking.",
     "datasetSize": 561,
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/258944e0-10a4-466f-b2ca-5bb346d58790.jpg",
+            "SR": "https://imgsli.com/i/6ac27b55-8061-4b15-8963-67d56f614734.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/4329b941-3027-499d-889b-421efa1a1219.jpg",
+            "SR": "https://imgsli.com/i/b3367a75-1884-4262-9cf8-c8bc22bb8b9e.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/7af49732-87da-46c1-bf62-1ce8f8fb2a9d.jpg",
+            "SR": "https://imgsli.com/i/221ba007-13a1-4360-bab9-95febb2055c4.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/895d7378-e1f4-4316-80a1-a9ad5247047f.jpg",
+            "SR": "https://imgsli.com/i/052f599e-15a3-40db-85c2-c53defa5d3c8.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/45b4d537-607d-4e68-aae4-43c007bdb1e5.jpg",
+            "SR": "https://imgsli.com/i/c1b952a5-6fa8-4116-a665-ea5444af8017.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/28c220e1-0d09-40ae-8e3b-6c4d75184544.jpg",
+            "SR": "https://imgsli.com/i/1f1c0280-26ba-4e9a-b42e-acad6a28e2b7.jpg"
+        }
+    ]
 }

--- a/data/models/2x-DigitalFlim-SuperUltraCompact.json
+++ b/data/models/2x-DigitalFlim-SuperUltraCompact.json
@@ -29,5 +29,26 @@
             ]
         }
     ],
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/0f07cea1-1b8c-4293-9d01-aacb7ebec093.jpg",
+            "SR": "https://imgsli.com/i/078f12e0-4460-4b1b-a252-bb7e15929478.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/46556b8d-ff46-4358-ae9c-46a97af41c30.jpg",
+            "SR": "https://imgsli.com/i/8b12de2f-cda7-4cb9-906a-80276109655e.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/04b51965-faa9-443d-9252-bb672c84e70f.jpg",
+            "SR": "https://imgsli.com/i/8fdbb673-189d-46db-af89-9fe3389fffd9.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/c4cc9894-f5ff-443f-9d4e-4b56b3375d23.jpg",
+            "SR": "https://imgsli.com/i/6fb757fc-f029-455e-a45b-48ac8e7eae53.jpg"
+        }
+    ]
 }

--- a/data/models/2x-DigitoonLite.json
+++ b/data/models/2x-DigitoonLite.json
@@ -37,5 +37,36 @@
     "dataset": "Blu-ray, HDTV, and DVD",
     "datasetSize": 21000,
     "pretrainedModelG": "2x-DigiGradients-Lite",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ea39f354-9268-4991-aa1c-ee43e2357e13.jpg",
+            "SR": "https://imgsli.com/i/32a72e9b-61ed-4b44-913b-baaaae4f8d88.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/13de87e6-8686-4287-a4a8-7ccc4593df8c.jpg",
+            "SR": "https://imgsli.com/i/13e99dbc-db10-4962-9369-44013d68a3f0.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/badd9f62-d419-41bf-ae58-839f043d056c.jpg",
+            "SR": "https://imgsli.com/i/86398576-e707-4718-8c45-90d2de44338b.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/945b05e0-57a8-4a41-b6f8-1354b08d0882.jpg",
+            "SR": "https://imgsli.com/i/927d6122-5b78-4ded-8e7a-18a4ab3710e6.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/00315afc-1780-4680-8e46-b50e9cdc7425.jpg",
+            "SR": "https://imgsli.com/i/cb4837b1-2dd9-402b-a1da-265cc6490437.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/062b8c94-2f39-482a-a323-93174c679b30.jpg",
+            "SR": "https://imgsli.com/i/cfa251f3-a3dc-418f-99af-b7b1f1973213.jpg"
+        }
+    ]
 }

--- a/data/models/2x-Futsuu-Anime.json
+++ b/data/models/2x-Futsuu-Anime.json
@@ -33,5 +33,56 @@
     "dataset": "Frames from a wide variety of animated sources",
     "datasetSize": 2661,
     "pretrainedModelG": "2x-Compact-Pretrain",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/c3ace82d-2dc8-4e43-923e-724f63fd27ac.jpg",
+            "SR": "https://imgsli.com/i/1744d07b-d2fe-4268-8db0-611953078454.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a7a2f578-2dc7-4993-b483-3b8e69511ae8.jpg",
+            "SR": "https://imgsli.com/i/c9f114b3-a6fe-42c5-a5f5-90f79a75eadc.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/9c73da28-fdd4-494b-8456-d4d7824b2e47.jpg",
+            "SR": "https://imgsli.com/i/4ed6877f-07b8-4f96-9c3b-24b83dabaeac.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/7a477716-1932-4faf-8d3a-e65c8ba7fca5.jpg",
+            "SR": "https://imgsli.com/i/63d179b4-9d88-4455-a284-acc27e3831a9.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/dc6c7907-a3ae-4a86-b974-edf9dda9087d.jpg",
+            "SR": "https://imgsli.com/i/e1f21824-c045-4480-b636-d6753ffb2bd5.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ebed6316-7598-434b-91b7-d5e8f4c3306c.jpg",
+            "SR": "https://imgsli.com/i/94a0716c-060a-49d3-b9fe-1596898c6077.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/54997675-66e2-4f40-8421-8f705e87d25c.jpg",
+            "SR": "https://imgsli.com/i/7c8326d3-0512-4d62-a035-ecdee71ab3c2.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a2524dee-a607-411f-97e7-9e78202bf1f2.jpg",
+            "SR": "https://imgsli.com/i/b49b4373-5637-450c-9063-a563a6460620.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1d7f0612-b21a-4e5c-9df6-ae17c23b0187.jpg",
+            "SR": "https://imgsli.com/i/8bedb358-6f12-4a8a-8bd4-32fabc77e962.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/2e4947d8-7f4f-4a02-acef-6f5ba98fa98d.jpg",
+            "SR": "https://imgsli.com/i/b4a3a844-fd66-4f1a-926f-8ef70dc2124f.jpg"
+        }
+    ]
 }

--- a/data/models/2x-GT-evA.json
+++ b/data/models/2x-GT-evA.json
@@ -36,5 +36,22 @@
     "dataset": "German blu ray of detective Conan and other shows",
     "datasetSize": 2710,
     "pretrainedModelG": "2x-Compact-Pretrain",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1051753650051088384/test_6.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1051753650428588092/test_2.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1051753651011600444/test3.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1051753651376504842/test_3.png"
+        }
+    ]
 }

--- a/data/models/2x-KemonoScale-v2.json
+++ b/data/models/2x-KemonoScale-v2.json
@@ -31,5 +31,10 @@
     "dataset": "@irodori7 twitter, irodori KF artbook scans, KF guidebook scans, custom renders in similar style",
     "datasetSize": 251,
     "pretrainedModelG": "2x-CGIMaster-v1",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/705815801290293329/850614850735439892/unknown.png"
+        }
+    ]
 }

--- a/data/models/2x-LD-Anime-Compact.json
+++ b/data/models/2x-LD-Anime-Compact.json
@@ -39,5 +39,46 @@
     "dataset": "DVD frames upscaled using Skr's LD-Anime model and color corrected.",
     "datasetSize": 1720,
     "pretrainedModelG": "2x-Compact-Pretrain",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/c6ec6b06-f152-403a-8b3f-4485daba60b2.jpg",
+            "SR": "https://imgsli.com/i/659879c5-6da4-4a34-a858-4134d74abf64.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/89fe28c2-aef7-478b-8d65-77ae25d2337b.jpg",
+            "SR": "https://imgsli.com/i/ed3b882a-95a3-4927-8eae-63d04ec13260.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/08962037-2ab5-4885-97c0-0375d02c2434.jpg",
+            "SR": "https://imgsli.com/i/38d73a88-5e5a-4fe5-bb64-6896ead07291.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b38407f5-0aaf-429a-9722-c5432a030562.jpg",
+            "SR": "https://imgsli.com/i/ef301244-f1ce-46dc-854b-1faeb13d5f8d.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6ff47851-3b62-448e-8ec1-f854dc30012f.jpg",
+            "SR": "https://imgsli.com/i/9f828665-0e7c-4046-9674-4238698438a7.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b3825587-1a1e-4a9a-a697-84dbe62d78ea.jpg",
+            "SR": "https://imgsli.com/i/80bcc4b0-d222-4f7b-be13-653732dbec67.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/18024b98-56f6-4d48-906d-4c2f265cdf1b.jpg",
+            "SR": "https://imgsli.com/i/b4fd9e06-38c6-449a-a78d-7a1fc3191a88.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/72b2ae99-f117-41c4-baaf-d49e2ae9dc33.jpg",
+            "SR": "https://imgsli.com/i/cc3c9e26-db55-41f0-889c-20b4afa792c9.jpg"
+        }
+    ]
 }

--- a/data/models/2x-LD-Anime-Skr-v1-0.json
+++ b/data/models/2x-LD-Anime-Skr-v1-0.json
@@ -38,5 +38,101 @@
     "dataset": "Laserdisc rips and remastered Blu-rays.",
     "datasetSize": 50000,
     "pretrainedModelG": "2x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/e7a97568-4c76-4277-a0a2-c86cb2e390e6.jpg",
+            "SR": "https://imgsli.com/i/625bb3c7-c25a-497f-bb06-fccf859c5882.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/c3b2bf2c-4a38-4a5a-b001-75ae07d7c7b6.jpg",
+            "SR": "https://imgsli.com/i/b053b1ab-190f-45a2-99eb-8014c6011319.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/fe853cd2-cefd-4a60-8da0-3a5a8a55161d.jpg",
+            "SR": "https://imgsli.com/i/0262b936-a1e1-47f0-a9da-30b1a4454012.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3072b720-230c-47f9-ac06-bd2ea71127b8.jpg",
+            "SR": "https://imgsli.com/i/64471925-2a15-4428-b16b-dda0db08fdc5.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/e56ee652-0fad-45db-ac00-73bbad9a10c1.jpg",
+            "SR": "https://imgsli.com/i/e26e81ad-c275-4273-ad91-a8f57f047693.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/16b95bf7-664e-4544-b09c-ac786af0b41b.jpg",
+            "SR": "https://imgsli.com/i/da8d9ae6-ce46-49d8-aebd-90fadd8e0605.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/583be047-29c5-43e7-a7c9-50c89de4b3db.jpg",
+            "SR": "https://imgsli.com/i/9e825ef1-81bc-4084-be3a-ab9595439441.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/bd04e1bd-4289-4806-9441-d65bab76147e.jpg",
+            "SR": "https://imgsli.com/i/4f7b4067-e626-46b7-9e22-9e2d9be83809.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/9b651a1d-5b39-4b3e-b16d-697db1497632.jpg",
+            "SR": "https://imgsli.com/i/7604bca8-cf5f-49fb-bb57-aee7f04b1c37.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/4a31b83a-aabb-4568-84f5-3de240b42fba.jpg",
+            "SR": "https://imgsli.com/i/1e77f219-0288-45cc-8b98-c25f3c7b0c9c.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/f1a25e4d-6161-41b5-90a3-c594b09aff83.jpg",
+            "SR": "https://imgsli.com/i/68990dc6-effa-49ac-89a4-654f7a284a88.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/c6ec6b06-f152-403a-8b3f-4485daba60b2.jpg",
+            "SR": "https://imgsli.com/i/2a859510-9eeb-4b1b-b1ad-6755e197cc2c.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/89fe28c2-aef7-478b-8d65-77ae25d2337b.jpg",
+            "SR": "https://imgsli.com/i/3bebd858-843e-4bc5-9acf-8c7b39fe1d50.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/08962037-2ab5-4885-97c0-0375d02c2434.jpg",
+            "SR": "https://imgsli.com/i/44937a61-838b-4981-8587-d52125571a89.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b38407f5-0aaf-429a-9722-c5432a030562.jpg",
+            "SR": "https://imgsli.com/i/b36a8f87-6d22-43e0-b189-42741cd4c1fa.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6ff47851-3b62-448e-8ec1-f854dc30012f.jpg",
+            "SR": "https://imgsli.com/i/df5553e9-1b29-4d09-834a-93812c0b6e4a.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b3825587-1a1e-4a9a-a697-84dbe62d78ea.jpg",
+            "SR": "https://imgsli.com/i/d60095ea-d90c-4a9f-bccd-390aa447bb2e.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/18024b98-56f6-4d48-906d-4c2f265cdf1b.jpg",
+            "SR": "https://imgsli.com/i/6f2353e3-c551-4f39-a861-7d6beb9e751c.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/72b2ae99-f117-41c4-baaf-d49e2ae9dc33.jpg",
+            "SR": "https://imgsli.com/i/f6b30ef2-d73e-4bdd-8711-0e22d2852280.jpg"
+        }
+    ]
 }

--- a/data/models/2x-Loyaldk-SuperPonyV1-0.json
+++ b/data/models/2x-Loyaldk-SuperPonyV1-0.json
@@ -33,5 +33,31 @@
     "trainingOTF": false,
     "dataset": "All MLP: FiM Episodes using scene detection frame grabbing as well as selected Prores4444 content https://shimmermare.com/4k-pony-project. Ran 2 separate datasets. LR's Include H264 Compression, Halo, Sharpening Halo/Fringe, Gaussian Blur, Dot crawl, Uniform Noise, Rainbow",
     "pretrainedModelG": "2x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/fe8ccca1-3469-478f-b1a2-607580cacb56.jpg",
+            "SR": "https://imgsli.com/i/47b72c28-691c-4c88-a5f7-0e4bad3d921f.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/fd84cb99-9d1c-49ed-a26a-27ece79859bf.jpg",
+            "SR": "https://imgsli.com/i/1bd3637b-21b9-4e31-9366-c7df4dafc44a.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b8426234-205e-4b4e-9e58-fa73eb2f183f.jpg",
+            "SR": "https://imgsli.com/i/691d59b6-d384-4013-9bcc-8d9abb1d42c9.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/8d575f56-81a7-4b0c-980c-2b977abae16d.jpg",
+            "SR": "https://imgsli.com/i/c0740307-d8b5-4c7c-8e46-862a52496b39.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/5a85e782-6a93-45bc-9d41-d7652f6362fd.jpg",
+            "SR": "https://imgsli.com/i/08f8e3e4-f132-417a-b565-bcfe2c480a93.jpg"
+        }
+    ]
 }

--- a/data/models/2x-MangaScaleV3.json
+++ b/data/models/2x-MangaScaleV3.json
@@ -27,5 +27,11 @@
         }
     ],
     "dataset": "Self curated custom manga dataset",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "SR": "https://imgsli.com/i/54b345f3-fcae-4c13-b630-b627efdfa97f.jpg",
+            "LR": "https://imgsli.com/i/ec1411e8-24c1-464f-89af-57c2aadc76d9.jpg"
+        }
+    ]
 }

--- a/data/models/2x-SHARP-ANIME-V1.json
+++ b/data/models/2x-SHARP-ANIME-V1.json
@@ -33,5 +33,11 @@
     "dataset": "lr is from anime version dvd and HR from anime blu-ray",
     "datasetSize": 7738,
     "pretrainedModelG": "2x-PSNR",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/738a29b1-fd68-4011-bf0c-0c2cc32a9722.jpg",
+            "SR": "https://imgsli.com/i/cefa4419-8c97-4257-895b-f2eccaf52df7.jpg"
+        }
+    ]
 }

--- a/data/models/2x-SHARP-ANIME-V2.json
+++ b/data/models/2x-SHARP-ANIME-V2.json
@@ -34,5 +34,11 @@
     "dataset": "LR from severals dvd anime and HR from bluray anime",
     "datasetSize": 3600,
     "pretrainedModelG": "2x-PSNR",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/643d215f-7b57-4078-beaa-21efa8d61921.jpg",
+            "SR": "https://imgsli.com/i/0379f105-59d3-4b54-ab2e-f09816c30905.jpg"
+        }
+    ]
 }

--- a/data/models/2x-SwatKats.json
+++ b/data/models/2x-SwatKats.json
@@ -35,5 +35,41 @@
     "dataset": "WEB-DL",
     "datasetSize": 5000,
     "pretrainedModelG": "2x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/2a200609-06f3-4887-b573-b35354ce5ef3.jpg",
+            "SR": "https://imgsli.com/i/4f083002-1a57-4b82-8eec-e06964b5e9de.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/d996f787-c0e6-4bd7-b277-ad2f46fc1a78.jpg",
+            "SR": "https://imgsli.com/i/4bae7108-019a-43e8-b32a-e91863678b30.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/5fa7e7e0-37d9-4146-90e0-4c52957fb7b0.jpg",
+            "SR": "https://imgsli.com/i/e41b6894-f9a8-474a-a8e2-82ff01061a69.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a4465a1b-eed1-4eef-836f-94a7968edb9e.jpg",
+            "SR": "https://imgsli.com/i/ed237fef-9582-4844-b474-ec01481a65b8.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/edf1e978-1fb7-48af-8dd4-5dbf7912b096.jpg",
+            "SR": "https://imgsli.com/i/818b5967-e484-4556-a9be-de3a0c047908.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/23229799-277d-4bd6-b46b-a56ee1c5b8c1.jpg",
+            "SR": "https://imgsli.com/i/aa5d88af-efab-4975-9fe6-e0bb7e058472.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/721eb494-19ed-4d82-94b4-d90b44ff6636.jpg",
+            "SR": "https://imgsli.com/i/e7f5983c-d562-4443-9904-12b04f7d5819.jpg"
+        }
+    ]
 }

--- a/data/models/2x-UniScale-CartoonRestore-lite.json
+++ b/data/models/2x-UniScale-CartoonRestore-lite.json
@@ -35,5 +35,34 @@
     "trainingBatchSize": 4,
     "trainingHRSize": 64,
     "dataset": "Custom Dataset consisting of lossless 4k frames from Metal Arms: Glitch in the System, Just Cause 3, Dirt 3, Forza Horizon 3, Sleeping Dogs, ATLA DVD, and self-edited photos from SignatureEdits",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/880826637543964712/882136618461458462/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/880826637543964712/882136455999262750/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/880826637543964712/882136979410673684/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/649861104645701637/882121519973666886/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/649861104645701637/882124248368427078/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/880826637543964712/882110147676221480/Spongebob_UniScale_CartoonRestore.mp4"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/547949806761410560/881971445813633044/Spongebob_Original.mp4"
+        }
+    ]
 }

--- a/data/models/2x-VimeoScale-Unet.json
+++ b/data/models/2x-VimeoScale-Unet.json
@@ -28,5 +28,21 @@
     "trainingBatchSize": 13,
     "trainingHRSize": 128,
     "dataset": "Combination of Collected Vimeo scenes (CG, realistic/video, movie trailers, and motion graphics) at original quality and REDS_sharp",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b52eb823-92aa-417a-ac5d-87d88e9be5fe.jpg",
+            "SR": "https://imgsli.com/i/a183a56f-c56f-4953-b472-f0f22c584e8f.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/7c095521-766d-4152-b252-7625c4a1952e.jpg",
+            "SR": "https://imgsli.com/i/97c54f00-92a5-4655-bcbb-3a4ed63b84d9.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/dddb002e-3787-4deb-8ae5-62024e86ccde.jpg",
+            "SR": "https://imgsli.com/i/a5f5300f-d5d6-454a-b608-9180061a0c8a.jpg"
+        }
+    ]
 }

--- a/data/models/2x-anifilm-compact.json
+++ b/data/models/2x-anifilm-compact.json
@@ -32,5 +32,20 @@
     "dataset": "Dragon Ball Z Movies",
     "datasetSize": 2836,
     "pretrainedModelG": "2x-Compact-Pretrain",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/903415274521374750/1004152057739087972/1659478894.4425747.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/52e34ef6-6794-43de-a888-3998f7cf1f26.jpg",
+            "SR": "https://imgsli.com/i/2d50661a-1aab-48dd-b494-ecad012e8f6d.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ad0028d2-1739-4c67-b3d1-fb8d1868fc54.jpg",
+            "SR": "https://imgsli.com/i/172e41a4-85e3-4952-9927-ae13c42fff46.jpg"
+        }
+    ]
 }

--- a/data/models/2x-cainliteanime.json
+++ b/data/models/2x-cainliteanime.json
@@ -5,7 +5,7 @@
     "tags": [
         "anime"
     ],
-    "description": "Category: Pretrained SOFVSR Models\nPurpose: Anime - interpolation",
+    "description": "Category: Pretrained SOFVSR Models\nPurpose: Anime - interpolation\n\nSample video: https://cdn.discordapp.com/attachments/724353640521007145/873861876352704533/1.webm",
     "date": "2021-08-06",
     "architecture": "cain",
     "size": null,

--- a/data/models/2x-explodV1.json
+++ b/data/models/2x-explodV1.json
@@ -5,7 +5,7 @@
     "tags": [
         "anime"
     ],
-    "description": "Category: Pretrained SOFVSR Models\nPurpose: Animethemes\n\nI think one of sharpest models for anime\n\nPlz don't steal without credits, k thx.",
+    "description": "Category: Pretrained SOFVSR Models\nPurpose: Animethemes\n\nI think one of sharpest models for anime. Sample video: https://cdn.discordapp.com/attachments/579685650824036387/1002663424695750686/output.mp4\n\nPlz don't steal without credits, k thx.",
     "date": "2022-07-29",
     "architecture": "cain-yuv",
     "size": null,

--- a/data/models/2x-fidelbd-pokemodel.json
+++ b/data/models/2x-fidelbd-pokemodel.json
@@ -33,5 +33,16 @@
     "trainingHRSize": 128,
     "dataset": "Made with images from the first episode of pokemon released on blu ray for the HRs and 112.5% upscaled images for the LRs to match 1/2x the HRs.",
     "pretrainedModelG": "2x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/377d317d-43ad-4314-9d7a-1280bc527fb0.jpg",
+            "SR": "https://imgsli.com/i/499b1f31-4df3-4f75-b20f-b0175881e85c.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/377d317d-43ad-4314-9d7a-1280bc527fb0.jpg",
+            "SR": "https://imgsli.com/i/02dba0ed-bce9-4d8c-9597-a0503d9e55b4.jpg"
+        }
+    ]
 }

--- a/data/models/2x-pokemodel-lite.json
+++ b/data/models/2x-pokemodel-lite.json
@@ -33,5 +33,31 @@
     "trainingHRSize": 128,
     "dataset": "Images from pokemon episodes",
     "datasetSize": 268,
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/d7f19d07-aeb2-429b-9d56-1105747bc4d0.jpg",
+            "SR": "https://imgsli.com/i/51ae153f-ccf5-4366-8d66-1aab3d1bf6cc.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3d7b6cef-e79d-4c75-9041-8a16cf013ccf.jpg",
+            "SR": "https://imgsli.com/i/2c25da10-d945-48f2-a629-27d70add93ce.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6674c30a-2ca0-4563-923b-9f3773127f3e.jpg",
+            "SR": "https://imgsli.com/i/155811cc-d574-4a6e-824d-a5d4221bf734.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/946a971e-669e-4ea9-a50f-cd3b3fca7aa7.jpg",
+            "SR": "https://imgsli.com/i/fcaafb13-c408-4671-ad48-e123c2941f7d.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/5aa76b31-c770-4509-9a19-ac54fa70f603.jpg",
+            "SR": "https://imgsli.com/i/4a886d04-9fed-4dcf-9c85-bd53d661a4b9.jpg"
+        }
+    ]
 }

--- a/data/models/2x-rvpV1.json
+++ b/data/models/2x-rvpV1.json
@@ -5,7 +5,7 @@
     "tags": [
         "pretrained"
     ],
-    "description": "Category: Pretrained SOFVSR Models\nPurpose: Video Frame Interpolation for anime openings\nPretrained: My ~~first~~ (ok technically second) attempt to create a video frame interpolation model and I like how it turned out. To use it, you can either use https://gitlab.com/hubert.sontowski2007/cainapp, https://github.com/styler00dollar/Colab-CAIN or the bot in [Game Upscale] (model called rvpv1 there, just use --model rvpv1). Some demo videos in pcloud, but you need to download them. The web player seems to playback in low fps. The architecture is mainly the same to the original CAIN, but i modified the padding to be zero padding instead. ``.pt`` means JIT model, `.pth`, means normal pytorch model. Architecture file is in pcloud as well. And no, no cupscale or flowframes.",
+    "description": "Category: Pretrained SOFVSR Models\nPurpose: Video Frame Interpolation for anime openings\nPretrained: My ~~first~~ (ok technically second) attempt to create a video frame interpolation model and I like how it turned out. To use it, you can either use https://gitlab.com/hubert.sontowski2007/cainapp, https://github.com/styler00dollar/Colab-CAIN or the bot in [Game Upscale] (model called rvpv1 there, just use --model rvpv1). Some demo videos in pcloud, but you need to download them. The web player seems to playback in low fps. The architecture is mainly the same to the original CAIN, but i modified the padding to be zero padding instead. ``.pt`` means JIT model, `.pth`, means normal pytorch model. Architecture file is in pcloud as well. And no, no cupscale or flowframes.\n\nSample video: https://files.catbox.moe/xiq9vi.mp4",
     "date": "2021-09-14",
     "architecture": "cain",
     "size": null,

--- a/data/models/2x-sudo-RealESRGAN-Dropout.json
+++ b/data/models/2x-sudo-RealESRGAN-Dropout.json
@@ -31,5 +31,26 @@
     ],
     "trainingIterations": 3799042,
     "pretrainedModelG": "2x-sudo-RealESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/990323693660033045/jpg_compare.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/990323694196916275/test2_compare.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/990323694561816606/f4_compare.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/990323695186763884/test_compare.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/990323695601987584/f2_compare.png"
+        }
+    ]
 }

--- a/data/models/2x-sudo-RealESRGAN.json
+++ b/data/models/2x-sudo-RealESRGAN.json
@@ -30,5 +30,26 @@
         }
     ],
     "trainingIterations": 3332758,
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/990323693660033045/jpg_compare.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/990323694196916275/test2_compare.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/990323694561816606/f4_compare.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/990323695186763884/test_compare.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/990323695601987584/f2_compare.png"
+        }
+    ]
 }

--- a/data/models/2x-sudo-UltraCompact.json
+++ b/data/models/2x-sudo-UltraCompact.json
@@ -32,5 +32,18 @@
     ],
     "trainingIterations": 1121175,
     "pretrainedModelG": "2x-realesrganv2-animevideo-xsx2",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/980550564725260358/compare.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/980550565354410066/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/980550565723529226/compare2.webp"
+        }
+    ]
 }

--- a/data/models/2x-sudo-rife4-testV1.json
+++ b/data/models/2x-sudo-rife4-testV1.json
@@ -25,5 +25,10 @@
         }
     ],
     "trainingIterations": 269662,
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/990345004260151296/ngnl_sudorife.mp4"
+        }
+    ]
 }

--- a/data/models/4x-AnimeSharp-lite.json
+++ b/data/models/4x-AnimeSharp-lite.json
@@ -33,5 +33,18 @@
     "dataset": "Used only thisanimedoesnotexist, upscaled with 4x-AnimeSharp",
     "datasetSize": 2700,
     "pretrainedModelG": "2x-UniScale-CartoonRestore-lite",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/547949405949657100/941776512049360986/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/547949405949657100/941770824543797268/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/903415274521374750/941779970013925506/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-AnimeSharp.json
+++ b/data/models/4x-AnimeSharp.json
@@ -30,5 +30,22 @@
     ],
     "trainingHRSize": 128,
     "dataset": "Custom",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/549525506585001985/941432207917084743/Clipboard-comparison.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/549525506585001985/941432638206541825/test_pic-comparison.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/903415274521374750/925533775616696340/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://media.discordapp.net/attachments/556604553424928768/925526934555881532/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-BigFace-v3.json
+++ b/data/models/4x-BigFace-v3.json
@@ -28,5 +28,21 @@
         }
     ],
     "pretrainedModelG": "4x-BigFace",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/12e0307a-f386-4f54-a472-bfaa2eb4cc9c.jpg",
+            "SR": "https://imgsli.com/i/dfdf08c3-f2f8-49be-8007-d95de9dc26c0.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/85188c01-b4e5-4b05-9a97-f1d1516fdba5.jpg",
+            "SR": "https://imgsli.com/i/6ca08e9b-326d-4c98-86e9-d03b2ef7ecf1.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a933df14-4571-4322-85b0-6d35345d7d34.jpg",
+            "SR": "https://imgsli.com/i/ffa6f3aa-2018-4b2f-8fa3-75c216b712d8.jpg"
+        }
+    ]
 }

--- a/data/models/4x-BigFace.json
+++ b/data/models/4x-BigFace.json
@@ -27,5 +27,21 @@
             ]
         }
     ],
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/12e0307a-f386-4f54-a472-bfaa2eb4cc9c.jpg",
+            "SR": "https://imgsli.com/i/8825b6c9-d173-40bf-ae8c-da9a0062cffc.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/85188c01-b4e5-4b05-9a97-f1d1516fdba5.jpg",
+            "SR": "https://imgsli.com/i/29a979f1-d8be-4cb0-9294-3904f0183af5.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a933df14-4571-4322-85b0-6d35345d7d34.jpg",
+            "SR": "https://imgsli.com/i/93768c5f-fac0-4683-b64c-3df890cb7cbc.jpg"
+        }
+    ]
 }

--- a/data/models/4x-BooruGan-600k.json
+++ b/data/models/4x-BooruGan-600k.json
@@ -32,5 +32,18 @@
     "trainingHRSize": 128,
     "dataset": "I used highres artworks from gelbooru",
     "pretrainedModelG": "4x-Manga109Attempt",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/913500929012150323/4f012e36d686033b274261295da89b32-comparison.jpg"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/913500929356070912/256x256fdbb-comparison.jpg"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/913500929649688617/franky-super-810x456-comparison.jpg"
+        }
+    ]
 }

--- a/data/models/4x-BooruGan-650k.json
+++ b/data/models/4x-BooruGan-650k.json
@@ -32,5 +32,18 @@
     "trainingHRSize": 128,
     "dataset": "I used highres artworks from gelbooru",
     "pretrainedModelG": "4x-Manga109Attempt",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/913500929012150323/4f012e36d686033b274261295da89b32-comparison.jpg"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/913500929356070912/256x256fdbb-comparison.jpg"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/913500929649688617/franky-super-810x456-comparison.jpg"
+        }
+    ]
 }

--- a/data/models/4x-CountryRoads.json
+++ b/data/models/4x-CountryRoads.json
@@ -32,5 +32,22 @@
     "dataset": "Streetside photos taken on Samsung Galaxy A21 camera with all enhancements disabled using GCam and FreeDCam, downscaled to 1024",
     "datasetSize": 236,
     "pretrainedModelG": "4x-PSNR",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/547949806761410560/880291337373618236/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/880291340301254657/880303552315146340/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://media.discordapp.net/attachments/547949806761410560/880290211026853918/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://media.discordapp.net/attachments/547949806761410560/880299665428447232/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-DeCompress-Strong.json
+++ b/data/models/4x-DeCompress-Strong.json
@@ -32,5 +32,10 @@
     "trainingHRSize": 112,
     "dataset": "Custom Dataset consisting of lossless 4k frames from Metal Arms: Glitch in the System, Just Cause 3, Dirt 3, Forza Horizon 3, Sleeping Dogs, and self-edited photos from SignatureEdits + ATLA DVD images",
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/884864597310459996/884952891721383936/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-DeCompress.json
+++ b/data/models/4x-DeCompress.json
@@ -32,5 +32,18 @@
     "trainingHRSize": 112,
     "dataset": "Custom Dataset consisting of lossless 4k frames from Metal Arms: Glitch in the System, Just Cause 3, Dirt 3, Forza Horizon 3, Sleeping Dogs, and self-edited photos from SignatureEdits + ATLA DVD images",
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/884864597310459996/884957054807179274/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/884864597310459996/884960697883193354/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/884864597310459996/884953810097827850/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-FSDedither-Manga.json
+++ b/data/models/4x-FSDedither-Manga.json
@@ -37,5 +37,11 @@
     "dataset": "Manga109 copied 14 times with different dithering and scaling",
     "datasetSize": 1526,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/831f293b-5d83-42d9-b5df-3c9f758ca80d.jpg",
+            "SR": "https://imgsli.com/i/9a40272b-c0c0-41d8-b52a-b70cb3516d12.jpg"
+        }
+    ]
 }

--- a/data/models/4x-FSDedither-Riven.json
+++ b/data/models/4x-FSDedither-Riven.json
@@ -34,5 +34,25 @@
     "trainingOTF": false,
     "dataset": "Photos - DIV2K+Flickr2K with different types of dithering applied",
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6ecf42ee-90e8-4c61-89bf-ca6ea02c972f.jpg",
+            "SR": "https://imgsli.com/i/5816213f-c287-4844-a8df-793178b730ed.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/2245c32e-165c-4806-97c4-db1312c1c9e3.jpg",
+            "SR": "https://imgsli.com/i/9a14d380-10bb-428e-904d-29944559f9a8.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/f9d7ea3a-42d8-40c7-9235-8ba4fd04e49d.jpg",
+            "SR": "https://imgsli.com/i/6031126d-6092-40b9-bedc-c146b8b95868.jpg"
+        },
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/j7Wtn0G.png"
+        }
+    ]
 }

--- a/data/models/4x-FSDedither.json
+++ b/data/models/4x-FSDedither.json
@@ -32,5 +32,11 @@
     "dataset": "Div2K+Flickr2K, linearly downscaled and dithered (half Floyd-Steinberg, half ordered) using GIMP",
     "datasetSize": 3450,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6522fb49-d20c-44e0-b8eb-e9e50b5d1cad.jpg",
+            "SR": "https://imgsli.com/i/a5d6613e-5021-41aa-9fe8-69e0cd9516dd.jpg"
+        }
+    ]
 }

--- a/data/models/4x-FSMangaV2.json
+++ b/data/models/4x-FSMangaV2.json
@@ -36,5 +36,10 @@
     "dataset": "Manga109 copied a bunch of times with different dithering methods, and both linear and nearest-neighbor scaling.",
     "datasetSize": 1526,
     "pretrainedModelG": "4x-PSNR",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/oVBVthF.png"
+        }
+    ]
 }

--- a/data/models/4x-Fabric-Alt.json
+++ b/data/models/4x-Fabric-Alt.json
@@ -33,5 +33,10 @@
     "dataset": "Custom Dataset consisting of edited RAW images taken by myself. Macro shots of fabrics and various other materials.",
     "datasetSize": 346,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/887850596214902835/887856392269094952/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-Fabric.json
+++ b/data/models/4x-Fabric.json
@@ -33,5 +33,18 @@
     "dataset": "Custom Dataset consisting of edited RAW images taken by myself. Macro shots of fabrics and various other materials.",
     "datasetSize": 346,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/887850596214902835/887852703873638410/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/887850596214902835/887852170156847124/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/887850596214902835/887853344545194084/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-GameAI-2-0.json
+++ b/data/models/4x-GameAI-2-0.json
@@ -33,5 +33,22 @@
     "dataset": "Textures from A Hat in Time, Kingdom Hearts 3 and World of Final Fantasy. 21.9k to 70k textures, up to 1024x1024 per texture.",
     "datasetSize": 21900,
     "pretrainedModelG": "4x-GameAI-1-0",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/947610558981632040/2ea384c8dc05593e-55207ec648ad52a4-00006213_2-comparison.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/947610559497510922/65aac3d41ce0297c-5ff21b7095173a35-00006213_2-comparison.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/947610560005033984/a6518186b4e88a86-ddbb8bd9666cd975-00006213_2-comparison.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/947610560369950740/ae6ae340a472b13d-2ade3b7d0cf4a09f-00005dd3_2-comparison.png"
+        }
+    ]
 }

--- a/data/models/4x-HDCube.json
+++ b/data/models/4x-HDCube.json
@@ -34,5 +34,71 @@
     "trainingHRSize": 128,
     "dataset": "artifact free textures and photos (stone, wood, metal, clothes, plants, characters, FX)",
     "datasetSize": 2000,
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/74d2ac37-96de-4f77-b7a9-8821aac62656.jpg",
+            "SR": "https://imgsli.com/i/a86ca862-a303-42c3-9449-4b7618cc940f.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/rEBbmuTB.png",
+            "SR": "https://i.slow.pics/lJttZXhP.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/2JHLei12.png",
+            "SR": "https://i.slow.pics/4gTu6pCy.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/HWgCanJf.png",
+            "SR": "https://i.slow.pics/aq7zOznB.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/3gZfpSoR.png",
+            "SR": "https://i.slow.pics/0Vuh9G84.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/dJaFEYCn.png",
+            "SR": "https://i.slow.pics/ENj4PGb3.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/N9ldl5RA.png",
+            "SR": "https://i.slow.pics/ILGjgzDf.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/cdnPaeWD.png",
+            "SR": "https://i.slow.pics/i0woQOn4.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/YeUFM9SM.png",
+            "SR": "https://i.slow.pics/xraOWdNY.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/O8l7bna6.png",
+            "SR": "https://i.slow.pics/YER8Ow7h.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/dHiYtJaS.png",
+            "SR": "https://i.slow.pics/cOgoV31t.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/UQDiziqK.png",
+            "SR": "https://i.slow.pics/u8bEQ0QC.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/SUen7VG2.png",
+            "SR": "https://i.slow.pics/NrRj0TPo.png"
+        }
+    ]
 }

--- a/data/models/4x-HDCube3.json
+++ b/data/models/4x-HDCube3.json
@@ -27,5 +27,11 @@
             ]
         }
     ],
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1946141d-8bcd-4072-afe7-2518a000dd0f.jpg",
+            "SR": "https://imgsli.com/i/5778bbd8-0f65-4d3c-bcee-8102df97cfd8.jpg"
+        }
+    ]
 }

--- a/data/models/4x-HellinaCel.json
+++ b/data/models/4x-HellinaCel.json
@@ -30,5 +30,11 @@
     "dataset": "Trained on upscaling downscaled cel photographs run through DetoriationFrames",
     "datasetSize": 69,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/15ec20ac-f1e7-4486-8e8e-5b8bf2cad048.jpg",
+            "SR": "https://imgsli.com/i/188fe0e0-b6ac-4c91-a242-973592b63781.jpg"
+        }
+    ]
 }

--- a/data/models/4x-Jaypeg90.json
+++ b/data/models/4x-Jaypeg90.json
@@ -34,5 +34,10 @@
     "trainingOTF": false,
     "dataset": "Flickr2K+Div2K, JPEG compressed with random quality from 85-95 and scaled with either cubic or NN scaling.",
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/n09m2Rt.png"
+        }
+    ]
 }

--- a/data/models/4x-Link.json
+++ b/data/models/4x-Link.json
@@ -33,5 +33,18 @@
     "dataset": "pexels.com, ambientcg.com, Wikimedia Commons. photos of chainmail from DeviantArt, game textures with chainmail, diffuse maps of chainmail from DAZ items. All items downscaled by factors of 2 to add capacity for LOD texture upscaling and increase generative effect of model.",
     "datasetSize": 561,
     "pretrainedModelG": "4x-Nickelfront",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1027685415756509265/4x_Link_500000_G-TestImage-0x9F6EFFE0.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1027685416180121722/4x_Link_500000_G-TestImage-CMMM_Knight_Templar_ID2_DiffuseMap.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1027685416528261203/4x_Link_500000_G-TestImage-Crest_Venetian_DiffuseMap.png"
+        }
+    ]
 }

--- a/data/models/4x-NMKD-PatchySharp.json
+++ b/data/models/4x-NMKD-PatchySharp.json
@@ -32,5 +32,10 @@
     "trainingHRSize": 256,
     "dataset": "DIV2K Clean + JPEG",
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/PzFkmAg.png"
+        }
+    ]
 }

--- a/data/models/4x-NMKD-YandereNeo.json
+++ b/data/models/4x-NMKD-YandereNeo.json
@@ -31,5 +31,10 @@
     "trainingIterations": 320000,
     "trainingBatchSize": 4,
     "dataset": "Yandere1200 (yande.re artworks)",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/oxs71v5.png"
+        }
+    ]
 }

--- a/data/models/4x-NXbrz.json
+++ b/data/models/4x-NXbrz.json
@@ -5,7 +5,7 @@
     "tags": [
         "pixel-art"
     ],
-    "description": "Category: Art/Pixel Art\n\nBasic pixel art upscaling, for people who want a more simpler style and lightweight pixel art upscaling model.",
+    "description": "Category: Art/Pixel Art\n\nBasic pixel art upscaling, for people who want a more simpler style and lightweight pixel art upscaling model.\n\nSample images: https://drive.google.com/drive/folders/1mYTMpwDlKQulBmjgKpcxL3-T6xAGXVxl?usp=sharing",
     "date": "2021-06-09",
     "architecture": "esrgan",
     "size": [

--- a/data/models/4x-OLDIES-ALTERNATIVE-FINAL.json
+++ b/data/models/4x-OLDIES-ALTERNATIVE-FINAL.json
@@ -34,5 +34,11 @@
     "dataset": "different frames from different anime blu-ray",
     "datasetSize": 1250,
     "pretrainedModelG": "4x-PSNR",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/8ea6b7fc-045c-4c9d-ac63-6da63c134262.jpg",
+            "SR": "https://imgsli.com/i/dffaf86c-2aa3-4ff4-844e-6384378f9d62.jpg"
+        }
+    ]
 }

--- a/data/models/4x-PackCraft-v4.json
+++ b/data/models/4x-PackCraft-v4.json
@@ -28,5 +28,10 @@
     "trainingHRSize": 512,
     "dataset": "Random screenshots from Alpha Minecraft taken at the correct angle, screen region, block placement, and cloud position (with slight random variance). LR images were OTF downscaled with box/area.",
     "datasetSize": 60000,
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/436411385673547787/750481717307113543/pack.png"
+        }
+    ]
 }

--- a/data/models/4x-PixelPerfectV4.json
+++ b/data/models/4x-PixelPerfectV4.json
@@ -5,7 +5,7 @@
     "tags": [
         "pixel-art"
     ],
-    "description": "Category: Art/Pixel Art\nPurpose: Pixel Art/Sprites\n\nSprite Upscaler",
+    "description": "Category: Art/Pixel Art\nPurpose: Pixel Art/Sprites\n\nSprite Upscaler\n\nComparison with v3: https://imgsli.com/MzgxMTc/2/1",
     "date": "2020-11-16",
     "architecture": "esrgan",
     "size": [
@@ -34,5 +34,11 @@
     "dataset": "Random anime images",
     "datasetSize": 300,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a5d3948d-c3cd-49f7-ba1c-205e77601aad.jpg",
+            "SR": "https://imgsli.com/i/d0cb98d9-4445-46a7-b0aa-57f1600e1bf5.jpg"
+        }
+    ]
 }

--- a/data/models/4x-RealisticRescaler.json
+++ b/data/models/4x-RealisticRescaler.json
@@ -35,5 +35,86 @@
     "dataset": "DIV2K, Flick2R, AmbientCG, Poly Haven, nomos2k",
     "datasetSize": 861,
     "pretrainedModelG": "4x-realesrgan-x4plus",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "SR": "https://imgsli.com/i/95409dc3-0303-4935-8722-edf6d7c331fd.jpg",
+            "LR": "https://imgsli.com/i/e9842609-3720-40c1-91b9-316ae03f5a21.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3aa0831f-1c8a-48a7-ad85-a79ce8c1202a.jpg",
+            "SR": "https://imgsli.com/i/4bfb99c7-0a7f-4239-afc1-663441694b9e.jpg"
+        },
+        {
+            "type": "paired",
+            "SR": "https://imgsli.com/i/8853d469-316e-4494-9a03-0e903ffa231c.jpg",
+            "LR": "https://imgsli.com/i/7146b542-fd14-4a90-a929-3fbfda4a0f6c.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/7867f29b-e806-4fdc-b46a-06d92ae87e14.jpg",
+            "SR": "https://imgsli.com/i/db91db78-6394-43b8-9e16-75c2500f27b1.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/be1ab607-d20e-4a9f-b5ce-ea6b18208542.jpg",
+            "SR": "https://imgsli.com/i/b8b61803-32d0-4b53-b05a-f05a0b3c961a.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/38bc9c5f-272d-4239-bf11-3299102c7f1f.jpg",
+            "SR": "https://imgsli.com/i/7fdf7ae9-dd01-4aaa-b687-7c95b35d7953.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/cf16113d-3203-43f9-ba7b-28613ebe9f9f.jpg",
+            "SR": "https://imgsli.com/i/693a6b80-9c92-4dea-a504-1e83df43d49b.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/65505713-e940-4cf9-8cf7-c026dbb32a49.jpg",
+            "SR": "https://imgsli.com/i/161b970a-f078-4072-a5c7-a0deaf62ac58.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/73e91572-41df-416a-b9f0-125a576f6bf6.jpg",
+            "SR": "https://imgsli.com/i/087aaae8-9ee8-4942-bb02-d1a885b6a8f6.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/53653fc0-aabb-47df-9097-18e12636dc27.jpg",
+            "SR": "https://imgsli.com/i/09856725-8edd-4e20-9d79-03518b951628.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/93b8c8d3-fd4e-46ed-aab5-f8467f509dea.jpg",
+            "SR": "https://imgsli.com/i/cd643a9a-e38c-4d20-abb1-8ffd042ea96d.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/94bcaf6a-321a-44e2-b7e0-9e8356764518.jpg",
+            "SR": "https://imgsli.com/i/9468ed56-1340-44f0-a316-95aff761a649.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a5b24dc6-37c3-4227-92b7-e826d81f052a.jpg",
+            "SR": "https://imgsli.com/i/e1e149bf-e366-4764-b152-a36bebfdd6d7.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/22d817be-12c7-412c-83ab-b6c3394b0189.jpg",
+            "SR": "https://imgsli.com/i/f007c22a-7f09-481d-af0c-cc5e9590ecd9.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/fde5c0b4-3c4a-4fb7-971b-a885e378bd4f.jpg",
+            "SR": "https://imgsli.com/i/f6302415-4014-456b-a543-98228588bf2e.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/d424a4a6-f309-45c2-90b0-2f46cb749183.jpg",
+            "SR": "https://imgsli.com/i/4a7d4855-8581-4e81-bef9-82570138e76b.jpg"
+        }
+    ]
 }

--- a/data/models/4x-SGI.json
+++ b/data/models/4x-SGI.json
@@ -32,5 +32,22 @@
     "trainingHRSize": 128,
     "dataset": "Very hi-res (up to 2500px) vintage cgi images and prerendered promotional renders for games from the 90s to early 2000s, as well as HD stills from movies made with SGI workstations (early pixar movies and shrek)",
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/lwFRhmc.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/ftvVu3i.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/0uXoAuJ.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/uIkm4hJ.png"
+        }
+    ]
 }

--- a/data/models/4x-SOFVSR-REDS-F3-V1.json
+++ b/data/models/4x-SOFVSR-REDS-F3-V1.json
@@ -5,7 +5,7 @@
     "tags": [
         "pretrained"
     ],
-    "description": "Category: Pretrained Discriminators\nPurpose: IRL videos\n\nupscale IRL videos. Use not recommended by creator",
+    "description": "Category: Pretrained Discriminators\nPurpose: IRL videos\n\nupscale IRL videos. Use not recommended by creator.\n\nSample video: https://cdn.discordapp.com/attachments/547949806761410560/813134983236419664/100k_iter.mp4",
     "date": "2021-02-26",
     "architecture": "sofvsr",
     "size": null,

--- a/data/models/4x-SkyrimTex-v2-1.json
+++ b/data/models/4x-SkyrimTex-v2-1.json
@@ -32,5 +32,14 @@
     "dataset": "Extracted Skyrim Textures, HRs processed with BC1-Smooth2. IRL images of rocks and grass",
     "datasetSize": 485,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/891300021453070387/891395469387890738/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/891393393849147423/891398051325960202/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-SkyrimTex-v2-Fabric.json
+++ b/data/models/4x-SkyrimTex-v2-Fabric.json
@@ -32,5 +32,14 @@
     "dataset": "Extracted Skyrim Textures, HRs processed with BC1-Smooth2. IRL images of rocks and grass",
     "datasetSize": 485,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/891300021453070387/891392169926098974/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/891393393849147423/891397870266224731/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-SmolFace.json
+++ b/data/models/4x-SmolFace.json
@@ -34,5 +34,21 @@
     "dataset": "FatalityFaces + danbooru side faces",
     "datasetSize": 5500,
     "pretrainedModelG": "4x-NMKD-UltraYandere",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/12e0307a-f386-4f54-a472-bfaa2eb4cc9c.jpg",
+            "SR": "https://imgsli.com/i/208f5ab0-1b9e-40ac-aa1f-f3a8b5254444.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/85188c01-b4e5-4b05-9a97-f1d1516fdba5.jpg",
+            "SR": "https://imgsli.com/i/908569de-c70e-4827-9607-2b989b4eb65e.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a933df14-4571-4322-85b0-6d35345d7d34.jpg",
+            "SR": "https://imgsli.com/i/5759c671-5d56-40e2-90c8-bbb0c9daf878.jpg"
+        }
+    ]
 }

--- a/data/models/4x-Struzan.json
+++ b/data/models/4x-Struzan.json
@@ -5,7 +5,7 @@
     "tags": [
         "pixel-art"
     ],
-    "description": "Category: Art/Pixel Art\nPurpose: Art\n\nUpscaling airbrush/pencil-based artwork",
+    "description": "Category: Art/Pixel Art\nPurpose: Art\n\nUpscaling airbrush/pencil-based artwork\n\nSample images: https://drive.google.com/drive/folders/1fyeIWInDrM6r-xxrCW4U09oafWw08u9S?usp=sharing",
     "date": "2020-10-12",
     "architecture": "esrgan",
     "size": [

--- a/data/models/4x-ThiefGold.json
+++ b/data/models/4x-ThiefGold.json
@@ -31,5 +31,11 @@
     "trainingHRSize": 128,
     "dataset": "Thief Gold & Thief II community made textures",
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/14fb5fb4-f3f4-416b-bcd3-379e60b2ac7e.jpg",
+            "SR": "https://imgsli.com/i/1fcb69ff-9d4a-4c8c-b022-61425cfcb0d0.jpg"
+        }
+    ]
 }

--- a/data/models/4x-ThiefGoldMod.json
+++ b/data/models/4x-ThiefGoldMod.json
@@ -31,5 +31,11 @@
     "trainingHRSize": 128,
     "dataset": "Thief Gold & Thief II community made textures",
     "pretrainedModelG": "4x-Manga109Attempt",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/14fb5fb4-f3f4-416b-bcd3-379e60b2ac7e.jpg",
+            "SR": "https://imgsli.com/i/1fcb69ff-9d4a-4c8c-b022-61425cfcb0d0.jpg"
+        }
+    ]
 }

--- a/data/models/4x-UltraSharp.json
+++ b/data/models/4x-UltraSharp.json
@@ -33,5 +33,22 @@
     "trainingHRSize": 128,
     "dataset": "So many. I used: RAW images shot by myself, SignatureEdits, AdobeMIT-5K, DIV2K, TLOK from brucethemoose, some rock/stone images from ALSA, and many images provided by <@724494344270381097> (thanks!)",
     "pretrainedModelG": "4x-UniScale-Balanced",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/902853011913732097/902855337705611294/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/902853011913732097/902853340600360990/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/902853011913732097/902855036768489512/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/900506271566938122/902867618086670356/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-UniScale-Balanced.json
+++ b/data/models/4x-UniScale-Balanced.json
@@ -32,5 +32,11 @@
     "dataset": "Custom Dataset consisting of lossless 4k frames from Metal Arms: Glitch in the System, Just Cause 3, Dirt 3, Forza Horizon 3, Sleeping Dogs, and self-edited photos from SignatureEdits",
     "datasetSize": 18909,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/LCM8sExR.png",
+            "SR": "https://i.slow.pics/79XopsLh.png"
+        }
+    ]
 }

--- a/data/models/4x-UniScale-Restore.json
+++ b/data/models/4x-UniScale-Restore.json
@@ -35,5 +35,14 @@
     "dataset": "Custom Dataset consisting of lossless 4k frames from Metal Arms: Glitch in the System, Just Cause 3, Dirt 3, Forza Horizon 3, Sleeping Dogs, and self-edited photos from SignatureEdits",
     "datasetSize": 18909,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/880826637543964712/880934732748169226/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/880826637543964712/880932754102026290/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-UniScale-Strong.json
+++ b/data/models/4x-UniScale-Strong.json
@@ -32,5 +32,11 @@
     "dataset": "Custom Dataset consisting of lossless 4k frames from Metal Arms: Glitch in the System, Just Cause 3, Dirt 3, Forza Horizon 3, Sleeping Dogs, and self-edited photos from SignatureEdits",
     "datasetSize": 18909,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/XlmwBz9r.png",
+            "SR": "https://i.slow.pics/V6d5sPeX.png"
+        }
+    ]
 }

--- a/data/models/4x-UniScaleNR-Balanced.json
+++ b/data/models/4x-UniScaleNR-Balanced.json
@@ -33,5 +33,11 @@
     "dataset": "Custom Dataset consisting of lossless 4k frames from Metal Arms: Glitch in the System, Just Cause 3, Dirt 3, Forza Horizon 3, Sleeping Dogs, and self-edited photos from SignatureEdits",
     "datasetSize": 18909,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/kfhfmB2l.png",
+            "SR": "https://i.slow.pics/BfQWQ3f2.png"
+        }
+    ]
 }

--- a/data/models/4x-UniScaleNR-Strong.json
+++ b/data/models/4x-UniScaleNR-Strong.json
@@ -33,5 +33,11 @@
     "dataset": "Custom Dataset consisting of lossless 4k frames from Metal Arms: Glitch in the System, Just Cause 3, Dirt 3, Forza Horizon 3, Sleeping Dogs, and self-edited photos from SignatureEdits",
     "datasetSize": 18909,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/mUBPAfLY.png",
+            "SR": "https://i.slow.pics/C6ukaQdr.png"
+        }
+    ]
 }

--- a/data/models/4x-UniScaleV2-Moderate.json
+++ b/data/models/4x-UniScaleV2-Moderate.json
@@ -32,5 +32,10 @@
     "trainingHRSize": 112,
     "dataset": "Custom Dataset consisting of lossless 4k frames from Metal Arms: Glitch in the System, Just Cause 3, Dirt 3, Forza Horizon 3, Sleeping Dogs, and self-edited photos from SignatureEdits + ATLA DVD images",
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/884239326471393331/884298572894441512/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-UniScaleV2-Sharp.json
+++ b/data/models/4x-UniScaleV2-Sharp.json
@@ -32,5 +32,14 @@
     "trainingHRSize": 112,
     "dataset": "Custom Dataset consisting of lossless 4k frames from Metal Arms: Glitch in the System, Just Cause 3, Dirt 3, Forza Horizon 3, Sleeping Dogs, and self-edited photos from SignatureEdits + ATLA DVD images",
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/884239326471393331/884296266857713704/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/884239326471393331/884294468709257216/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-UniScaleV2-Soft.json
+++ b/data/models/4x-UniScaleV2-Soft.json
@@ -32,5 +32,10 @@
     "trainingHRSize": 112,
     "dataset": "Custom Dataset consisting of lossless 4k frames from Metal Arms: Glitch in the System, Just Cause 3, Dirt 3, Forza Horizon 3, Sleeping Dogs, and self-edited photos from SignatureEdits + ATLA DVD images",
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/884239326471393331/884302370136289323/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-UniversalUpscalerV2-Sharp.json
+++ b/data/models/4x-UniversalUpscalerV2-Sharp.json
@@ -5,7 +5,7 @@
     "tags": [
         "general-upscaler"
     ],
-    "description": "General Upscaler",
+    "description": "General Upscaler\n\nComparison with v1: https://imgsli.com/NDc3ODA/1/2",
     "date": "2021-04-01",
     "architecture": "esrgan",
     "size": [
@@ -32,5 +32,11 @@
     "trainingOTF": false,
     "dataset": "Realistic images",
     "pretrainedModelG": "1x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6f584a00-9207-452a-818b-6c5cad94ef7a.jpg",
+            "SR": "https://imgsli.com/i/e75cfdeb-f4a2-4796-9cae-3f51757d4f2e.jpg"
+        }
+    ]
 }

--- a/data/models/4x-Valar.json
+++ b/data/models/4x-Valar.json
@@ -29,5 +29,10 @@
     "trainingIterations": 400000,
     "dataset": "Hand selected 1471 Raw images from the Adobe-MIT 5k dataset, processed using Rawtherapee.",
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/888256099986321408/5.png"
+        }
+    ]
 }

--- a/data/models/4x-VimeoScale.json
+++ b/data/models/4x-VimeoScale.json
@@ -25,5 +25,26 @@
     "trainingBatchSize": 13,
     "trainingHRSize": 128,
     "dataset": "200gb+ Combination of Collected Vimeo scenes (CG, realistic/video, movie trailers, and motion graphics) at original quality and Vimeo90k",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1e5fd788-2e08-479b-8b3a-65dc9258b8e4.jpg",
+            "SR": "https://imgsli.com/i/df5b78d3-c495-46ba-8aa9-8fa908091c56.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6f87ade4-397e-4488-b3d2-8a357594dfcc.jpg",
+            "SR": "https://imgsli.com/i/d0fbe66e-a42f-4111-b5ea-4ad40a98206f.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/507a2684-8029-48e3-94ee-c44fb5eae10b.jpg",
+            "SR": "https://imgsli.com/i/b5e53de4-25eb-48bb-8b65-95a929cfab06.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/0308cb64-5d23-45f9-9d25-b2fbf012cf9f.jpg",
+            "SR": "https://imgsli.com/i/ca6b240b-8d93-4322-b350-f5a72baf1d8a.jpg"
+        }
+    ]
 }

--- a/data/models/4x-VolArt.json
+++ b/data/models/4x-VolArt.json
@@ -32,5 +32,14 @@
     "dataset": "Artwork by Yasushi Nirasawa, provided by <@295426806188736523>",
     "datasetSize": 526,
     "pretrainedModelG": "4x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/888869052867543060/888869070928248852/unknown.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/888869052867543060/888869784169619496/unknown.png"
+        }
+    ]
 }

--- a/data/models/4x-anifilm-compact.json
+++ b/data/models/4x-anifilm-compact.json
@@ -32,5 +32,20 @@
     "dataset": "Dragon Ball Z Movies",
     "datasetSize": 2836,
     "pretrainedModelG": "4x-Compact-Pretrain",
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/903415274521374750/1004158991544365097/1659480539.543144.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/10422c4b-91a6-472a-b36d-9ee202bf87b3.jpg",
+            "SR": "https://imgsli.com/i/e8bebd92-0530-41ee-b078-deaabff1189d.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/dc896eea-6629-4bb4-a359-0e33555503d1.jpg",
+            "SR": "https://imgsli.com/i/257605f4-6dd4-4e4a-8baa-6a76eebf837a.jpg"
+        }
+    ]
 }

--- a/data/models/4x-escale.json
+++ b/data/models/4x-escale.json
@@ -32,5 +32,21 @@
     "trainingHRSize": 128,
     "dataset": "Various eroge dumps",
     "pretrainedModelG": "4x-muy4-035-1",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/XUUndUn1.png",
+            "SR": "https://i.slow.pics/KkruuRke.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/CJuXeTEQ.png",
+            "SR": "https://i.slow.pics/fdfj8Dm7.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/r6fcuFOi.png",
+            "SR": "https://i.slow.pics/1EMrKCXs.png"
+        }
+    ]
 }

--- a/data/models/4x-eula-anifilm-v1.json
+++ b/data/models/4x-eula-anifilm-v1.json
@@ -34,5 +34,16 @@
     "dataset": "Dragon Ball Level Sets",
     "datasetSize": 51000,
     "pretrainedModelG": "4x-PSNR",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/KuiPMFTe.png",
+            "SR": "https://i.slow.pics/PGTgPxwM.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/kdTxFcOt.png",
+            "SR": "https://i.slow.pics/TBarB9KG.png"
+        }
+    ]
 }

--- a/data/models/4x-eula-digimanga-bw-v1.json
+++ b/data/models/4x-eula-digimanga-bw-v1.json
@@ -32,5 +32,106 @@
     "trainingHRSize": 128,
     "dataset": "600dpi digital manga. LR images repeated with different compression strengths, and gamma adjustments.",
     "pretrainedModelG": "4x-PSNR",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/sLypBoiX.png",
+            "SR": "https://i.slow.pics/SSYcxXig.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/x8bYqlWf.png",
+            "SR": "https://i.slow.pics/caPW2MbP.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/20N7pmXL.png",
+            "SR": "https://i.slow.pics/nDWNPmK6.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/pfzrdsIu.png",
+            "SR": "https://i.slow.pics/1yTEujeg.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/MGrm6MqU.png",
+            "SR": "https://i.slow.pics/7xXQpjt0.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/6hk7a6t5.png",
+            "SR": "https://i.slow.pics/1uy2TPwa.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/xEnTfTXx.png",
+            "SR": "https://i.slow.pics/2MhrabnO.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/iHlkgFPA.png",
+            "SR": "https://i.slow.pics/9Xqer7rr.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/r05wIUdi.png",
+            "SR": "https://i.slow.pics/JbqUGtsH.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/Biq6DDTs.jpg",
+            "SR": "https://i.slow.pics/p6LNfJEP.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/kmXADepE.png",
+            "SR": "https://i.slow.pics/N2TLvfDw.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/GcDfUdOz.png",
+            "SR": "https://i.slow.pics/9EsR9p4Z.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/8WeXkefI.png",
+            "SR": "https://i.slow.pics/JycZSVG0.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/dtSt8kr5.png",
+            "SR": "https://i.slow.pics/aNdRz3mY.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/SPRe9Zu0.png",
+            "SR": "https://i.slow.pics/CUK0WaiR.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/pmM6bCvy.png",
+            "SR": "https://i.slow.pics/ry0587s4.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/dXVMAyjv.jpg",
+            "SR": "https://i.slow.pics/qCiIclDy.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/igxFfo1S.png",
+            "SR": "https://i.slow.pics/CNufJk7B.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/DIKVx3z2.png",
+            "SR": "https://i.slow.pics/p60y5sq3.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/Je01f7LJ.png",
+            "SR": "https://i.slow.pics/hWUlwQ6P.png"
+        }
+    ]
 }

--- a/data/models/4x-eula-digimanga-bw-v2-nc1.json
+++ b/data/models/4x-eula-digimanga-bw-v2-nc1.json
@@ -33,5 +33,61 @@
     "dataset": "v1's dataset + real-life LRs upscaled with v1",
     "datasetSize": 19019,
     "pretrainedModelG": "4x-eula-digimanga-bw-v1",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/Biq6DDTs.jpg",
+            "SR": "https://i.slow.pics/4drvnmEF.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/kmXADepE.png",
+            "SR": "https://i.slow.pics/oc98KrUq.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/GcDfUdOz.png",
+            "SR": "https://i.slow.pics/o4gbFDZ7.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/8WeXkefI.png",
+            "SR": "https://i.slow.pics/hQqc4zFl.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/dtSt8kr5.png",
+            "SR": "https://i.slow.pics/N8YdTJfQ.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/SPRe9Zu0.png",
+            "SR": "https://i.slow.pics/mjbHxqYM.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/pmM6bCvy.png",
+            "SR": "https://i.slow.pics/CKsO6QUz.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/dXVMAyjv.jpg",
+            "SR": "https://i.slow.pics/RQuRBHLA.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/igxFfo1S.png",
+            "SR": "https://i.slow.pics/vzHwzGha.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/DIKVx3z2.png",
+            "SR": "https://i.slow.pics/EKW1w69a.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/Je01f7LJ.png",
+            "SR": "https://i.slow.pics/sXL82LZy.png"
+        }
+    ]
 }

--- a/data/models/4x-realesrgan-x4minus.json
+++ b/data/models/4x-realesrgan-x4minus.json
@@ -34,5 +34,21 @@
     "dataset": "Same as realesrgan-x4plus, but later modified to crop some shallow focus images.",
     "datasetSize": 58000,
     "pretrainedModelG": "4x-realesrgan-x4plus",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b5e46848-4465-4d59-afe9-dce4d6fbe2cd.jpg",
+            "SR": "https://imgsli.com/i/99a4248c-27bd-4008-b952-3b2b0f0644a3.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/19d677c6-dba9-454f-8faf-a7fdd7394bc3.jpg",
+            "SR": "https://imgsli.com/i/b9f336bb-af24-4a85-ab4d-ab80a5fe5f8a.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/afd3ef66-637f-44a9-a04c-9b630f65e741.jpg",
+            "SR": "https://imgsli.com/i/ba941c5c-d846-478b-8d7d-a0f34739b80a.jpg"
+        }
+    ]
 }

--- a/data/models/4x-realesrgan-x4plus.json
+++ b/data/models/4x-realesrgan-x4plus.json
@@ -33,6 +33,21 @@
             "type": "standalone",
             "url": "https://github.com/xinntao/Real-ESRGAN/raw/master/assets/teaser.jpg",
             "thumbnail": ""
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b5e46848-4465-4d59-afe9-dce4d6fbe2cd.jpg",
+            "SR": "https://imgsli.com/i/ea77702b-c63d-47f5-a4aa-05f9d1e3fc3f.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/19d677c6-dba9-454f-8faf-a7fdd7394bc3.jpg",
+            "SR": "https://imgsli.com/i/c6722e6b-0e3c-44b4-938b-89010dddb903.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/afd3ef66-637f-44a9-a04c-9b630f65e741.jpg",
+            "SR": "https://imgsli.com/i/84317670-a22a-4f06-af38-b0afca0a8fda.jpg"
         }
     ]
 }

--- a/data/models/8x-BoyMeBob-Redux.json
+++ b/data/models/8x-BoyMeBob-Redux.json
@@ -32,5 +32,58 @@
     "trainingHRSize": 256,
     "dataset": "SpongeBob Season 11",
     "datasetSize": 24123,
-    "images": []
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://p-lux3.pcloud.com/D4ZFqLCfeZXFC3CCZZZcUH1o7Z3VZZnl0ZXZ52H0ZHzZZZy6TKXZFl67UPA7QtF7Wa0Eh3h390u1WWVy/th-32633200259-2048x576.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://p-lux1.pcloud.com/D4ZIMLCfeZMoP3CCZZZoUH1o7Z3VZZnl0ZXZqvT0ZrkZZZy6TKXZiJM29YazhIFHESCfRjHuBhwDBeuk/th-32633199741-2048x576.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://p-lux4.pcloud.com/D4ZlUSpsTZngP3CCZZZoUH1o7Z3VZZnl0ZXZKIuXZMzZZZy6TKXZIyiG3Lj5iCL1RMsdzO7M3kJw8Ogk/th-32633198275-2048x576.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://p-lux3.pcloud.com/D4Z4CLCfeZtqP3CCZZZpIH1o7Z3VZZnl0ZXZjuB0ZFRZZZy6TKXZLHGnpx1lUcuq8aL4owC6hSwD5Puy/th-32633198776-2048x576.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://p-lux3.pcloud.com/D4ZX6LCfeZHYP3CCZZZ7aH1o7Z3VZZnl0ZXZt4V5ZHzZZZy6TKXZMR0iF3UO78zLlSpi5HoVimGxUngk/th-32633197094-2048x576.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://p-lux2.pcloud.com/D4ZEJ4CfeZEYP3CCZZZ7aH1o7Z3VZZnl0ZXZNtH5ZS0ZZZy6TKXZ6wSpKtGTnUkGsWdRXxoPkyIsqOok/th-32633197131-2048x576.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://p-lux2.pcloud.com/D4Zay8CfeZsdg3CCZZZkaH1o7Z3VZZnl0ZXZP405Z9VZZZy6TKXZFVpqoBBtlSzejBGjdHeXMHGP0hMV/th-32633194977-2048x576.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://p-lux4.pcloud.com/D4Zh4mCfeZzdg3CCZZZHaH1o7Z3VZZnl0ZXZbCzJZXJZZZy6TKXZv3S9bMS7rYylE3I33DAJfkCeUTdy/th-32633194960-2048x576.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://p-lux1.pcloud.com/D4ZrgbCfeZHpx3CCZZZYaH1o7Z3VZZnl0ZXZ7MK5ZO0ZZZy6TKXZJdAwt0u29lzaHQUv5AFe78es2YvX/th-32633204048-2048x576.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://p-lux4.pcloud.com/D4Z04QCfeZdOC3CCZZZfaH1o7Z3VZZnl0ZXZXQvXZ8VZZZy6TKXZ5prO8Tg6nghyGHb1BFpJdu0j9DPX/th-32633202739-2048x576.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://p-lux3.pcloud.com/D4Zrl8CfeZjIC3CCZZZeaH1o7Z3VZZnl0ZXZN93VZFRZZZy6TKXZbu0PYE5JHF8UGmzs740YkbASVPBV/th-32633202840-2048x576.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://p-lux4.pcloud.com/D4Z2S4CfeZfeC3CCZZZwaH1o7Z3VZZnl0ZXZcPKVZVXZZZy6TKXZE7GULIwmg4f7WURzxwAy3miQCwkV/th-32633201683-2048x576.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://p-lux1.pcloud.com/D4ZFCuStMZkWC3CCZZZEaH1o7Z3VZZnl0ZXZ3Nv0ZvkZZZy6TKXZXfEh3yW78N5wjnvRu3146Vt05FQX/th-32633201417-2048x576.png"
+        }
+    ]
 }

--- a/data/models/8x-TGHQFace8x.json
+++ b/data/models/8x-TGHQFace8x.json
@@ -35,5 +35,11 @@
     "dataset": "Flickr Cropped Faces",
     "datasetSize": 70000,
     "pretrainedModelG": "8x-ESRGAN",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/577940f0-435d-4951-825c-2e17cc447aa2.jpg",
+            "SR": "https://imgsli.com/i/ffcd7bc1-ad2d-4294-8380-f37b0a6cdb95.jpg"
+        }
+    ]
 }


### PR DESCRIPTION
This adds all (useful) sample images from the old model db.

While this branch is ready, we don't have lazy loaded images yet. This is a requirement for merging this, because we are going to DDoS our image hosters otherwise.

Here's a visualization of roughly how many models have sample images:
![image](https://user-images.githubusercontent.com/20878432/233793210-f9230e76-21b1-4dda-97ea-5c2ca468af44.png)
