### PR TITLE
Made some model props clickable tags

### DIFF
--- a/src/elements/components/editable-tags.module.scss
+++ b/src/elements/components/editable-tags.module.scss
@@ -9,7 +9,7 @@
 .menuItem {
     border-radius: 0.5rem;
     padding: 0.25rem 0.5rem;
-    font: inherit;
+    font-family: inherit;
     font-weight: 500;
     border: none;
 

--- a/src/elements/components/editable-tags.tsx
+++ b/src/elements/components/editable-tags.tsx
@@ -7,6 +7,22 @@ import { TagId } from '../../lib/schema';
 import { compareTagId, isDerivedTags } from '../../lib/util';
 import style from './editable-tags.module.scss';
 
+export interface SmallTagProps {
+    tagId: TagId;
+    name: string;
+}
+export function SmallTag({ tagId, name }: SmallTagProps) {
+    return (
+        <Link
+            className={`${style.tag} bg-gray-200 text-xs text-gray-800 dark:bg-gray-700 dark:text-gray-100`}
+            href={`/?t=${tagId}`}
+            title={`Show all models with the ${name} tag`}
+        >
+            {name}
+        </Link>
+    );
+}
+
 export interface EditableTagsProps {
     tags: readonly TagId[];
     onChange?: (value: TagId[]) => void;
@@ -26,14 +42,11 @@ export function EditableTags({ tags, onChange, readonly }: EditableTagsProps) {
             {tags.map((tagId) => {
                 const name = tagData.get(tagId)?.name ?? `unknown tag:${tagId}`;
                 return (
-                    <Link
-                        className={`${style.tag} bg-gray-200 text-xs text-gray-800 dark:bg-gray-700 dark:text-gray-100`}
-                        href={`/?t=${tagId}`}
+                    <SmallTag
                         key={tagId}
-                        title={`Show all models with the ${name} tag`}
-                    >
-                        {name}
-                    </Link>
+                        name={name}
+                        tagId={tagId}
+                    />
                 );
             })}
         </div>

--- a/src/lib/hooks/use-update-model.ts
+++ b/src/lib/hooks/use-update-model.ts
@@ -3,12 +3,14 @@ import { DBApi } from '../data-api';
 import { Model, ModelId } from '../schema';
 import { noop } from '../util';
 
+export type UpdateModelPropertyFn = <K extends keyof Model>(key: K, value: Model[K]) => void;
+
 export interface UseUpdateModel {
-    updateModelProperty: <K extends keyof Model>(key: K, value: Model[K]) => void;
+    updateModelProperty: UpdateModelPropertyFn;
 }
 
 export function useUpdateModel(webApi: DBApi | undefined, modelId: ModelId): UseUpdateModel {
-    const updateModelProperty = useMemo<UseUpdateModel['updateModelProperty']>(() => {
+    const updateModelProperty = useMemo<UpdateModelPropertyFn>(() => {
         if (!webApi) return noop;
         return <K extends keyof Model>(key: K, value: Model[K]) => {
             const fn = async () => {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -142,11 +142,11 @@ export function isDerivedTags(id: TagId): boolean {
 export function getColorMode(numberOfChannels: number) {
     switch (numberOfChannels) {
         case 1:
-            return 'grayscale';
+            return 'Grayscale';
         case 3:
-            return 'rgb';
+            return 'RGB';
         case 4:
-            return 'rgba';
+            return 'RGBA';
         default:
             return numberOfChannels;
     }


### PR DESCRIPTION
As mentioned on discord by alsa:

> I love that I can click on tags, but for the arch details in the table I have to go back, open advanced filers and then choose them if I want to filter by that?

So I made the architecture, scale, and color mode clickable tags on the model page.
![image](https://user-images.githubusercontent.com/20878432/235766464-784ee539-091e-4caf-b1bc-cd49314c548a.png)

Clicking any one of those tags will take you to the search results of all models with that tag.