### PR TITLE
Improved hitbox for card title links

### DIFF
--- a/src/elements/components/model-card.module.scss
+++ b/src/elements/components/model-card.module.scss
@@ -59,7 +59,7 @@
 
     .details {
         padding: 0.75rem;
-        padding-top: 0.5rem;
+        padding-top: 0;
 
         &.paired {
             position: absolute;
@@ -79,6 +79,7 @@
         a.name {
             word-break: normal;
             overflow-wrap: anywhere;
+            padding-top: 0.5rem;
         }
     }
 


### PR DESCRIPTION
This stretches the hitbox of model card titles up to touch the hitbox of the model card image. This eliminates the gap between title and image.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/7263d960-e994-4003-8c98-2cb212e15834)
