### PR TITLE
De-buff pretrained models in search

### DIFF
--- a/src/lib/search/search-index.ts
+++ b/src/lib/search/search-index.ts
@@ -12,9 +12,9 @@ export interface CorpusEntry<Id, Tag> {
     readonly texts: readonly WeightedText[];
 }
 export interface SearchResult<Id> {
-    readonly id: Id;
+    id: Id;
     /** A score greater than zero. */
-    readonly score: number;
+    score: number;
 }
 
 export class SearchIndex<Id, Tag> {


### PR DESCRIPTION
Pretrained models are only really interesting for models trainers but not so much for regular users. So I every so slightly reduced the search score of all pretrained models. This has the effect that they will be last in the list of search results if there is no search text. If the user searches for a model by name, this de-buff is pretty much irrelevant.