### PR TITLE
More efficient lazy model card

### DIFF
--- a/src/elements/components/model-card.tsx
+++ b/src/elements/components/model-card.tsx
@@ -99,18 +99,28 @@ export const ModelCardContent = memo(({ id, model }: BaseModelCardProps) => {
 
 export const ModelCard = memo(({ id, model, lazy = false }: ModelCardProps) => {
     const inner = (
-        <ModelCardContent
-            id={id}
-            model={model}
-        />
-    );
-
-    return (
         <div
             className={`${style.modelCard} border-gray-300 bg-white shadow-lg hover:shadow-xl dark:border-gray-700 dark:bg-fade-900`}
         >
-            {lazy ? <LazyLoadComponent threshold={400}>{inner}</LazyLoadComponent> : inner}
+            <ModelCardContent
+                id={id}
+                model={model}
+            />
         </div>
+    );
+
+    if (!lazy) return inner;
+
+    return (
+        <LazyLoadComponent
+            placeholder={
+                <div
+                    className={`${style.modelCard} border-gray-300 bg-white shadow-lg hover:shadow-xl dark:border-gray-700 dark:bg-fade-900`}
+                />
+            }
+        >
+            {inner}
+        </LazyLoadComponent>
     );
 });
 


### PR DESCRIPTION
I made a small mistake when adding lazy loading. `LazyLoadComponent` needs a placeholder and uses an empty `<span>` by default. 

```html
<div class="model-card_modelCard__QF9dZ border-gray-300 bg-white shadow-lg hover:shadow-xl dark:border-gray-700 dark:bg-fade-900">
  <span class="" style="display:inline-block"></span>
</div>
```

This results in roughly 350 unnecessary DOM elements on the main page. So this PR changes that to use the model card wrapper instead. We need the wrapper anyway, so might as well use it as the placeholder.