### PR TITLE
Replace padding with margin to hide overflow

### DIFF
--- a/src/elements/components/model-card.tsx
+++ b/src/elements/components/model-card.tsx
@@ -173,7 +173,7 @@ export const ModelCardContent = memo(({ id, model }: BaseModelCardProps) => {
                 </div>
 
                 {/* Description */}
-                <div className="mb-1 py-1 text-sm text-gray-600 line-clamp-3 dark:text-gray-400">{description}</div>
+                <div className="mb-2 mt-1 text-sm text-gray-600 line-clamp-3 dark:text-gray-400">{description}</div>
 
                 {/* Tags */}
                 <div className="flex flex-row flex-wrap gap-1 text-xs">


### PR DESCRIPTION
This maybe fixes an issue I noticed. On mobile, you'll sometimes see one pixel of the text on the fourth line. The description div already has `overflow: hidden`, but it also has padding. So I replaced the padding with margin to make sure the fourth line is no longer juuust visible because of padding. 