### PR TITLE
Removed unnecessary top padding from the model pages

### DIFF
--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -171,7 +171,7 @@ export default function Page({ modelId, modelData }: Props) {
             </Head>
             <PageContainer>
                 {/* Two columns */}
-                <div className="grid h-full w-full gap-4 py-6 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-3">
+                <div className="grid h-full w-full gap-4 pb-6 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-3">
                     {/* Left column */}
                     <div className="relative flex h-full flex-col gap-4 sm:col-span-1 lg:col-span-2">
                         <ImageCarousel


### PR DESCRIPTION
This makes the padding of the model pages consistent with the search page. This changes also saves space on mobile.

![image](https://user-images.githubusercontent.com/20878432/235225285-6d0ec264-bc2d-44f0-ba12-e45a998e6039.png)
![image](https://user-images.githubusercontent.com/20878432/235225459-d11f6a0f-d22a-456d-b1d9-a1cbc264d0ae.png)
