### PR TITLE
Fixed 3 images

### DIFF
--- a/data/models/1x-DeBink-Lite.json
+++ b/data/models/1x-DeBink-Lite.json
@@ -5,7 +5,7 @@
     "tags": [
         "video-frame"
     ],
-    "description": "Category: Video Compression\nPurpose: Compression\n\nThis model was trained on lossless video frames of Metal Arms: Glitch in the System, compressed with Bink V1 for the LR frames. It's a lot more efficient than my first DeBink model, and also has less artifacts. It's not quite as robust, but the compression is barely noticeable in videos after processing with this.",
+    "description": "Category: Video Compression\nPurpose: Compression\n\nThis model was trained on lossless video frames of Metal Arms: Glitch in the System, compressed with Bink V1 for the LR frames. It's a lot more efficient than my first DeBink model, and also has less artifacts. It's not quite as robust, but the compression is barely noticeable in videos after processing with this.\n\nSample video: https://cdn.discordapp.com/attachments/903415274521374750/904129653374078976/XB_Demo_Mov-85600_G.mp4",
     "date": "2021-10-30",
     "architecture": "esrgan",
     "size": [
@@ -27,10 +27,5 @@
             ]
         }
     ],
-    "images": [
-        {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/903415274521374750/904129653374078976/XB_Demo_Mov-85600_G.mp4"
-        }
-    ]
+    "images": []
 }

--- a/data/models/1x-sudo-inpaint-PartialConv2D.json
+++ b/data/models/1x-sudo-inpaint-PartialConv2D.json
@@ -5,7 +5,7 @@
     "tags": [
         "inpainting"
     ],
-    "description": "Experimental PartialConv2D attempt to paint with ESRGAN. Took ~10.4 days of training on a P100 and around 1.5 months in total due to Colab limits. Not sure if I will continue training it since training is very slow, but may get better.. Warning: Result can vary with different tilesizes. Try not to tile your data.",
+    "description": "Experimental PartialConv2D attempt to paint with ESRGAN. Took ~10.4 days of training on a P100 and around 1.5 months in total due to Colab limits. Not sure if I will continue training it since training is very slow, but may get better.. Warning: Result can vary with different tilesizes. Try not to tile your data.\n\nSample image: https://e.pcloud.link/publink/show?code=kZQOu7ZldzmFyMPUcFNGkEvwqOxQ8Bl3CeX",
     "date": "2020-12-05",
     "architecture": "esrgan",
     "size": [
@@ -33,10 +33,5 @@
     "trainingOTF": false,
     "dataset": "Full res yande.re images",
     "datasetSize": 9147,
-    "images": [
-        {
-            "type": "standalone",
-            "url": "https://edef1.pcloud.com/D4ZhwsKk7ZIA6bT7ZZZ8KH1o7Z3VZZnl0ZXZOyQRZaZZZQOu7ZFhcBkz5jsCBI82KOB0ThAjWd6E4k/th-1333687702-1800x952.png"
-        }
-    ]
+    "images": []
 }

--- a/data/models/2x-sudo-rife4-testV1.json
+++ b/data/models/2x-sudo-rife4-testV1.json
@@ -5,7 +5,7 @@
     "tags": [
         "pretrained"
     ],
-    "description": "Category: Pretrained SOFVSR Models\nPurpose: Animation interpolation\n\nI never really mentioned it in model-releases prior since I think not too many care about interpolation here, but I trained a rife4 model for animation a some months ago, which is better than rife4 and rife4.2 imo. Thought I should also mention it here as well. I also converted it into ncnn. (Nihuis rife ncnn models are only exported with the fastest mode and not the best quality. I exported ncnn models for the most important quality settings. Due to different export/quality settings, there are multiple models. For that reason alone, my ncnn models are much better too, since nihui only exported the fastest one.) My https://github.com/styler00dollar/VSGAN-tensorrt-docker also has the rife ncnn extention, which can use VMAF, dedup, scene detection and so on, which I would recommend. My models are in that extention as well, just select model 10, 11 or 12 and use the dev docker. That test video is done with 2x framerate, enbemble True and FastMode False, combined with scene detection and dedup stuff, tta False. Towards the best quality rife can do. Plz don't steal without credits, k thx.\n\nPretrained model: RifeV4",
+    "description": "Category: Pretrained SOFVSR Models\nPurpose: Animation interpolation\n\nI never really mentioned it in model-releases prior since I think not too many care about interpolation here, but I trained a rife4 model for animation a some months ago, which is better than rife4 and rife4.2 imo. Thought I should also mention it here as well. I also converted it into ncnn. (Nihuis rife ncnn models are only exported with the fastest mode and not the best quality. I exported ncnn models for the most important quality settings. Due to different export/quality settings, there are multiple models. For that reason alone, my ncnn models are much better too, since nihui only exported the fastest one.) My https://github.com/styler00dollar/VSGAN-tensorrt-docker also has the rife ncnn extention, which can use VMAF, dedup, scene detection and so on, which I would recommend. My models are in that extention as well, just select model 10, 11 or 12 and use the dev docker. That test video is done with 2x framerate, enbemble True and FastMode False, combined with scene detection and dedup stuff, tta False. Towards the best quality rife can do. Plz don't steal without credits, k thx.\n\nPretrained model: RifeV4\n\nSample video: https://cdn.discordapp.com/attachments/579685650824036387/990345004260151296/ngnl_sudorife.mp4",
     "date": "2022-06-25",
     "architecture": "rife",
     "size": null,
@@ -25,10 +25,5 @@
         }
     ],
     "trainingIterations": 269662,
-    "images": [
-        {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/579685650824036387/990345004260151296/ngnl_sudorife.mp4"
-        }
-    ]
+    "images": []
 }


### PR DESCRIPTION
I found 3 invalid images. 2 were videos and the last one is somewhat dead. The last one was for sudo's inpaint model. Sudo has an example image hosted by pcloud, and it seems like pcloud does not like direct image links. Pcloud download links expire after a few hours, so we can't directly link to anything on there.