### PR TITLE
Show similar models

### DIFF
--- a/src/lib/hooks/use-models.ts
+++ b/src/lib/hooks/use-models.ts
@@ -33,18 +33,21 @@ export function useModels(models?: Readonly<Record<ModelId, Model>>): UseModels 
 
     useEffect(() => update(staticData), [update, staticData]);
 
-    useEffect(() => {
-        startListeningForUpdates();
-        return addUpdateListener(() => {
-            getWebApi()
-                .then(async (webApi) => {
-                    if (!webApi) return;
-                    const models = await webApi.models.getAll();
-                    update(models);
-                })
-                .catch((e) => console.error(e));
-        });
+    const updateWithWebApi = useCallback((): void => {
+        getWebApi()
+            .then(async (webApi) => {
+                if (!webApi) return;
+                const models = await webApi.models.getAll();
+                update(models);
+            })
+            .catch((e) => console.error(e));
     }, [update]);
+
+    useEffect(() => {
+        updateWithWebApi();
+        startListeningForUpdates();
+        return addUpdateListener(updateWithWebApi);
+    }, [updateWithWebApi]);
 
     return { modelData: data };
 }

--- a/src/lib/hooks/use-models.ts
+++ b/src/lib/hooks/use-models.ts
@@ -31,8 +31,6 @@ export function useModels(models?: Readonly<Record<ModelId, Model>>): UseModels 
         });
     }, []);
 
-    useEffect(() => update(staticData), [update, staticData]);
-
     const updateWithWebApi = useCallback((): void => {
         getWebApi()
             .then(async (webApi) => {
@@ -44,7 +42,11 @@ export function useModels(models?: Readonly<Record<ModelId, Model>>): UseModels 
     }, [update]);
 
     useEffect(() => {
+        update(staticData);
         updateWithWebApi();
+    }, [update, updateWithWebApi, staticData]);
+
+    useEffect(() => {
         startListeningForUpdates();
         return addUpdateListener(updateWithWebApi);
     }, [updateWithWebApi]);

--- a/src/lib/server/cached-models.ts
+++ b/src/lib/server/cached-models.ts
@@ -1,0 +1,17 @@
+import { Model, ModelId } from '../schema';
+import { fileApi, getFileApiMutationCounterUnsynchronized } from './file-data';
+
+let cached_models: ReadonlyMap<ModelId, Model> | undefined = undefined;
+let cached_mutation_counter = 0;
+/**
+ * This is a cached version of `fileApi.models.getAll()`.
+ *
+ * The caller is not allowed to mutate the returned map or any of its values.
+ */
+export async function getCachedModels(): Promise<ReadonlyMap<ModelId, Model>> {
+    if (cached_models === undefined || cached_mutation_counter !== getFileApiMutationCounterUnsynchronized()) {
+        cached_models = await fileApi.models.getAll();
+        cached_mutation_counter = getFileApiMutationCounterUnsynchronized();
+    }
+    return cached_models;
+}

--- a/src/lib/server/file-data.ts
+++ b/src/lib/server/file-data.ts
@@ -327,7 +327,7 @@ const addMutation = () => {
 };
 const wrapCollection = <Id, Value>(collection: CollectionApi<Id, Value>): CollectionApi<Id, Value> => {
     collection = new SynchronizedCollection(collection, fileLock);
-    collection = notifyOnWrite(collection, { after: addMutation });
+    collection = notifyOnWrite(collection, { before: addMutation, after: addMutation });
     return collection;
 };
 
@@ -341,6 +341,9 @@ export const fileApi: DBApi = {
 
 export function getFileApiMutationCounter(): Promise<number> {
     return fileLock.read(() => Promise.resolve(mutationCounter));
+}
+export function getFileApiMutationCounterUnsynchronized(): number {
+    return mutationCounter;
 }
 
 const watcher = new FSWatcher({ persistent: false, ignorePermissionErrors: true, usePolling: true });

--- a/src/lib/similar.ts
+++ b/src/lib/similar.ts
@@ -1,0 +1,101 @@
+import { Arch, ArchId, Model, ModelId, TagId } from './schema';
+import { asArray } from './util';
+
+export interface SimilarModel {
+    readonly id: ModelId;
+    readonly score: number;
+}
+
+export function getSimilarModels(
+    refId: ModelId,
+    models: ReadonlyMap<ModelId, Model>,
+    architectures: ReadonlyMap<ArchId, Arch>
+): SimilarModel[] {
+    const simScorer = createSimilarityScorer(models, architectures);
+    const ref = models.get(refId);
+    if (!ref) return [];
+
+    const ids: SimilarModel[] = [];
+    for (const [id, model] of models) {
+        if (id === refId) continue;
+
+        let score = simScorer(ref, model);
+        if (score <= 0) continue;
+
+        // punish missing data
+        if (!model.license) score -= 0.1;
+        if (!model.images.length) score -= 0.15;
+
+        ids.push({ id, score });
+    }
+
+    // sort by score (and id for stability)
+    ids.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+
+    return ids;
+}
+
+export function createSimilarityScorer(
+    models: ReadonlyMap<ModelId, Model>,
+    architectures: ReadonlyMap<ArchId, Arch>
+): (ref: Model, other: Model) => number {
+    const tagUsage = new Map<TagId, number>();
+    for (const model of models.values()) {
+        for (const tag of model.tags) {
+            tagUsage.set(tag, (tagUsage.get(tag) || 0) + 1);
+        }
+    }
+    const colorModeUsage = new Map<string, number>();
+    for (const model of models.values()) {
+        const colorMode = getColorModel(model);
+        colorModeUsage.set(colorMode, (colorModeUsage.get(colorMode) || 0) + 1);
+    }
+
+    return (ref, other) => {
+        // same input type is required
+        const refArch = architectures.get(ref.architecture);
+        const otherArch = architectures.get(other.architecture);
+        if (!refArch || !otherArch || refArch.input !== otherArch.input) {
+            return 0;
+        }
+
+        let score = 0;
+
+        // similar tags are important
+        // we want to punish models with a lot more tags than the reference
+        const tagPunish = 1 / (Math.max(0, other.tags.length - Math.max(4, ref.tags.length + 1)) + 1) ** 0.5;
+        for (const tag of ref.tags) {
+            if (other.tags.includes(tag)) {
+                score += (tagPunish * 10) / (tagUsage.get(tag) ?? 1) ** 0.5;
+            }
+        }
+        // no tags in common is a deal breaker
+        if (score === 0) return 0;
+
+        // same scale is a bit important
+        if (ref.scale === other.scale) {
+            score += 1;
+        }
+        // 1x models typically have a different function than >=2x models
+        if ((ref.scale === 1) === (other.scale === 1)) {
+            score += 1;
+        }
+
+        // same color mode is very important
+        const colorModel = getColorModel(ref);
+        if (colorModel === getColorModel(other)) {
+            score += 2 / (colorModeUsage.get(colorModel) ?? 1) ** 0.5;
+        }
+
+        // same author indicates model families
+        if (asArray(ref.author).some((a) => asArray(other.author).includes(a))) {
+            score += 0.2;
+        }
+
+        return score;
+    };
+}
+
+function getColorModel(m: Model): string {
+    return `${m.inputChannels}-${m.outputChannels}`;
+}

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -114,6 +114,8 @@ export function withoutHash(urlFragment: string, removeTrailingSlash = true): st
     return fragment;
 }
 
+export function typedEntries<K extends string, V>(o: Record<K, V>): [K, V][];
+export function typedEntries<K extends string, V>(o: Partial<Record<K, V>>): [K, V | undefined][];
 export function typedEntries<K extends string, V>(o: Record<K, V>): [K, V][] {
     return Object.entries(o) as [K, V][];
 }

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -28,7 +28,7 @@ import { getSimilarModels } from '../../lib/similar';
 import { STATIC_ARCH_DATA } from '../../lib/static-data';
 import { asArray, getColorMode, getPreviewImage, joinListString, typedEntries } from '../../lib/util';
 
-const MAX_SIMILAR_MODELS = 36;
+const MAX_SIMILAR_MODELS = 12 * 2;
 
 interface Params extends ParsedUrlQuery {
     id: ModelId;
@@ -244,7 +244,7 @@ function MetadataTable({ rows }: { rows: (false | null | undefined | readonly [s
                     return (
                         <tr key={i}>
                             <th
-                                className="whitespace-nowrap bg-fade-100 px-6 py-4 font-medium text-fade-900 dark:bg-fade-800 dark:text-white"
+                                className="bg-fade-100 px-6 py-4 font-medium text-fade-900 dark:bg-fade-800 dark:text-white sm:whitespace-nowrap"
                                 scope="row"
                             >
                                 {label}
@@ -282,13 +282,13 @@ export default function Page({ modelId, similar: staticSimilar, modelData: stati
     }
 
     const [similar, similarWithScores] = useMemo(() => {
-        if (editMode && modelData.size > Object.keys(staticModelData).length) {
+        if (modelData.size > Object.keys(staticModelData).length) {
             const withScores = getSimilarModels(modelId, modelData, archData).slice(0, MAX_SIMILAR_MODELS);
             return [withScores.map(({ id }) => id), withScores];
         } else {
             return [staticSimilar, []];
         }
-    }, [editMode, staticSimilar, staticModelData, modelData, modelId, archData]);
+    }, [staticSimilar, staticModelData, modelData, modelId, archData]);
 
     return (
         <>
@@ -305,7 +305,7 @@ export default function Page({ modelId, similar: staticSimilar, modelData: stati
             </Head>
             <PageContainer>
                 {/* Two columns */}
-                <div className="grid h-full w-full gap-4 pb-6 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-3">
+                <div className="grid h-full w-full gap-4 pb-4 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-3">
                     {/* Left column */}
                     <div className="relative flex h-full flex-col gap-4 sm:col-span-1 lg:col-span-2">
                         <ImageCarousel
@@ -500,23 +500,26 @@ export default function Page({ modelId, similar: staticSimilar, modelData: stati
                         </div>
                     </div>
                 </div>
-                <div>
-                    <h2 className="text-lg font-bold">Similar Models</h2>
-                    {editMode && similarWithScores.length > 0 && (
-                        <details>
-                            <summary>Show scores</summary>{' '}
-                            <pre className="overflow-auto">
-                                {similarWithScores
-                                    .map(({ id, score }) => `${score.toFixed(2).padEnd(6)} ${id}`)
-                                    .join('\n')}
-                            </pre>
-                        </details>
-                    )}
-                    <ModelCardGrid
-                        modelData={modelData}
-                        models={similar}
-                    />
-                </div>
+                {similar.length > 0 && (
+                    <div>
+                        <h2 className="text-lg font-bold">Similar Models</h2>
+                        {editMode && similarWithScores.length > 0 && (
+                            <details>
+                                <summary>Show scores</summary>{' '}
+                                <pre className="overflow-auto">
+                                    {similarWithScores
+                                        .map(({ id, score }) => `${score.toFixed(2).padEnd(6)} ${id}`)
+                                        .join('\n')}
+                                </pre>
+                            </details>
+                        )}
+                        <ModelCardGrid
+                            modelData={modelData}
+                            models={similar}
+                        />
+                    </div>
+                )}
+                <div className="h-6" />
             </PageContainer>
         </>
     );

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -22,8 +22,10 @@ import { useUsers } from '../../lib/hooks/use-users';
 import { useWebApi } from '../../lib/hooks/use-web-api';
 import { MODEL_PROPS } from '../../lib/model-props';
 import { ArchId, Image, Model, ModelId, Resource, TagId } from '../../lib/schema';
+import { getCachedModels } from '../../lib/server/cached-models';
 import { fileApi } from '../../lib/server/file-data';
 import { getSimilarModels } from '../../lib/similar';
+import { STATIC_ARCH_DATA } from '../../lib/static-data';
 import { asArray, getColorMode, getPreviewImage, joinListString, typedEntries } from '../../lib/util';
 
 const MAX_SIMILAR_MODELS = 36;
@@ -533,8 +535,8 @@ export const getStaticProps: GetStaticProps<Props, Params> = async (context) => 
     const modelId = context.params?.id;
     if (!modelId) throw new Error("Missing path param 'id'");
 
-    const modelData = await fileApi.models.getAll();
-    const archData = await fileApi.architectures.getAll();
+    const modelData = await getCachedModels();
+    const archData = STATIC_ARCH_DATA;
 
     const similar = getSimilarModels(modelId, modelData, archData)
         .slice(0, MAX_SIMILAR_MODELS)

--- a/src/pages/users/[id].tsx
+++ b/src/pages/users/[id].tsx
@@ -6,6 +6,7 @@ import { HeadCommon } from '../../elements/head-common';
 import { PageContainer } from '../../elements/page';
 import { useModels } from '../../lib/hooks/use-models';
 import { Model, ModelId, User, UserId } from '../../lib/schema';
+import { getCachedModels } from '../../lib/server/cached-models';
 import { fileApi } from '../../lib/server/file-data';
 
 interface Params extends ParsedUrlQuery {
@@ -62,7 +63,7 @@ export const getStaticProps: GetStaticProps<Props, Params> = async (context) => 
     if (!userId) throw new Error("Missing path param 'id'");
 
     const user = await fileApi.users.get(userId);
-    const models = await fileApi.models.getAll();
+    const models = await getCachedModels();
 
     return {
         props: {


### PR DESCRIPTION
Resolves #197.

This PR adds a section of similar models below the regular model page. It will show the 24 most similar models (or less, if there aren't that many) using our regular model grid. 

In edit mode, we'll also get the option to see the similarity scores. We'll probably need to tweak the sim score in the future, so this will come in handy. 

![image](https://user-images.githubusercontent.com/20878432/236938669-6fcdeee5-8f50-46f9-b7e6-f2ba5af5af64.png)


Other changes:
- Fixed `useModels` not always updating correctly.
- Added `getCachedModels` for improved build performance.
- Added `MetadataTable` component to reduce code duplication. This was supposed to be its own PR, but I worked on it and this PR at the same time, and untangling them became a mess. So there's one PR now...