### PR TITLE
Fixed sort dropdown alignment

### DIFF
--- a/src/elements/components/model-results.module.scss
+++ b/src/elements/components/model-results.module.scss
@@ -29,6 +29,10 @@
         list-style-type: none;
         overflow: hidden;
         min-width: 100%;
+        right: 0;
+        @media screen and (max-width: 380px) {
+            right: auto;
+        }
     }
 
     .sortIcon {

--- a/src/elements/components/model-results.tsx
+++ b/src/elements/components/model-results.tsx
@@ -78,7 +78,7 @@ export function SortSelector({ sort, setSort }: { sort: Sort; setSort: (sort: So
                         leaveTo="opacity-0"
                     >
                         <Listbox.Options
-                            className={`${style.options} mt-1 rounded-md border border-solid border-gray-300 bg-white text-base shadow-lg dark:border-gray-700 dark:bg-fade-800 sm:right-0 sm:text-sm`}
+                            className={`${style.options} mt-1 rounded-md border border-solid border-gray-300 bg-white text-base shadow-lg dark:border-gray-700 dark:bg-fade-800 sm:text-sm`}
                         >
                             {typedEntries(SORT_OPTIONS).map(([value, { label, hide }]) => {
                                 if (hide) return null;


### PR DESCRIPTION
When I changed the breakpoint for mobile, I forgot to update it for the alignment of the dropdown too. The dropdown is right aligned on large screens and left aligned on small ones.