### PR TITLE
Simpler download button

### DIFF
--- a/src/elements/components/download-button.tsx
+++ b/src/elements/components/download-button.tsx
@@ -104,9 +104,7 @@ export const DownloadButton = ({ resource, readonly, onChange }: DownloadButtonP
                         </svg>
                     )}
                     Download {resource.size ? `(${(resource.size / 1024 / 1024).toFixed(1)} MB)` : ''}
-                    <div className="text-center text-sm font-normal">
-                        {isExternal ? `Hosted offsite by ${host}` : 'Hosted by OpenModelDB'}
-                    </div>
+                    {isExternal && <div className="text-center text-sm font-normal">{`Hosted by ${host}`}</div>}
                 </div>
             </Link>
 


### PR DESCRIPTION
I made it so that the download button simply says "Download" when we are the hoster. I don't think there's a reason to announce that we are hosting a particular file, since we want that to become the default.

![image](https://user-images.githubusercontent.com/20878432/233990127-630a2af3-18e8-48c6-821f-090924a49f03.png)
