### PR TITLE
Replace standalone captioned comparison images with paired ones

### DIFF
--- a/data/models/1x-DeRoqBeta-lite.json
+++ b/data/models/1x-DeRoqBeta-lite.json
@@ -30,8 +30,9 @@
     ],
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1001671437293207672/1658887461.0522466.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108219533715582986/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108219534076289106/SR.png"
         }
     ]
 }

--- a/data/models/1x-Focus.json
+++ b/data/models/1x-Focus.json
@@ -34,16 +34,19 @@
     "pretrainedModelG": "1x-ESRGAN",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/893483065664483338/893483645803847690/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108220390720929863/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108220391127789589/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/893483065664483338/893497416207188028/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108220021970305024/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108220022226173992/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/893483065664483338/893483280895193118/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108220507259678812/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108220508023050321/SR.png"
         }
     ]
 }

--- a/data/models/1x-Kim2091-DeJpeg-v0.json
+++ b/data/models/1x-Kim2091-DeJpeg-v0.json
@@ -32,12 +32,14 @@
     "dataset": "Custom JPEG dataset",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/903415274521374750/1041539960672632832/1668392853.8196685.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108220692580814959/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108220692912148481/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/903415274521374750/1041540021175463956/1668392885.0326388.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108220773098864730/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108220773451169862/SR.png"
         }
     ]
 }

--- a/data/models/1x-MangaJPEGLQ.json
+++ b/data/models/1x-MangaJPEGLQ.json
@@ -35,8 +35,9 @@
     "dataset": "Expanded self curated custom manga dataset",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/579685650824036387/855269193762865152/Example_LQ_Input-comparison.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108220899737473035/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108220900060438610/SR.png"
         }
     ]
 }

--- a/data/models/1x-RoQ-nRoll.json
+++ b/data/models/1x-RoQ-nRoll.json
@@ -34,16 +34,19 @@
     "pretrainedModelG": "1x-ESRGAN",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/911838608879677440/912086092755374200/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108221165882855546/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108221166176452718/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/911838608879677440/912084886792314880/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108221246702895265/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108221247059415060/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/911838608879677440/912085213859954788/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108221090980966582/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108221091396194334/SR.png"
         },
         {
             "type": "paired",

--- a/data/models/1x-SheeepIt.json
+++ b/data/models/1x-SheeepIt.json
@@ -34,20 +34,24 @@
     "datasetSize": 4,
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/903415274521374750/999820017652740176/1658446060.8526323.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108221482007527444/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108221482355662868/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/903415274521374750/999821036583391292/1658446301.0955725.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108221557463068702/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108221557895069808/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/903415274521374750/999821212718993478/1658446346.8536465.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108221624064417842/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108221624475467940/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/903415274521374750/999820756043169803/1658446237.0734627.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108221685594865765/LR.png?width=960&height=702",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108221686182060093/SR.png?width=960&height=702"
         }
     ]
 }

--- a/data/models/1x-SheeepIt.json
+++ b/data/models/1x-SheeepIt.json
@@ -50,8 +50,8 @@
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108221685594865765/LR.png?width=960&height=702",
-            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108221686182060093/SR.png?width=960&height=702"
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108221685594865765/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108221686182060093/SR.png"
         }
     ]
 }

--- a/data/models/2x-KemonoScale-v2.json
+++ b/data/models/2x-KemonoScale-v2.json
@@ -35,8 +35,9 @@
     "pretrainedModelG": "2x-CGIMaster-v1",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/705815801290293329/850614850735439892/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108221944970625106/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108221945394233474/SR.png"
         }
     ]
 }

--- a/data/models/2x-KemonoScale-v2.json
+++ b/data/models/2x-KemonoScale-v2.json
@@ -36,7 +36,7 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108221944970625106/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108631117696864327/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108221945394233474/SR.png"
         }
     ]

--- a/data/models/2x-NMKD-YandereNeo.json
+++ b/data/models/2x-NMKD-YandereNeo.json
@@ -1,5 +1,5 @@
 {
-    "name": "NMKD YandereNeo",
+    "name": "NMKD YandereNeo (2x)",
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [

--- a/data/models/2x-anifilm-compact.json
+++ b/data/models/2x-anifilm-compact.json
@@ -1,5 +1,5 @@
 {
-    "name": "anifilm Compact",
+    "name": "Anifilm Compact (2x)",
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
@@ -33,10 +33,6 @@
     "datasetSize": 2836,
     "pretrainedModelG": "2x-Compact-Pretrain",
     "images": [
-        {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/903415274521374750/1004152057739087972/1659478894.4425747.png"
-        },
         {
             "type": "paired",
             "LR": "https://imgsli.com/i/52e34ef6-6794-43de-a888-3998f7cf1f26.jpg",

--- a/data/models/4x-AnimeSharp-lite.json
+++ b/data/models/4x-AnimeSharp-lite.json
@@ -36,17 +36,17 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223182818787468/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108631845144367155/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223183166906368/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223346631524413/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108631893760561162/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223346975440958/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223426465902642/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108631952854106152/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223426885337211/SR.png"
         }
     ]

--- a/data/models/4x-AnimeSharp-lite.json
+++ b/data/models/4x-AnimeSharp-lite.json
@@ -35,16 +35,19 @@
     "pretrainedModelG": "2x-UniScale-CartoonRestore-lite",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/547949405949657100/941776512049360986/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223182818787468/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223183166906368/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/547949405949657100/941770824543797268/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223346631524413/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223346975440958/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/903415274521374750/941779970013925506/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223426465902642/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223426885337211/SR.png"
         }
     ]
 }

--- a/data/models/4x-AnimeSharp.json
+++ b/data/models/4x-AnimeSharp.json
@@ -32,20 +32,23 @@
     "dataset": "Custom",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/549525506585001985/941432207917084743/Clipboard-comparison.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108222598334140426/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108222599089094696/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/549525506585001985/941432638206541825/test_pic-comparison.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108222833789780028/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108222834192416778/SR.png"
         },
         {
             "type": "standalone",
             "url": "https://cdn.discordapp.com/attachments/903415274521374750/925533775616696340/unknown.png"
         },
         {
-            "type": "standalone",
-            "url": "https://media.discordapp.net/attachments/556604553424928768/925526934555881532/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108222984021356614/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108222984424001616/SR.png"
         }
     ]
 }

--- a/data/models/4x-AnimeSharp.json
+++ b/data/models/4x-AnimeSharp.json
@@ -33,12 +33,12 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108222598334140426/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108631664269201488/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108222599089094696/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108222833789780028/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108631715297112084/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108222834192416778/SR.png"
         },
         {
@@ -47,7 +47,7 @@
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108222984021356614/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108631757827346473/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108222984424001616/SR.png"
         }
     ]

--- a/data/models/4x-BooruGan-600k.json
+++ b/data/models/4x-BooruGan-600k.json
@@ -35,17 +35,17 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223562793361488/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108632046714236970/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223563586080778/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223623577223208/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108632090536333373/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223624038580314/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223719601606696/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108632177605885982/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223720419512330/SR.png"
         }
     ]

--- a/data/models/4x-BooruGan-600k.json
+++ b/data/models/4x-BooruGan-600k.json
@@ -34,16 +34,19 @@
     "pretrainedModelG": "4x-Manga109Attempt",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/579685650824036387/913500929012150323/4f012e36d686033b274261295da89b32-comparison.jpg"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223562793361488/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223563586080778/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/579685650824036387/913500929356070912/256x256fdbb-comparison.jpg"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223623577223208/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223624038580314/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/579685650824036387/913500929649688617/franky-super-810x456-comparison.jpg"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223719601606696/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223720419512330/SR.png"
         }
     ]
 }

--- a/data/models/4x-BooruGan-650k.json
+++ b/data/models/4x-BooruGan-650k.json
@@ -34,16 +34,19 @@
     "pretrainedModelG": "4x-Manga109Attempt",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/579685650824036387/913500929012150323/4f012e36d686033b274261295da89b32-comparison.jpg"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223832285786203/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223832948473997/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/579685650824036387/913500929356070912/256x256fdbb-comparison.jpg"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223906088767619/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223906478817280/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/579685650824036387/913500929649688617/franky-super-810x456-comparison.jpg"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223986510331935/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223987189817384/SR.png"
         }
     ]
 }

--- a/data/models/4x-BooruGan-650k.json
+++ b/data/models/4x-BooruGan-650k.json
@@ -35,17 +35,17 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223832285786203/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108632617227669604/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223832948473997/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223906088767619/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108632665894178827/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223906478817280/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108223986510331935/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108632709183578152/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108223987189817384/SR.png"
         }
     ]

--- a/data/models/4x-CountryRoads.json
+++ b/data/models/4x-CountryRoads.json
@@ -35,12 +35,12 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224382154846208/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108632798589354086/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224382549114920/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224451146956850/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108632846953889812/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224451532820480/SR.png"
         },
         {
@@ -49,7 +49,7 @@
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224524605980683/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108632895989481472/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224525050589296/SR.png"
         }
     ]

--- a/data/models/4x-CountryRoads.json
+++ b/data/models/4x-CountryRoads.json
@@ -34,20 +34,23 @@
     "pretrainedModelG": "4x-PSNR",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/547949806761410560/880291337373618236/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224382154846208/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224382549114920/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/880291340301254657/880303552315146340/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224451146956850/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224451532820480/SR.png"
         },
         {
             "type": "standalone",
             "url": "https://media.discordapp.net/attachments/547949806761410560/880290211026853918/unknown.png"
         },
         {
-            "type": "standalone",
-            "url": "https://media.discordapp.net/attachments/547949806761410560/880299665428447232/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224524605980683/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224525050589296/SR.png"
         }
     ]
 }

--- a/data/models/4x-DeCompress-Strong.json
+++ b/data/models/4x-DeCompress-Strong.json
@@ -34,8 +34,9 @@
     "pretrainedModelG": "4x-ESRGAN",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/884864597310459996/884952891721383936/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224958112473220/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224958443831318/SR.png"
         }
     ]
 }

--- a/data/models/4x-DeCompress-Strong.json
+++ b/data/models/4x-DeCompress-Strong.json
@@ -35,7 +35,7 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224958112473220/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108633122574172210/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224958443831318/SR.png"
         }
     ]

--- a/data/models/4x-DeCompress.json
+++ b/data/models/4x-DeCompress.json
@@ -35,17 +35,17 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224672446828654/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108632984090857532/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224672992084008/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224766810271824/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108633004772962324/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224767221305384/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224829439610981/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108633018098257970/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224829859053588/SR.png"
         }
     ]

--- a/data/models/4x-DeCompress.json
+++ b/data/models/4x-DeCompress.json
@@ -34,16 +34,19 @@
     "pretrainedModelG": "4x-ESRGAN",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/884864597310459996/884957054807179274/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224672446828654/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224672992084008/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/884864597310459996/884960697883193354/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224766810271824/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224767221305384/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/884864597310459996/884953810097827850/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108224829439610981/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108224829859053588/SR.png"
         }
     ]
 }

--- a/data/models/4x-FSMangaV2.json
+++ b/data/models/4x-FSMangaV2.json
@@ -39,7 +39,7 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225428138770492/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108638070024192000/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225428570787902/SR.png"
         }
     ]

--- a/data/models/4x-FSMangaV2.json
+++ b/data/models/4x-FSMangaV2.json
@@ -38,8 +38,9 @@
     "pretrainedModelG": "4x-PSNR",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://i.imgur.com/oVBVthF.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225428138770492/LR.png?width=960&height=600",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225428570787902/SR.png?width=960&height=600"
         }
     ]
 }

--- a/data/models/4x-FSMangaV2.json
+++ b/data/models/4x-FSMangaV2.json
@@ -39,8 +39,8 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225428138770492/LR.png?width=960&height=600",
-            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225428570787902/SR.png?width=960&height=600"
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225428138770492/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225428570787902/SR.png"
         }
     ]
 }

--- a/data/models/4x-Fabric.json
+++ b/data/models/4x-Fabric.json
@@ -36,12 +36,14 @@
     "pretrainedModelG": "4x-ESRGAN",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/887850596214902835/887852703873638410/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225110747381881/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225110390870036/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/887850596214902835/887852170156847124/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225292159438848/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225292503351466/SR.png"
         },
         {
             "type": "standalone",

--- a/data/models/4x-Fabric.json
+++ b/data/models/4x-Fabric.json
@@ -37,12 +37,12 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225110747381881/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108633291965354024/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225110390870036/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225292159438848/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108633345421746206/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225292503351466/SR.png"
         },
         {

--- a/data/models/4x-GameAI-2-0.json
+++ b/data/models/4x-GameAI-2-0.json
@@ -36,8 +36,9 @@
     "pretrainedModelG": "4x-GameAI-1-0",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/579685650824036387/947610558981632040/2ea384c8dc05593e-55207ec648ad52a4-00006213_2-comparison.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225587526500373/LR.png?width=905&height=905",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225587908198521/SR.png?width=905&height=905"
         },
         {
             "type": "standalone",

--- a/data/models/4x-GameAI-2-0.json
+++ b/data/models/4x-GameAI-2-0.json
@@ -37,7 +37,7 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225587526500373/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108638004542709771/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225587908198521/SR.png"
         },
         {

--- a/data/models/4x-GameAI-2-0.json
+++ b/data/models/4x-GameAI-2-0.json
@@ -37,8 +37,8 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225587526500373/LR.png?width=905&height=905",
-            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225587908198521/SR.png?width=905&height=905"
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225587526500373/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225587908198521/SR.png"
         },
         {
             "type": "standalone",

--- a/data/models/4x-Link.json
+++ b/data/models/4x-Link.json
@@ -35,16 +35,18 @@
     "pretrainedModelG": "4x-Nickelfront",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1027685415756509265/4x_Link_500000_G-TestImage-0x9F6EFFE0.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225797493366865/LR.png?width=905&height=905",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225798000873512/SR.png?width=905&height=905"
         },
         {
             "type": "standalone",
             "url": "https://cdn.discordapp.com/attachments/579685650824036387/1027685416180121722/4x_Link_500000_G-TestImage-CMMM_Knight_Templar_ID2_DiffuseMap.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1027685416528261203/4x_Link_500000_G-TestImage-Crest_Venetian_DiffuseMap.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225880704176168/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225880997765160/SR.png"
         }
     ]
 }

--- a/data/models/4x-Link.json
+++ b/data/models/4x-Link.json
@@ -36,8 +36,8 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225797493366865/LR.png?width=905&height=905",
-            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225798000873512/SR.png?width=905&height=905"
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108225797493366865/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108225798000873512/SR.png"
         },
         {
             "type": "standalone",

--- a/data/models/4x-NMKD-YandereNeo.json
+++ b/data/models/4x-NMKD-YandereNeo.json
@@ -34,7 +34,7 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226081263206460/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108633741972217927/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226081577775175/SR.png"
         }
     ]

--- a/data/models/4x-NMKD-YandereNeo.json
+++ b/data/models/4x-NMKD-YandereNeo.json
@@ -1,5 +1,5 @@
 {
-    "name": "NMKD YandereNeo",
+    "name": "NMKD YandereNeo (4x)",
     "author": "nmkd",
     "license": "WTFPL",
     "tags": [
@@ -33,8 +33,9 @@
     "dataset": "Yandere1200 (yande.re artworks)",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://i.imgur.com/oxs71v5.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226081263206460/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226081577775175/SR.png"
         }
     ]
 }

--- a/data/models/4x-SGI.json
+++ b/data/models/4x-SGI.json
@@ -35,17 +35,17 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226185143529522/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108633820279885854/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226185424551956/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226391100641382/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108633876286427136/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226391402627093/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226447883108452/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108633926651609118/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226448277389373/SR.png"
         },
         {

--- a/data/models/4x-SGI.json
+++ b/data/models/4x-SGI.json
@@ -34,16 +34,19 @@
     "pretrainedModelG": "4x-ESRGAN",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://i.imgur.com/lwFRhmc.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226185143529522/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226185424551956/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://i.imgur.com/ftvVu3i.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226391100641382/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226391402627093/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://i.imgur.com/0uXoAuJ.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226447883108452/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226448277389373/SR.png"
         },
         {
             "type": "standalone",

--- a/data/models/4x-UltraSharp.json
+++ b/data/models/4x-UltraSharp.json
@@ -36,13 +36,13 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226605396004994/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108634043681079326/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226605794467850/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226661431906445/LR.png?width=960&height=679",
-            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226661830373416/SR.png?width=960&height=679"
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226661431906445/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226661830373416/SR.png"
         },
         {
             "type": "standalone",

--- a/data/models/4x-UltraSharp.json
+++ b/data/models/4x-UltraSharp.json
@@ -35,12 +35,14 @@
     "pretrainedModelG": "4x-UniScale-Balanced",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/902853011913732097/902855337705611294/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226605396004994/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226605794467850/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/902853011913732097/902853340600360990/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226661431906445/LR.png?width=960&height=679",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226661830373416/SR.png?width=960&height=679"
         },
         {
             "type": "standalone",

--- a/data/models/4x-UniScale-Restore.json
+++ b/data/models/4x-UniScale-Restore.json
@@ -37,12 +37,14 @@
     "pretrainedModelG": "4x-ESRGAN",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/880826637543964712/880934732748169226/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226848791461928/LR.png?width=960&height=712",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226849160581152/SR.png?width=960&height=712"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/880826637543964712/880932754102026290/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226952625664031/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226952927662230/SR.png"
         }
     ]
 }

--- a/data/models/4x-UniScale-Restore.json
+++ b/data/models/4x-UniScale-Restore.json
@@ -38,12 +38,12 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226848791461928/LR.png?width=960&height=712",
-            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226849160581152/SR.png?width=960&height=712"
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226848791461928/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226849160581152/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108226952625664031/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108634546636853248/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108226952927662230/SR.png"
         }
     ]

--- a/data/models/4x-UniScaleV2-Moderate.json
+++ b/data/models/4x-UniScaleV2-Moderate.json
@@ -35,7 +35,7 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227067172098119/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108634637623898223/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227067516043284/SR.png"
         }
     ]

--- a/data/models/4x-UniScaleV2-Moderate.json
+++ b/data/models/4x-UniScaleV2-Moderate.json
@@ -34,8 +34,9 @@
     "pretrainedModelG": "4x-ESRGAN",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/884239326471393331/884298572894441512/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227067172098119/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227067516043284/SR.png"
         }
     ]
 }

--- a/data/models/4x-UniScaleV2-Sharp.json
+++ b/data/models/4x-UniScaleV2-Sharp.json
@@ -34,12 +34,14 @@
     "pretrainedModelG": "4x-ESRGAN",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/884239326471393331/884296266857713704/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227233371394048/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227233761472542/SR.png"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/884239326471393331/884294468709257216/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227287226257418/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227287528259604/SR.png"
         }
     ]
 }

--- a/data/models/4x-UniScaleV2-Sharp.json
+++ b/data/models/4x-UniScaleV2-Sharp.json
@@ -35,12 +35,12 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227233371394048/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108634712215408731/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227233761472542/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227287226257418/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108634753055338546/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227287528259604/SR.png"
         }
     ]

--- a/data/models/4x-UniScaleV2-Soft.json
+++ b/data/models/4x-UniScaleV2-Soft.json
@@ -35,8 +35,8 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227389940564078/LR.png?width=960&height=715",
-            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227390309666836/SR.png?width=960&height=715"
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227389940564078/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227390309666836/SR.png"
         }
     ]
 }

--- a/data/models/4x-UniScaleV2-Soft.json
+++ b/data/models/4x-UniScaleV2-Soft.json
@@ -34,8 +34,9 @@
     "pretrainedModelG": "4x-ESRGAN",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/884239326471393331/884302370136289323/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227389940564078/LR.png?width=960&height=715",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227390309666836/SR.png?width=960&height=715"
         }
     ]
 }

--- a/data/models/4x-UniScaleV2-Soft.json
+++ b/data/models/4x-UniScaleV2-Soft.json
@@ -35,7 +35,7 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227389940564078/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108638226811461692/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227390309666836/SR.png"
         }
     ]

--- a/data/models/4x-VolArt.json
+++ b/data/models/4x-VolArt.json
@@ -34,12 +34,14 @@
     "pretrainedModelG": "4x-ESRGAN",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/888869052867543060/888869070928248852/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227487063883826/LR.png?width=960&height=851",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227487441354852/SR.png?width=960&height=851"
         },
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/888869052867543060/888869784169619496/unknown.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227542692941844/LR.png?width=603&height=905",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227543112359936/SR.png?width=603&height=905"
         }
     ]
 }

--- a/data/models/4x-VolArt.json
+++ b/data/models/4x-VolArt.json
@@ -35,12 +35,12 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227487063883826/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108638290208366653/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227487441354852/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227542692941844/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108638356646150185/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227543112359936/SR.png"
         }
     ]

--- a/data/models/4x-VolArt.json
+++ b/data/models/4x-VolArt.json
@@ -35,13 +35,13 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227487063883826/LR.png?width=960&height=851",
-            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227487441354852/SR.png?width=960&height=851"
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227487063883826/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227487441354852/SR.png"
         },
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227542692941844/LR.png?width=603&height=905",
-            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227543112359936/SR.png?width=603&height=905"
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108227542692941844/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108227543112359936/SR.png"
         }
     ]
 }

--- a/data/models/4x-anifilm-compact.json
+++ b/data/models/4x-anifilm-compact.json
@@ -35,8 +35,8 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108222216279167016/LR.png?width=960&height=840",
-            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108222217071898676/SR.png?width=960&height=840"
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108222216279167016/LR.png",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108222217071898676/SR.png"
         },
         {
             "type": "paired",

--- a/data/models/4x-anifilm-compact.json
+++ b/data/models/4x-anifilm-compact.json
@@ -35,7 +35,7 @@
     "images": [
         {
             "type": "paired",
-            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108222216279167016/LR.png",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108631223124885625/LR.png",
             "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108222217071898676/SR.png"
         },
         {

--- a/data/models/4x-anifilm-compact.json
+++ b/data/models/4x-anifilm-compact.json
@@ -1,5 +1,5 @@
 {
-    "name": "Anifilm Compact",
+    "name": "Anifilm Compact (4x)",
     "author": "kim2091",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
@@ -34,8 +34,9 @@
     "pretrainedModelG": "4x-Compact-Pretrain",
     "images": [
         {
-            "type": "standalone",
-            "url": "https://cdn.discordapp.com/attachments/903415274521374750/1004158991544365097/1659480539.543144.png"
+            "type": "paired",
+            "LR": "https://media.discordapp.net/attachments/1108219399560761385/1108222216279167016/LR.png?width=960&height=840",
+            "SR": "https://media.discordapp.net/attachments/1108219399560761385/1108222217071898676/SR.png?width=960&height=840"
         },
         {
             "type": "paired",


### PR DESCRIPTION
This PR replaces many (but not all) of the standalone captioned comparison images with paired variants with the captions cropped out. While I was replacing them, I noticed that there were a few that my script missed. I will refine the script to get the rest once this is merged.