### PR TITLE
Make tag tooltips click-through

### DIFF
--- a/src/elements/tag-selector.tsx
+++ b/src/elements/tag-selector.tsx
@@ -88,7 +88,6 @@ export function TagSelector({ selection, onChange }: TagSelectorProps) {
 
             {isClient && (
                 <Tooltip
-                    clickable
                     closeOnEsc
                     className={style.tooltip}
                     id={TOOLTIP_ID}


### PR DESCRIPTION
While making #150, I noticed that tag tooltips get in the way. So I made them click-through. 