### PR TITLE
Add model page

### DIFF
--- a/src/elements/header.tsx
+++ b/src/elements/header.tsx
@@ -1,13 +1,11 @@
 /* eslint-disable jsx-a11y/alt-text */
 /* eslint-disable @next/next/no-img-element */
-import { useRouter } from 'next/router';
 import React from 'react';
 import { FaDiscord, FaGithub } from 'react-icons/fa';
 import { MdDarkMode, MdLightMode } from 'react-icons/md';
 import Logo from '../../public/logo.svg';
 import { toggleColorScheme } from '../lib/color-scheme';
-import { useEditModeToggle, useWebApi } from '../lib/hooks/use-web-api';
-import { ModelId } from '../lib/schema';
+import { useEditModeToggle } from '../lib/hooks/use-web-api';
 import { joinClasses } from '../lib/util';
 import { HeaderDrawer } from './components/header-drawer';
 import { Link } from './components/link';
@@ -15,8 +13,6 @@ import style from './header.module.scss';
 
 export function Header() {
     const { editModeAvailable, editMode, toggleEditMode } = useEditModeToggle();
-    const router = useRouter();
-    const { webApi } = useWebApi();
 
     return (
         <>
@@ -43,62 +39,17 @@ export function Header() {
                     >
                         How To Upscale
                     </Link>
-                    {editMode && webApi && (
-                        <button
+                    {editMode && (
+                        <Link
                             className={joinClasses(
                                 style.docLink,
-                                'bg-transparent font-medium tracking-wide text-accent hover:bg-fade-100 dark:text-accent-400 dark:hover:bg-fade-800',
+                                'font-medium tracking-wide text-accent hover:bg-fade-100 dark:text-accent-400 dark:hover:bg-fade-800',
                                 style.hideMobile
                             )}
-                            onClick={() => {
-                                (async () => {
-                                    const modelId = prompt('Enter model ID');
-                                    if (!modelId) {
-                                        return;
-                                    }
-                                    const arches = await webApi.architectures.getAll();
-                                    if (!arches.size) {
-                                        return;
-                                    }
-                                    const firstArch = [...arches.entries()][0][0];
-                                    webApi.models
-                                        .update([
-                                            [
-                                                modelId as ModelId,
-                                                {
-                                                    name: modelId,
-                                                    author: [],
-                                                    license: null,
-                                                    tags: [],
-                                                    description: '',
-                                                    date: new Date().toISOString().split('T')[0],
-                                                    architecture: firstArch,
-                                                    size: null,
-                                                    scale: 4,
-                                                    inputChannels: 3,
-                                                    outputChannels: 3,
-                                                    resources: [],
-                                                    images: [],
-                                                },
-                                            ],
-                                        ])
-                                        .then(() => {
-                                            setTimeout(() => {
-                                                router.push(`/models/${modelId}`).catch((error) => {
-                                                    console.error(error);
-                                                });
-                                            }, 1000);
-                                        })
-                                        .catch((error) => {
-                                            console.error(error);
-                                        });
-                                })().catch((error) => {
-                                    console.error(error);
-                                });
-                            }}
+                            href="/add-model"
                         >
                             Add Model
-                        </button>
+                        </Link>
                     )}
 
                     <span className={style.spacer} />

--- a/src/pages/add-model.tsx
+++ b/src/pages/add-model.tsx
@@ -1,0 +1,136 @@
+import { useRouter } from 'next/router';
+import React, { useState } from 'react';
+import { EditableIntegerLabel } from '../elements/components/editable-label';
+import { HeadCommon } from '../elements/head-common';
+import { PageContainer } from '../elements/page';
+import { useModels } from '../lib/hooks/use-models';
+import { useWebApi } from '../lib/hooks/use-web-api';
+import { ArchId, Model, ModelId } from '../lib/schema';
+import { delay } from '../lib/util';
+
+function PageContent() {
+    const { modelData } = useModels();
+    const router = useRouter();
+    const { webApi, editMode } = useWebApi();
+
+    const [pretrained, setPretrained] = useState<ModelId | ''>('');
+    const [idName, setIdName] = useState('Unknown');
+    const [scale, setScale] = useState(1);
+    const fullId = `${scale}x-${idName}` as ModelId;
+
+    if (!editMode || !modelData.size) return null;
+
+    const addModel = async () => {
+        if (modelData.has(fullId)) {
+            alert(`Model ${fullId} already exists`);
+            return;
+        }
+
+        const model: Model = {
+            name: idName,
+            author: [],
+            license: null,
+            tags: [],
+            description: '',
+            date: new Date().toISOString().split('T')[0],
+            architecture: 'esrgan' as ArchId,
+            size: null,
+            scale,
+            inputChannels: 3,
+            outputChannels: 3,
+            resources: [],
+            images: [],
+        };
+
+        const pre = pretrained ? modelData.get(pretrained) : undefined;
+        if (pre && pretrained) {
+            model.architecture = pre.architecture;
+            model.inputChannels = pre.inputChannels;
+            model.outputChannels = pre.outputChannels;
+            model.size = pre.size;
+            model.pretrainedModelG = pretrained;
+        }
+
+        await webApi.models.update([[fullId, model]]);
+
+        await delay(1000);
+        await router.push(`/models/${fullId}`);
+    };
+
+    return (
+        <>
+            <h1>Add Model</h1>
+            <div className="grid grid-cols-4">
+                <div>Pretrained model:</div>
+                <div className="col-span-3">
+                    <select
+                        className="w-full"
+                        value={pretrained}
+                        onChange={(e) => {
+                            const value = e.target.value as ModelId | '';
+                            setPretrained(value);
+                            if (value) {
+                                const model = modelData.get(value);
+                                if (model) {
+                                    setScale(model.scale);
+                                }
+                            }
+                        }}
+                    >
+                        <option value="">None</option>
+                        {[...modelData.keys()].map((id) => (
+                            <option
+                                key={id}
+                                value={id}
+                            >
+                                {id}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+
+                <div>Id:</div>
+                <div className="col-span-3">
+                    <input
+                        className="w-full"
+                        type="text"
+                        value={idName}
+                        onChange={(e) => setIdName(e.target.value)}
+                    />
+                </div>
+
+                <div>Scale:</div>
+                <div className="col-span-3">
+                    <EditableIntegerLabel
+                        readonly={!!pretrained}
+                        value={scale}
+                        onChange={setScale}
+                    />
+                </div>
+            </div>
+            <p>
+                Full id: <code>{fullId}</code>
+            </p>
+            <p>
+                <button
+                    onClick={() => {
+                        addModel().catch((e) => console.error(e));
+                    }}
+                >
+                    Add Model
+                </button>
+            </p>
+        </>
+    );
+}
+
+export default function Page() {
+    return (
+        <>
+            <HeadCommon title="Add model" />
+            <PageContainer wrapper>
+                <PageContent />
+            </PageContainer>
+        </>
+    );
+}


### PR DESCRIPTION
Closes #59.

The new page is ugly as the night, but it's functional. The basic workflow is that you select the pretrained model (if possible), the name part of the id, and the model's scale. We will create a new model and redirect to the model's page. Since we know the pretrained model in many cases, we can fill in arch-related properties automatically.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/c6015314-0d9c-405a-b3fd-cf1411e0f007)
