### PR TITLE
Fixed react warning about path props

### DIFF
--- a/src/elements/components/header-drawer.tsx
+++ b/src/elements/components/header-drawer.tsx
@@ -58,9 +58,9 @@ export const HeaderDrawer = () => {
                         xmlns="http://www.w3.org/2000/svg"
                     >
                         <path
-                            clip-rule="evenodd"
+                            clipRule="evenodd"
                             d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                            fill-rule="evenodd"
+                            fillRule="evenodd"
                         ></path>
                     </svg>
                     <span className="sr-only">Close menu</span>


### PR DESCRIPTION
I saw this warning and fixed it. The icon still looks exactly the same.

![image](https://user-images.githubusercontent.com/20878432/236010205-6a21ad64-6be5-425f-be60-391183cdbe4b.png)
