### PR TITLE
Added partial support for captions

### DIFF
--- a/src/elements/components/image-carousel-edit-popover.tsx
+++ b/src/elements/components/image-carousel-edit-popover.tsx
@@ -8,12 +8,22 @@ export interface EditImageProps {
 }
 
 function PairedImageMenu({ image, onChange }: { image?: PairedImage; onChange: (value: PairedImage) => void }) {
+    const [caption, setCaption] = useState(image?.caption ?? '');
     const [lr, setLR] = useState(image?.LR ?? '');
     const [sr, setSR] = useState(image?.SR ?? '');
     const [thumbnail, setThumbnail] = useState(image?.thumbnail ?? '');
 
     return (
         <div className="flex flex-col">
+            <div className="flex flex-col">
+                <label htmlFor="image-caption">Caption</label>
+                <input
+                    id="image-caption"
+                    type="text"
+                    value={caption}
+                    onChange={(e) => setCaption(e.target.value)}
+                />
+            </div>
             <div className="flex flex-col">
                 <label htmlFor="image-lr">
                     LR <a className="text-red-500">*</a>
@@ -32,16 +42,16 @@ function PairedImageMenu({ image, onChange }: { image?: PairedImage; onChange: (
                 </label>
                 <input
                     required
-                    id="image-lr"
+                    id="image-sr"
                     type="text"
                     value={sr}
                     onChange={(e) => setSR(e.target.value)}
                 />
             </div>
             <div className="flex flex-col">
-                <label htmlFor="image-sr">Thumbnail</label>
+                <label htmlFor="image-thumbnail">Thumbnail</label>
                 <input
-                    id="image-lr"
+                    id="image-thumbnail"
                     type="text"
                     value={thumbnail}
                     onChange={(e) => setThumbnail(e.target.value)}
@@ -57,6 +67,7 @@ function PairedImageMenu({ image, onChange }: { image?: PairedImage; onChange: (
                         LR: lr,
                         SR: sr,
                         thumbnail: thumbnail || undefined,
+                        caption: caption || undefined,
                     });
                 }}
             >
@@ -73,27 +84,37 @@ function StandaloneImageMenu({
     image?: StandaloneImage;
     onChange: (value: StandaloneImage) => void;
 }) {
+    const [caption, setCaption] = useState(image?.caption ?? '');
     const [url, setURL] = useState(image?.url ?? '');
     const [thumbnail, setThumbnail] = useState(image?.thumbnail ?? '');
 
     return (
         <div className="flex flex-col">
             <div className="flex flex-col">
+                <div className="flex flex-col">
+                    <label htmlFor="image-caption">Caption</label>
+                    <input
+                        id="image-caption"
+                        type="text"
+                        value={caption}
+                        onChange={(e) => setCaption(e.target.value)}
+                    />
+                </div>
                 <label htmlFor="image-url">
                     URL <a className="text-red-500">*</a>
                 </label>
                 <input
                     required
-                    id="image-lr"
+                    id="image-url"
                     type="text"
                     value={url}
                     onChange={(e) => setURL(e.target.value)}
                 />
             </div>
             <div className="flex flex-col">
-                <label htmlFor="image-sr">Thumbnail</label>
+                <label htmlFor="image-thumbnail">Thumbnail</label>
                 <input
-                    id="image-lr"
+                    id="image-thumbnail"
                     type="text"
                     value={thumbnail}
                     onChange={(e) => setThumbnail(e.target.value)}
@@ -108,6 +129,7 @@ function StandaloneImageMenu({
                         type: 'standalone',
                         url: url,
                         thumbnail: thumbnail || undefined,
+                        caption: caption || undefined,
                     });
                 }}
             >

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -64,6 +64,7 @@ export type Image = PairedImage | StandaloneImage;
 
 export interface PairedImage {
     type: 'paired';
+    caption?: string;
     LR: string;
     SR: string;
     thumbnail?: string;
@@ -71,6 +72,7 @@ export interface PairedImage {
 
 export interface StandaloneImage {
     type: 'standalone';
+    caption?: string;
     url: string;
     thumbnail?: string;
 }

--- a/src/lib/server/file-data.ts
+++ b/src/lib/server/file-data.ts
@@ -101,7 +101,7 @@ async function writeModelData(id: ModelId, model: Readonly<Model>): Promise<void
         sortObjectKeys(r, ['platform', 'type', 'size', 'sha256', 'urls']);
     }
     for (const i of model.images) {
-        sortObjectKeys(i, ['type', 'LR', 'SR', 'url', 'thumbnail']);
+        sortObjectKeys(i, ['type', 'caption', 'LR', 'SR', 'url', 'thumbnail']);
     }
     model.tags.sort(compareTagId);
     const file = getModelDataPath(id);


### PR DESCRIPTION
See #189.

This PR adds support for captions in model data and allows us to edit them. 

However, I didn't know how to best display captions to our users. I think that this could be done is follow-up PRs.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/fedc1d60-d650-428c-9202-b3f25f848137)

---

I also fixed the incorrect ids of some input elements. 