### PR TITLE
Break long markdown elements

### DIFF
--- a/src/elements/markdown.module.scss
+++ b/src/elements/markdown.module.scss
@@ -1,4 +1,7 @@
 .markdown {
+    word-break: normal;
+    overflow-wrap: anywhere;
+
     h2 {
         margin-top: 1.5em;
         margin-bottom: 1em;
@@ -7,13 +10,6 @@
     h3 {
         margin-top: 1.75em;
         margin-bottom: 1em;
-    }
-
-    @media screen and (max-width: 900px) {
-        & {
-            word-break: normal;
-            overflow-wrap: anywhere;
-        }
     }
 }
 

--- a/src/elements/markdown.module.scss
+++ b/src/elements/markdown.module.scss
@@ -11,7 +11,8 @@
 
     @media screen and (max-width: 900px) {
         & {
-            overflow-wrap: break-word;
+            word-break: normal;
+            overflow-wrap: anywhere;
         }
     }
 }


### PR DESCRIPTION
I noticed that long Markdown links would dictate the page width on mobile because they did not break. This PR fixes that. I also made this effect always present, not just on small screens as before.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/78678bd8-211d-406d-b9fb-88943d0c19f8)
