### PR TITLE
Better word breaking for model card titles

### DIFF
--- a/src/elements/components/model-card.module.scss
+++ b/src/elements/components/model-card.module.scss
@@ -40,6 +40,11 @@
         right: 0;
         padding: 0.75rem;
         padding-top: 0.5rem;
+
+        a.name {
+            word-break: normal;
+            overflow-wrap: anywhere;
+        }
     }
 
     .tagBase {

--- a/src/elements/components/model-card.tsx
+++ b/src/elements/components/model-card.tsx
@@ -59,7 +59,7 @@ export const ModelCard = memo(({ id, model }: ModelCardProps) => {
 
                 <div className={style.details}>
                     <Link
-                        className="block text-xl font-bold text-gray-800 dark:text-gray-100"
+                        className={`${style.name} block text-xl font-bold text-gray-800 dark:text-gray-100`}
                         href={`/models/${id}`}
                     >
                         {model.name}


### PR DESCRIPTION
Very long titles that are one word (=no spaces) overflowed when the model card was small enough, so I fixed that.