### PR TITLE
Denser advanced tag selector

### DIFF
--- a/src/elements/tag-selector.module.scss
+++ b/src/elements/tag-selector.module.scss
@@ -4,7 +4,25 @@
     color: inherit;
 
     h4 {
-        margin: 0.5em 0;
+        margin: 0.5rem 0;
+    }
+
+    &.advanced {
+        @media only screen and (min-width: 640px) {
+            display: grid;
+            grid-template-columns: 1fr 1000fr;
+
+            h4 {
+                margin: 0.1rem 1rem 0 0;
+                text-align: right;
+            }
+
+            & > div:not(:last-child) {
+                margin-bottom: 0.75rem;
+
+                // border-bottom: 1px solid #444;
+            }
+        }
     }
 }
 

--- a/src/elements/tag-selector.module.scss
+++ b/src/elements/tag-selector.module.scss
@@ -19,8 +19,6 @@
 
             & > div:not(:last-child) {
                 margin-bottom: 0.75rem;
-
-                // border-bottom: 1px solid #444;
             }
         }
     }

--- a/src/elements/tag-selector.tsx
+++ b/src/elements/tag-selector.tsx
@@ -128,13 +128,13 @@ function AdvancedTagSelector({ selection, onChange }: TagSelectorProps) {
     const { editMode } = useWebApi();
 
     return (
-        <div className={style.tagSelector}>
+        <div className={`${style.tagSelector} ${style.advanced}`}>
             {categoryOrder.map(([categoryId, category]) => {
                 if (category.tags.length === 0 || (category.editOnly && !editMode))
                     return <React.Fragment key={categoryId} />;
 
                 return (
-                    <div key={categoryId}>
+                    <React.Fragment key={categoryId}>
                         <h4>{category.name}</h4>
                         <div>
                             {category.tags.map((tagId) => {
@@ -155,7 +155,7 @@ function AdvancedTagSelector({ selection, onChange }: TagSelectorProps) {
                                 );
                             })}
                         </div>
-                    </div>
+                    </React.Fragment>
                 );
             })}
         </div>


### PR DESCRIPTION
I made the design of the advanced tag selector a little more dense to use the available screen space better. This allows to finally see all tags on my laptop without zooming out.

Before:
![image](https://user-images.githubusercontent.com/20878432/236007411-08d6720a-8869-41cb-8fb0-95e4f768ef6d.png)

After:
![image](https://user-images.githubusercontent.com/20878432/236007437-38ad71f7-90ff-4710-87b2-f28fbeecd249.png)
