### PR TITLE
Always lower-case sha256

### DIFF
--- a/src/elements/components/download-button-edit-popover.tsx
+++ b/src/elements/components/download-button-edit-popover.tsx
@@ -58,7 +58,7 @@ function ResourceMenu({ resource, onChange }: EditResourceProps) {
                     id="resource-sha256"
                     type="string"
                     value={sha256}
-                    onChange={(e) => setSHA256(e.target.value)}
+                    onChange={(e) => setSHA256(e.target.value.toLowerCase())}
                 />
             </div>
             <div className="flex flex-col">


### PR DESCRIPTION
Checksum hexadecimals should always be lower case for consistency.