### PR TITLE
Added option to sort model in search page

### DIFF
--- a/src/elements/components/model-card-grid.tsx
+++ b/src/elements/components/model-card-grid.tsx
@@ -4,7 +4,7 @@ import { ModelCard } from './model-card';
 import style from './model-card-grid.module.scss';
 
 interface ModelCardGridProps {
-    models: ModelId[];
+    models: readonly ModelId[];
     modelData: ReadonlyMap<ModelId, Model>;
     /**
      * The number models that will be eagerly displayed before lazy loading starts.

--- a/src/elements/components/model-results.module.scss
+++ b/src/elements/components/model-results.module.scss
@@ -1,3 +1,13 @@
+.controls {
+    display: flex;
+    align-items: center;
+
+    @media screen and (max-width: 380px) {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
 .sortSelector {
     display: inline-flex;
     flex-direction: row;
@@ -19,5 +29,17 @@
         list-style-type: none;
         overflow: hidden;
         min-width: 100%;
+    }
+
+    .sortIcon {
+        margin-right: 0.25rem;
+
+        &.asc {
+            transform: scaleY(-1);
+        }
+
+        &.desc {
+            transform: scaleY(1);
+        }
     }
 }

--- a/src/elements/components/model-results.module.scss
+++ b/src/elements/components/model-results.module.scss
@@ -1,0 +1,23 @@
+.sortSelector {
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+
+    .button {
+        border: none;
+        font-family: inherit;
+        color: inherit;
+        position: relative;
+        text-align: left;
+        cursor: pointer;
+    }
+
+    .options {
+        position: absolute;
+        padding-left: 0;
+        z-index: 40;
+        list-style-type: none;
+        overflow: hidden;
+        min-width: 100%;
+    }
+}

--- a/src/elements/components/model-results.tsx
+++ b/src/elements/components/model-results.tsx
@@ -1,8 +1,8 @@
 import { Listbox, Transition } from '@headlessui/react';
 import { Fragment, memo, useMemo, useState } from 'react';
-import { FiChevronDown } from 'react-icons/fi';
+import { MdSort } from 'react-icons/md';
 import { Model, ModelId } from '../../lib/schema';
-import { Sort, sortModels } from '../../lib/sort-models';
+import { Sort, parseSort, sortModels } from '../../lib/sort-models';
 import { typedEntries } from '../../lib/util';
 import { ModelCardGrid } from './model-card-grid';
 import style from './model-results.module.scss';
@@ -22,7 +22,7 @@ export const ModelResults = memo(({ models, modelData }: ModelResultsProps) => {
 
     return (
         <>
-            <div className="mb-3 flex flex-col sm:flex-row sm:items-center">
+            <div className={`${style.controls} mb-3`}>
                 <span className="mx-3">
                     Found <span className="font-medium">{sortedModels.length}</span> model
                     {sortedModels.length === 1 ? '' : 's'}
@@ -54,6 +54,8 @@ const SORT_OPTIONS: Readonly<Record<Sort, { label: string; hide?: boolean }>> = 
 };
 
 export function SortSelector({ sort, setSort }: { sort: Sort; setSort: (sort: Sort) => void }) {
+    const [, order] = parseSort(sort);
+
     return (
         <div className={style.sortSelector}>
             <Listbox
@@ -62,11 +64,11 @@ export function SortSelector({ sort, setSort }: { sort: Sort; setSort: (sort: So
             >
                 <div className="relative">
                     <Listbox.Button
-                        className={`${style.button} w-full rounded-lg bg-transparent py-1 pl-3 pr-9 text-base hover:bg-gray-200 ui-open:bg-gray-200 dark:hover:bg-gray-700 dark:ui-open:bg-gray-700`}
+                        className={`${style.button} w-full rounded-lg bg-transparent py-1 pl-9 pr-3 text-base hover:bg-gray-200 ui-open:bg-gray-200 dark:hover:bg-gray-700 dark:ui-open:bg-gray-700`}
                     >
                         <span className="block truncate">{SORT_OPTIONS[sort].label}</span>
-                        <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
-                            <FiChevronDown />
+                        <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                            <MdSort className={`${style.sortIcon} ${style[order]}`} />
                         </span>
                     </Listbox.Button>
                     <Transition

--- a/src/elements/components/model-results.tsx
+++ b/src/elements/components/model-results.tsx
@@ -1,0 +1,116 @@
+import { Listbox, Transition } from '@headlessui/react';
+import { Fragment, memo, useMemo, useState } from 'react';
+import { FiChevronDown } from 'react-icons/fi';
+import { Model, ModelId } from '../../lib/schema';
+import { Sort, sortModels } from '../../lib/sort-models';
+import { typedEntries } from '../../lib/util';
+import { ModelCardGrid } from './model-card-grid';
+import style from './model-results.module.scss';
+
+interface ModelResultsProps {
+    modelData: ReadonlyMap<ModelId, Model>;
+    models: readonly ModelId[];
+}
+
+// eslint-disable-next-line react/display-name
+export const ModelResults = memo(({ models, modelData }: ModelResultsProps) => {
+    const [sort, setSort] = useState<Sort>('relevance-desc');
+
+    const sortedModels = useMemo(() => {
+        return sortModels(models, sort, modelData);
+    }, [models, sort, modelData]);
+
+    return (
+        <>
+            <div className="mb-3 flex flex-col sm:flex-row sm:items-center">
+                <span className="mx-3">
+                    Found <span className="font-medium">{sortedModels.length}</span> model
+                    {sortedModels.length === 1 ? '' : 's'}
+                </span>
+                <span className="h-1 flex-grow" />
+                <SortSelector
+                    setSort={setSort}
+                    sort={sort}
+                />
+            </div>
+            <ModelCardGrid
+                lazyOffset={12}
+                modelData={modelData}
+                models={sortedModels}
+            />
+        </>
+    );
+});
+
+const SORT_OPTIONS: Readonly<Record<Sort, { label: string; hide?: boolean }>> = {
+    'relevance-desc': { label: 'Relevance' },
+    'relevance-asc': { label: 'Relevance', hide: true },
+    'date-desc': { label: 'Latest' },
+    'date-asc': { label: 'Oldest', hide: true },
+    'scale-desc': { label: 'Largest Scale' },
+    'scale-asc': { label: 'Smallest Scale' },
+    'size-desc': { label: 'Largest Size' },
+    'size-asc': { label: 'Smallest Size' },
+};
+
+export function SortSelector({ sort, setSort }: { sort: Sort; setSort: (sort: Sort) => void }) {
+    return (
+        <div className={style.sortSelector}>
+            <Listbox
+                value={sort}
+                onChange={setSort}
+            >
+                <div className="relative">
+                    <Listbox.Button
+                        className={`${style.button} w-full rounded-lg bg-transparent py-1 pl-3 pr-9 text-base hover:bg-gray-200 ui-open:bg-gray-200 dark:hover:bg-gray-700 dark:ui-open:bg-gray-700`}
+                    >
+                        <span className="block truncate">{SORT_OPTIONS[sort].label}</span>
+                        <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
+                            <FiChevronDown />
+                        </span>
+                    </Listbox.Button>
+                    <Transition
+                        as={Fragment}
+                        leave="transition ease-in duration-100"
+                        leaveFrom="opacity-100"
+                        leaveTo="opacity-0"
+                    >
+                        <Listbox.Options
+                            className={`${style.options} mt-1 rounded-md border border-solid border-gray-300 bg-white text-base shadow-lg dark:border-gray-700 dark:bg-fade-800 sm:right-0 sm:text-sm`}
+                        >
+                            {typedEntries(SORT_OPTIONS).map(([value, { label, hide }]) => {
+                                if (hide) return null;
+
+                                return (
+                                    <Listbox.Option
+                                        className={({ active }) =>
+                                            `relative cursor-pointer select-none py-2 px-4 ${
+                                                active
+                                                    ? 'bg-gray-200 text-black dark:bg-accent-600 dark:text-white'
+                                                    : ''
+                                            }`
+                                        }
+                                        key={value}
+                                        value={value}
+                                    >
+                                        {({ selected }) => (
+                                            <>
+                                                <span
+                                                    className={`block truncate ${
+                                                        selected ? 'font-medium' : 'font-normal'
+                                                    }`}
+                                                >
+                                                    {label}
+                                                </span>
+                                            </>
+                                        )}
+                                    </Listbox.Option>
+                                );
+                            })}
+                        </Listbox.Options>
+                    </Transition>
+                </div>
+            </Listbox>
+        </div>
+    );
+}

--- a/src/lib/sort-models.ts
+++ b/src/lib/sort-models.ts
@@ -1,0 +1,80 @@
+import { Model, ModelId } from './schema';
+import { EMPTY_ARRAY, assertNever } from './util';
+
+export type Sort = `${SortBy}-${SortOrder}`;
+export type SortBy = 'relevance' | 'date' | 'scale' | 'size';
+export type SortOrder = 'asc' | 'desc';
+
+export type ParsedSort = [SortBy, SortOrder];
+export type ParsedSortOf<T extends Sort> = T extends `${infer By extends SortBy}-${infer Order extends SortOrder}`
+    ? [By, Order]
+    : never;
+
+export function parseSort<S extends Sort>(sort: S): ParsedSortOf<S> {
+    return sort.split('-') as ParsedSortOf<S>;
+}
+
+export function sortModels(
+    models: readonly ModelId[],
+    sort: Sort,
+    modelData: ReadonlyMap<ModelId, Model>
+): readonly ModelId[] {
+    // we assume that models are sorted by relevance desc by default
+    if (sort === 'relevance-desc') {
+        return models;
+    } else if (sort === 'relevance-asc') {
+        return [...models].reverse();
+    }
+
+    const [by, order] = parseSort(sort);
+    const compare = getCompareFn(by, order, modelData);
+    return [...models].sort(compare);
+}
+
+function getCompareFn(
+    by: Exclude<SortBy, 'relevance'>,
+    order: SortOrder,
+    modelData: ReadonlyMap<ModelId, Model>
+): (a: ModelId, b: ModelId) => number {
+    const keyFn = getSortKeyFn(by, modelData);
+    const unknown = order === 'asc' ? 1e100 : -1e100;
+    const f = order === 'asc' ? 1 : -1;
+    return (a, b) => f * ((keyFn(a) ?? unknown) - (keyFn(b) ?? unknown));
+}
+function getSortKeyFn(
+    by: Exclude<SortBy, 'relevance'>,
+    modelData: ReadonlyMap<ModelId, Model>
+): (id: ModelId) => number | undefined {
+    switch (by) {
+        case 'date':
+            return (id) => {
+                const date = modelData.get(id)?.date;
+                if (!date) {
+                    return undefined;
+                }
+                return Date.parse(date);
+            };
+
+        case 'scale':
+            return (id) => modelData.get(id)?.scale;
+
+        case 'size':
+            return (id) => {
+                const resources = modelData.get(id)?.resources ?? EMPTY_ARRAY;
+
+                // find the minimum size
+                let size: number | undefined = undefined;
+                for (const resource of resources) {
+                    if (resource.size !== null) {
+                        if (size === undefined || resource.size < size) {
+                            size = resource.size;
+                        }
+                    }
+                }
+                return size;
+            };
+
+        default:
+            return assertNever(by);
+    }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import { GetStaticProps } from 'next';
 import React, { useCallback, useMemo, useState } from 'react';
 import { Link } from '../elements/components/link';
-import { ModelCardGrid } from '../elements/components/model-card-grid';
+import { ModelResults } from '../elements/components/model-results';
 import { SearchBar } from '../elements/components/searchbar';
 import { HeadCommon } from '../elements/head-common';
 import { PageContainer } from '../elements/page';
@@ -148,17 +148,10 @@ export default function Page({ modelData: staticModelData }: Props) {
 
                 {/* Model Cards */}
                 {selectedModels.length > 0 ? (
-                    <>
-                        <div className="mb-3 ml-3">
-                            Found <span className="font-medium">{selectedModels.length}</span> model
-                            {selectedModels.length === 1 ? '' : 's'}
-                        </div>
-                        <ModelCardGrid
-                            lazyOffset={12}
-                            modelData={modelData}
-                            models={selectedModels}
-                        />
-                    </>
+                    <ModelResults
+                        modelData={modelData}
+                        models={selectedModels}
+                    />
                 ) : (
                     <div className="flex flex-col items-center justify-center p-6">
                         <div className="text-2xl font-bold text-accent-500 dark:text-gray-100">No models found</div>


### PR DESCRIPTION
Resolves #182.

This PR adds the `ModelResults` which can sort models by arbitrary criteria. Right now, I added sorting by relevance, date, scale, and size. The default sort mode is "relevance", which doesn't sort the models at all, because `ModelResults` assumes that models are sorted by relevance to begin with.

I'm not really happy with the design of the dropdown, but I can't think of something better rn.

![image](https://user-images.githubusercontent.com/20878432/236695667-2d09b2f1-4b9d-4ada-814e-725f7d0a833c.png)

![image](https://user-images.githubusercontent.com/20878432/236695503-cc7e8c23-ceb9-4c79-984b-b2878552b38d.png)

![image](https://user-images.githubusercontent.com/20878432/236695754-c4b459b9-eec7-4a10-934b-6130f3377313.png)
