### PR TITLE
Improved line height of model name

### DIFF
--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -181,7 +181,7 @@ export default function Page({ modelId, modelData }: Props) {
                         />
                         <div className="relative">
                             <div>
-                                <h1 className="m-0">
+                                <h1 className="mt-0 mb-1 leading-10">
                                     <EditableLabel
                                         readonly={!editMode}
                                         text={modelData.name}


### PR DESCRIPTION
This makes long model names look more compact on mobile.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/20878432/235239909-ac523e73-7417-42f7-8937-2b0d23380b96.png) | ![image](https://user-images.githubusercontent.com/20878432/235239916-3e08679d-afb3-4fc1-8896-0ed700a79af2.png) |
