### PR TITLE
Add blur effect to paired image cards

### DIFF
--- a/src/elements/components/model-card.module.scss
+++ b/src/elements/components/model-card.module.scss
@@ -1,3 +1,6 @@
+@use 'sass:color';
+
+@import '../util.module';
 @import '../../styles/theme';
 
 .modelCard {
@@ -53,10 +56,11 @@
     .paired {
         position: absolute;
 
-        backdrop-filter: blur(2rem);
+        backdrop-filter: blur(2rem) saturate(1.5) opacity(0.95);
 
         @include themed using($t) {
-            background-color: t($t, rgba(255, 255, 255, 0.75), rgba(0, 0, 0, 0.75));
+            background: linear-gradient(transparent, t($t, white, $fade-900))
+                t($t, color.change(white, $alpha: 0.7), color.change($fade-900, $alpha: 0.7));
         }
     }
 

--- a/src/elements/components/model-card.module.scss
+++ b/src/elements/components/model-card.module.scss
@@ -1,9 +1,12 @@
+@import '../../styles/theme';
+
 .modelCard {
     position: relative;
     height: 350px;
     border-radius: 0.5rem;
     border-width: 1px;
     border-style: solid;
+    overflow: hidden;
 
     .inner {
         position: relative;
@@ -35,7 +38,6 @@
     }
 
     .details {
-        position: relative;
         left: 0;
         bottom: 0;
         right: 0;
@@ -45,6 +47,16 @@
         a.name {
             word-break: normal;
             overflow-wrap: anywhere;
+        }
+    }
+
+    .paired {
+        position: absolute;
+
+        backdrop-filter: blur(2rem);
+
+        @include themed using($t) {
+            background-color: t($t, rgba(255, 255, 255, 0.75), rgba(0, 0, 0, 0.75));
         }
     }
 

--- a/src/elements/components/model-card.module.scss
+++ b/src/elements/components/model-card.module.scss
@@ -56,7 +56,7 @@
     .paired {
         position: absolute;
 
-        backdrop-filter: blur(2rem) saturate(1.5) opacity(0.95);
+        backdrop-filter: blur(2rem) saturate(2);
 
         @include themed using($t) {
             background: linear-gradient(transparent, t($t, white, $fade-900))

--- a/src/elements/components/model-card.module.scss
+++ b/src/elements/components/model-card.module.scss
@@ -60,7 +60,7 @@
 
         @include themed using($t) {
             background: linear-gradient(transparent, t($t, white, $fade-900))
-                t($t, color.change(white, $alpha: 0.7), color.change($fade-900, $alpha: 0.7));
+                t($t, color.change(white, $alpha: 0.7), color.change($fade-900, $alpha: 0.8));
         }
     }
 

--- a/src/elements/components/model-card.tsx
+++ b/src/elements/components/model-card.tsx
@@ -43,7 +43,7 @@ const SideBySideImage = ({ model, image }: { model: Model; image: Image }) => {
             <div className="relative flex h-full w-1/2 content-center overflow-hidden align-middle">
                 <img
                     alt={model.name}
-                    className="rendering-pixelated absolute top-1/2 left-1/2 z-0 m-auto object-cover object-center"
+                    className="rendering-pixelated absolute top-1/3 left-1/2 z-0 m-auto object-cover object-center"
                     loading="lazy"
                     src={image.LR}
                     style={{
@@ -63,7 +63,7 @@ const SideBySideImage = ({ model, image }: { model: Model; image: Image }) => {
             <div className="relative flex h-full w-1/2 content-center overflow-hidden align-middle">
                 <img
                     alt={model.name}
-                    className="rendering-pixelated absolute top-1/2 left-1/2 z-0 m-auto object-cover object-center"
+                    className="rendering-pixelated absolute top-1/3 left-1/2 z-0 m-auto object-cover object-center"
                     loading="lazy"
                     src={image.SR}
                     style={{
@@ -150,7 +150,7 @@ export const ModelCardContent = memo(({ id, model }: BaseModelCardProps) => {
                 {getModelCardImageComponent(model)}
             </Link>
 
-            <div className={style.details}>
+            <div className={joinClasses(style.details, model.images[0]?.type === 'paired' && style.paired)}>
                 <Link
                     className={`${style.name} block text-xl font-bold text-gray-800 dark:text-gray-100`}
                     href={`/models/${id}`}


### PR DESCRIPTION
I think it gives it a nice effect. It only gets applied to paired images, the standalone and "no image" ones are like they were before. I also had to shift the images up to get them approximately where they were positioned before this change pushed them down a bit.

![image](https://github.com/OpenModelDB/open-model-database/assets/34788790/66a5d912-b5a4-42b1-ac99-a00a8fac57c8)
