### PR TITLE
Add slight gradient to header background

### DIFF
--- a/src/elements/header.module.scss
+++ b/src/elements/header.module.scss
@@ -12,7 +12,8 @@
 
 .header {
     @include themed using ($t) {
-        background-color: t($t, color.change(white, $alpha: 0.8), color.change($fade-900, $alpha: 0.85));
+        background: linear-gradient(t($t, white, $fade-900), transparent)
+            t($t, color.change(white, $alpha: 0.8), color.change($fade-900, $alpha: 0.85));
     }
 
     transition: background-color linear 0.2s, border-color linear 0.2s;


### PR DESCRIPTION
This adds a gradient to the header's background. From top to bottom, it used the regular background with 100% alpha and transitions to transparent. This has the effect that whatever is behind the header gets faded out. This not only looks nice, it also prevents slight flickering caused by blurring the backdrop, and it makes header elements more readable.

![image](https://user-images.githubusercontent.com/20878432/235224689-e6fd0b04-e315-4cea-ac50-bb8cda6c7369.png)
![image](https://user-images.githubusercontent.com/20878432/235224735-710f49d5-4604-4e88-8bbc-83faa92cad17.png)
 