### PR TITLE
Added models released since

### DIFF
--- a/data/models/1x-DEPVR-Artifact.json
+++ b/data/models/1x-DEPVR-Artifact.json
@@ -1,0 +1,44 @@
+{
+    "name": "DEPVR Artifact",
+    "author": "cf2lter",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "game-textures",
+        "restoration"
+    ],
+    "description": "Attempts to remove PVRTC compression artifacts. If 1x_DEPVR is unable to remove some artifacts you should use the other version but it can't remove color artifacts properly so you should overlay color of normal version to it.",
+    "date": "2023-03-26",
+    "architecture": "esrgan",
+    "size": [
+        "64nf",
+        "23nb"
+    ],
+    "scale": 1,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 66665765,
+            "sha256": "a5a476d22f60c53dad2a5c01f1be04a239c5997ef5cde56e6e5181a19036384f",
+            "urls": [
+                "https://mega.nz/folder/O58BHDLL#q9clb4tfbh4_Jd2M6lA6ZA"
+            ]
+        }
+    ],
+    "trainingIterations": 24000,
+    "trainingEpochs": 4000,
+    "trainingBatchSize": 16,
+    "trainingHRSize": 32,
+    "trainingOTF": false,
+    "dataset": "Custom",
+    "datasetSize": 128,
+    "pretrainedModelG": "1x-BCGone-DetailedV2-40-60",
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1089380932382896299/depvrcomp2.png"
+        }
+    ]
+}

--- a/data/models/1x-DEPVR.json
+++ b/data/models/1x-DEPVR.json
@@ -1,0 +1,49 @@
+{
+    "name": "DEPVR",
+    "author": "cf2lter",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "game-textures",
+        "restoration"
+    ],
+    "description": "Attempts to remove PVRTC compression artifacts. If 1x_DEPVR is unable to remove some artifacts you should use the other version but it can't remove color artifacts properly so you should overlay color of normal version to it.",
+    "date": "2023-03-26",
+    "architecture": "esrgan",
+    "size": [
+        "64nf",
+        "23nb"
+    ],
+    "scale": 1,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 66665765,
+            "sha256": "fc1e6ad8c397f4b6503ea2497734743199ac7cf2c463663521b86a13ffe77c99",
+            "urls": [
+                "https://mega.nz/folder/O58BHDLL#q9clb4tfbh4_Jd2M6lA6ZA"
+            ]
+        }
+    ],
+    "trainingIterations": 24000,
+    "trainingEpochs": 4000,
+    "trainingBatchSize": 16,
+    "trainingHRSize": 32,
+    "trainingOTF": false,
+    "dataset": "Custom",
+    "datasetSize": 128,
+    "pretrainedModelG": "1x-BCGone-DetailedV2-40-60",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://cdn.discordapp.com/attachments/579685650824036387/1089380930935849000/Orig.png",
+            "SR": "https://cdn.discordapp.com/attachments/579685650824036387/1089380931615338568/DEPVR.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1089380932382896299/depvrcomp2.png"
+        }
+    ]
+}

--- a/data/models/1x-GainRESV3-Natural.json
+++ b/data/models/1x-GainRESV3-Natural.json
@@ -33,5 +33,16 @@
     "dataset": "5K resolution shots from paladins rendered by 200% for hr and 37.5%(1080p) for lr then downscaled to 1080",
     "datasetSize": 150,
     "pretrainedModelG": "1x-BCGone-DetailedV2-40-60",
-    "images": []
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6c5367ab-092f-4db7-8e67-7dd26b429bfb.jpg",
+            "SR": "https://imgsli.com/i/643ca3a7-8488-4a3f-808a-4b7c9f8df874.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/79fddc79-26b8-4c48-9799-71dc43884323.jpg",
+            "SR": "https://imgsli.com/i/ee47f4e6-6aba-479e-b8cb-b5ac8bb9cb2b.jpg"
+        }
+    ]
 }

--- a/data/models/1x-GainRESV4.json
+++ b/data/models/1x-GainRESV4.json
@@ -1,0 +1,49 @@
+{
+    "name": "GainRESV4",
+    "author": "cf2lter",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "anti-aliasing"
+    ],
+    "description": "Eliminate aliasing and general artifacts caused by not enough resolution. Model knows to add clarity and soften oversharpened areas. Gives image a supersampled look. Had a better version thats more faithful to details but i lost it.",
+    "date": "2023-03-05",
+    "architecture": "esrgan",
+    "size": [
+        "64nf",
+        "23nb"
+    ],
+    "scale": 1,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 66665765,
+            "sha256": "bb604d9aa66c3b012e1543bef1f325b622a7625b43e94d2d06c8c98d84a3c773",
+            "urls": [
+                "https://mega.nz/file/r8k1FDYT#6jKY6d4UH0txdqU-3JpsFvKcEEeMTSnhrqmzjbgp1zE"
+            ]
+        }
+    ],
+    "trainingIterations": 170000,
+    "trainingEpochs": 900,
+    "trainingBatchSize": 4,
+    "trainingHRSize": 128,
+    "trainingOTF": false,
+    "dataset": "Game renderings native 1080p as lr and 4320p downscaled with mitchell as hr",
+    "datasetSize": 360,
+    "pretrainedModelG": "1x-BCGone-DetailedV2-40-60",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6c5367ab-092f-4db7-8e67-7dd26b429bfb.jpg",
+            "SR": "https://imgsli.com/i/4c09163e-d7c2-495a-8815-36430775062f.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/79fddc79-26b8-4c48-9799-71dc43884323.jpg",
+            "SR": "https://imgsli.com/i/59da9723-2ea1-4643-8963-3217469dced2.jpg"
+        }
+    ]
+}

--- a/data/models/2x-90s-cartoon-v1.json
+++ b/data/models/2x-90s-cartoon-v1.json
@@ -1,0 +1,76 @@
+{
+    "name": "90s Cartoon v1",
+    "author": "eva-01",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "anime",
+        "cartoon"
+    ],
+    "description": "Upscale 90s and early 2000 American cartoons",
+    "date": "2023-03-10",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 2,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 2417798,
+            "sha256": "be1a04a1d921f7588870f874f9d01759b1ea59ede7aa8f266eb52d9bc1d0313e",
+            "urls": [
+                "https://drive.google.com/drive/folders/1EXxiZtQfWWLeemiEhH0WyrBpGoxVbGNZ"
+            ]
+        },
+        {
+            "platform": "onnx",
+            "type": "onnx",
+            "size": 2407679,
+            "sha256": "911a7cc9a95919f01fdb45ca3ea4d41a96093f3ebc1a0732cc015ac817ef3b63",
+            "urls": [
+                "https://drive.google.com/drive/folders/1ETbjGNUO2zwtpelNs2nbWhVrjsC39hQX"
+            ]
+        }
+    ],
+    "trainingIterations": 75000,
+    "trainingBatchSize": 20,
+    "trainingHRSize": 128,
+    "trainingOTF": false,
+    "dataset": "HD rescans of some 90s cartoons and some cels, i also used 4xfilmfream V1 as teacher for some of the images in the dataset",
+    "datasetSize": 1250,
+    "pretrainedModelG": "2x-GT-v2-evA",
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/QgqxmUE.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/W1B9yQ6.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/3s6DC1G.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/3tSak7q.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/kZmQvGg.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/o9AixpW.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://i.imgur.com/0GyusQj.png"
+        }
+    ]
+}

--- a/data/models/2x-AniScale.json
+++ b/data/models/2x-AniScale.json
@@ -1,0 +1,77 @@
+{
+    "name": "AniScale",
+    "author": "sirosky",
+    "license": "CC-BY-NC-4.0",
+    "tags": [
+        "anime",
+        "dehalo",
+        "restoration"
+    ],
+    "description": "2x general purpose anime upscaler, with a focus on cleaning up scuffed sources while enhancing texture detail. While the model was trained on DVDs, it still works well on modern anime. The model is trained to deal with noise, compression artifacts, blur, bleeding, haloing and scuffed line art. Apparently, it also learned to deal with some dotcrawl.",
+    "date": "2023-04-16",
+    "architecture": "esrgan",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 2,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 4838301,
+            "sha256": "8036d8e4da1c1f16db79a4aefbda86f7c9a07c6a7fa03d5d2d9e2f0012909671",
+            "urls": [
+                "https://cdn.discordapp.com/attachments/579685650824036387/1097231218333974668/2x_AniScale_30000.pth",
+                "https://icedrive.net/s/5fiR884Qh2ggGitujhgzxW19VZjj"
+            ]
+        }
+    ],
+    "trainingIterations": 30000,
+    "trainingEpochs": 24,
+    "trainingBatchSize": 6,
+    "trainingHRSize": 256,
+    "trainingOTF": false,
+    "dataset": "Anime DVDRip",
+    "datasetSize": 7200,
+    "images": [
+        {
+            "type": "paired",
+            "caption": "House",
+            "LR": "https://imgsli.com/i/0f974ab0-43b3-4150-9812-02f04c8dedc7.jpg",
+            "SR": "https://imgsli.com/i/133f3370-241e-4b1b-9aa1-4fccd7191f4e.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "Bleeding",
+            "LR": "https://imgsli.com/i/4f89a226-f009-4a05-a7ba-52d6d0e74c94.jpg",
+            "SR": "https://imgsli.com/i/786af27f-5ad0-4da1-a120-6a43b4c0fce7.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "Strawhat",
+            "LR": "https://imgsli.com/i/e9b51e51-5300-494d-a9b3-a9cae485eeb2.jpg",
+            "SR": "https://imgsli.com/i/977c44f1-29a0-420a-b42d-9b5917ae5c31.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "Dotcrawl",
+            "LR": "https://imgsli.com/i/39f8705c-de3e-4446-a42c-cbbebe74d5c2.jpg",
+            "SR": "https://imgsli.com/i/0ea78a0b-a4be-46f2-9693-2efbad7f85b1.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "Roofs",
+            "LR": "https://imgsli.com/i/991defcc-59dc-43e8-aefb-867c9acbe782.jpg",
+            "SR": "https://imgsli.com/i/b1d4daf8-ac83-4eb7-af6e-9c08db1a1146.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "Haloooo",
+            "LR": "https://imgsli.com/i/fb1e808b-c0ab-4d55-bfa8-069abb965f9b.jpg",
+            "SR": "https://imgsli.com/i/e1e0c900-715b-439f-ab0b-ac72809cef47.jpg"
+        }
+    ]
+}

--- a/data/models/2x-AnimeJaNai-Standard-v1-Compact.json
+++ b/data/models/2x-AnimeJaNai-Standard-v1-Compact.json
@@ -1,0 +1,44 @@
+{
+    "name": "AnimeJaNai Standard v1 Compact",
+    "author": "the-database",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "anime",
+        "restoration"
+    ],
+    "description": "Realtime 2x model intended for high or medium quality 1080p anime with an emphasis on correcting the inherit blurriness of anime while preserving details and colors. Not suitable for artifact-heavy or highly compressed content as it will just sharpen artifacts. Also works with SD anime by running the model twice. Can be set up to run with mpv on Windows using https://github.com/the-database/mpv-upscale-2x_animejanai\n\nMinimum of RTX 3080 is recommended for running UltraCompact model on 1080p in realtime; RTX 4090 is required to run Compact on 1080p in realtime. SuperUltraCompact should run in realtime on 1080p on some lower cards. The compact model is recommended on SD content. \n\nSamples: https://imgsli.com/MTUxMDYx \\\nComparisons to Anime4K + other compact models and upscalers: https://imgsli.com/MTUxMjY4",
+    "date": "2023-01-29",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 2,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "onnx",
+            "type": "onnx",
+            "size": 2409821,
+            "sha256": "00d6b2ef70d3a9a2334ed94ae5bbde7a7b88af298923d87f3a448fe65ea8ef99",
+            "urls": [
+                "https://github.com/the-database/mpv-upscale-2x_animejanai/releases/download/1.0.0/mpv-upscale-2x_animejanai_v1.zip"
+            ]
+        }
+    ],
+    "trainingIterations": 120000,
+    "trainingBatchSize": 12,
+    "trainingHRSize": 512,
+    "trainingOTF": false,
+    "dataset": "frames from 1080p anime",
+    "datasetSize": 2416,
+    "pretrainedModelG": "2x-Compact-Pretrain",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1a0d1ffe-2f90-416d-8038-f0625b321c52.jpg",
+            "SR": "https://imgsli.com/i/6f74adb8-50dc-4faa-b114-4b0cceae8b05.jpg"
+        }
+    ]
+}

--- a/data/models/2x-AnimeJaNai-Standard-v1-SuperUltraCompact.json
+++ b/data/models/2x-AnimeJaNai-Standard-v1-SuperUltraCompact.json
@@ -1,0 +1,44 @@
+{
+    "name": "AnimeJaNai Standard v1 SuperUltraCompact",
+    "author": "the-database",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "anime",
+        "restoration"
+    ],
+    "description": "Realtime 2x model intended for high or medium quality 1080p anime with an emphasis on correcting the inherit blurriness of anime while preserving details and colors. Not suitable for artifact-heavy or highly compressed content as it will just sharpen artifacts. Also works with SD anime by running the model twice. Can be set up to run with mpv on Windows using https://github.com/the-database/mpv-upscale-2x_animejanai\n\nMinimum of RTX 3080 is recommended for running UltraCompact model on 1080p in realtime; RTX 4090 is required to run Compact on 1080p in realtime. SuperUltraCompact should run in realtime on 1080p on some lower cards. The compact model is recommended on SD content. \n\nSamples: https://imgsli.com/MTUxMDYx \\\nComparisons to Anime4K + other compact models and upscalers: https://imgsli.com/MTUxMjY4",
+    "date": "2023-01-29",
+    "architecture": "compact",
+    "size": [
+        "24nf",
+        "8nc"
+    ],
+    "scale": 2,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "onnx",
+            "type": "onnx",
+            "size": 184169,
+            "sha256": "3fc706e7abede1b5882bd137928045d4c944a8db802b6e2cb46f2bbef1b7ed6d",
+            "urls": [
+                "https://github.com/the-database/mpv-upscale-2x_animejanai/releases/download/1.0.0/mpv-upscale-2x_animejanai_v1.zip"
+            ]
+        }
+    ],
+    "trainingIterations": 100000,
+    "trainingBatchSize": 12,
+    "trainingHRSize": 512,
+    "trainingOTF": false,
+    "dataset": "frames from 1080p anime",
+    "datasetSize": 2416,
+    "pretrainedModelG": "2x-SuperUltraCompact-Pretrain",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1a0d1ffe-2f90-416d-8038-f0625b321c52.jpg",
+            "SR": "https://imgsli.com/i/d5e6a711-950a-4139-b192-b87b3521822d.jpg"
+        }
+    ]
+}

--- a/data/models/2x-AnimeJaNai-Standard-v1-UltraCompact.json
+++ b/data/models/2x-AnimeJaNai-Standard-v1-UltraCompact.json
@@ -1,0 +1,44 @@
+{
+    "name": "AnimeJaNai Standard v1 UltraCompact",
+    "author": "the-database",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "anime",
+        "restoration"
+    ],
+    "description": "Realtime 2x model intended for high or medium quality 1080p anime with an emphasis on correcting the inherit blurriness of anime while preserving details and colors. Not suitable for artifact-heavy or highly compressed content as it will just sharpen artifacts. Also works with SD anime by running the model twice. Can be set up to run with mpv on Windows using https://github.com/the-database/mpv-upscale-2x_animejanai\n\nMinimum of RTX 3080 is recommended for running UltraCompact model on 1080p in realtime; RTX 4090 is required to run Compact on 1080p in realtime. SuperUltraCompact should run in realtime on 1080p on some lower cards. The compact model is recommended on SD content. \n\nSamples: https://imgsli.com/MTUxMDYx \\\nComparisons to Anime4K + other compact models and upscalers: https://imgsli.com/MTUxMjY4",
+    "date": "2023-01-29",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "8nc"
+    ],
+    "scale": 2,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "onnx",
+            "type": "onnx",
+            "size": 1223042,
+            "sha256": "980e6f0320a1b4427935656bba75ad23c7acebd406ae17cdd87c2491b73ee51c",
+            "urls": [
+                "https://github.com/the-database/mpv-upscale-2x_animejanai/releases/download/1.0.0/mpv-upscale-2x_animejanai_v1.zip"
+            ]
+        }
+    ],
+    "trainingIterations": 10000,
+    "trainingBatchSize": 12,
+    "trainingHRSize": 512,
+    "trainingOTF": false,
+    "dataset": "frames from 1080p anime",
+    "datasetSize": 2416,
+    "pretrainedModelG": "2x-UltraCompact-Pretrain",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1a0d1ffe-2f90-416d-8038-f0625b321c52.jpg",
+            "SR": "https://imgsli.com/i/6197a53f-18fa-4c3b-b52c-6f99cfd3be0a.jpg"
+        }
+    ]
+}

--- a/data/models/2x-AnimeJaNai-Strong-v1-Compact.json
+++ b/data/models/2x-AnimeJaNai-Strong-v1-Compact.json
@@ -1,0 +1,44 @@
+{
+    "name": "AnimeJaNai Strong v1 Compact",
+    "author": "the-database",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "anime",
+        "restoration"
+    ],
+    "description": "Realtime 2x model intended for high or medium quality 1080p anime with an emphasis on correcting the inherit blurriness of anime while preserving details and colors. Not suitable for artifact-heavy or highly compressed content as it will just sharpen artifacts. Also works with SD anime by running the model twice. Can be set up to run with mpv on Windows using https://github.com/the-database/mpv-upscale-2x_animejanai\n\nMinimum of RTX 3080 is recommended for running UltraCompact model on 1080p in realtime; RTX 4090 is required to run Compact on 1080p in realtime. SuperUltraCompact should run in realtime on 1080p on some lower cards. The compact model is recommended on SD content. \n\nSamples: https://imgsli.com/MTUxMDYx \\\nComparisons to Anime4K + other compact models and upscalers: https://imgsli.com/MTUxMjY4",
+    "date": "2023-01-29",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 2,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "onnx",
+            "type": "onnx",
+            "size": 2408780,
+            "sha256": "35456a2bedbe9607279b1d48a6fa388e8ba2e3b7b3628b0ee6b52ddb8b0a4e77",
+            "urls": [
+                "https://github.com/the-database/mpv-upscale-2x_animejanai/releases/download/1.0.0/mpv-upscale-2x_animejanai_v1.zip"
+            ]
+        }
+    ],
+    "trainingIterations": 120000,
+    "trainingBatchSize": 12,
+    "trainingHRSize": 512,
+    "trainingOTF": false,
+    "dataset": "frames from 1080p anime",
+    "datasetSize": 2416,
+    "pretrainedModelG": "2x-Compact-Pretrain",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1a0d1ffe-2f90-416d-8038-f0625b321c52.jpg",
+            "SR": "https://imgsli.com/i/aca5e614-b821-4d11-ae6d-c6c689995f36.jpg"
+        }
+    ]
+}

--- a/data/models/2x-AnimeJaNai-Strong-v1-UltraCompact.json
+++ b/data/models/2x-AnimeJaNai-Strong-v1-UltraCompact.json
@@ -1,0 +1,64 @@
+{
+    "name": "AnimeJaNai Strong v1 UltraCompact",
+    "author": "the-database",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "anime",
+        "restoration"
+    ],
+    "description": "Realtime 2x model intended for high or medium quality 1080p anime with an emphasis on correcting the inherit blurriness of anime while preserving details and colors. Not suitable for artifact-heavy or highly compressed content as it will just sharpen artifacts. Also works with SD anime by running the model twice. Can be set up to run with mpv on Windows using https://github.com/the-database/mpv-upscale-2x_animejanai\n\nMinimum of RTX 3080 is recommended for running UltraCompact model on 1080p in realtime; RTX 4090 is required to run Compact on 1080p in realtime. SuperUltraCompact should run in realtime on 1080p on some lower cards. The compact model is recommended on SD content. \n\nSamples: https://imgsli.com/MTUxMDYx \\\nComparisons to Anime4K + other compact models and upscalers: https://imgsli.com/MTUxMjY4",
+    "date": "2023-01-29",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "8nc"
+    ],
+    "scale": 2,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "onnx",
+            "type": "onnx",
+            "size": 1222447,
+            "sha256": "60eaa3b9426fe06c5282091cde5613fcf4024a30055a5b612f9d32d0c3ce57ae",
+            "urls": [
+                "https://github.com/the-database/mpv-upscale-2x_animejanai/releases/download/1.0.0/mpv-upscale-2x_animejanai_v1.zip"
+            ]
+        }
+    ],
+    "trainingIterations": 10000,
+    "trainingBatchSize": 12,
+    "trainingHRSize": 512,
+    "trainingOTF": false,
+    "dataset": "frames from 1080p anime",
+    "datasetSize": 2416,
+    "pretrainedModelG": "2x-UltraCompact-Pretrain",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1a0d1ffe-2f90-416d-8038-f0625b321c52.jpg",
+            "SR": "https://imgsli.com/i/71b70e79-a529-47d5-b2f7-3aad8e1c5ab5.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/cd32d835-778c-4d01-b665-8098da623e62.jpg",
+            "SR": "https://imgsli.com/i/c910b883-76b3-42fa-8170-d8a847296384.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/4af7e16f-87f0-4dc1-9ceb-3e3bf7224baf.jpg",
+            "SR": "https://imgsli.com/i/a1a1166b-231b-4237-896a-dfe22eca150c.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/074652f5-54c0-4403-8926-5bdbc355d9eb.jpg",
+            "SR": "https://imgsli.com/i/c589caf6-7225-4536-88fc-eebfc65b6251.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/736fb35f-5082-4a03-ac6a-34f7cdab8214.jpg",
+            "SR": "https://imgsli.com/i/7c57ebf5-f1c2-437b-909d-f40bd1ad5999.jpg"
+        }
+    ]
+}

--- a/data/models/2x-GT-v2-evA.json
+++ b/data/models/2x-GT-v2-evA.json
@@ -1,0 +1,76 @@
+{
+    "name": "GT-v2-evA",
+    "author": "eva-01",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "anime",
+        "cartoon"
+    ],
+    "description": "This is the v2 of my 2xGT model, the main purpose of it is to improve upon the v1 model and make more it generalized.\nfor upscaling videos that have grain I would recommend denoising and de-haloing it before passing it through  the model.",
+    "date": "2023-03-10",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 2,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 2417798,
+            "sha256": "0d431d6e33a23ceb5099ec0fa997bfd4edb1bdd9b5587916c08accae6fa303fe",
+            "urls": [
+                "https://drive.google.com/drive/folders/1EXxiZtQfWWLeemiEhH0WyrBpGoxVbGNZ"
+            ]
+        },
+        {
+            "platform": "onnx",
+            "type": "onnx",
+            "size": 2407679,
+            "sha256": "3753f4e9a92e367e35dd002391c237e01bf991e3852aaf7158dbd0318e252e42",
+            "urls": [
+                "https://drive.google.com/drive/folders/1ETbjGNUO2zwtpelNs2nbWhVrjsC39hQX"
+            ]
+        }
+    ],
+    "trainingIterations": 160000,
+    "trainingBatchSize": 20,
+    "trainingHRSize": 128,
+    "trainingOTF": false,
+    "dataset": "German blu ray of detective Conan and other shows and some cels",
+    "datasetSize": 2910,
+    "pretrainedModelG": "2x-anifilm-compact",
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1083748850222772224/1.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1083748850822545448/2.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1083748851472674876/3.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1083748852059865150/4.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1083748852642889818/5.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1083748853154590750/6.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1083748853729198170/7.png"
+        }
+    ]
+}

--- a/data/models/2x-HFA2kCompact.json
+++ b/data/models/2x-HFA2kCompact.json
@@ -1,0 +1,164 @@
+{
+    "name": "HFA2kCompact",
+    "author": "helaman",
+    "license": "CC-BY-4.0",
+    "tags": [
+        "anime",
+        "restoration"
+    ],
+    "description": "A compact anime 2x upscaling model based on musl's HFA2k dataset.\n\nCompact 2x anime upscaler with otf compression and blur. The '2xHFA2kCompact.pth' (4.6 MB) is the original trained model file, the other model files are conversions using chaiNNer. Trained on musl's latest dataset release for Anime SISR, which has been extracted from modern anime films, where the selection criteria was high SNR, no DOF and high frequency information.\n\nExamples: https://imgsli.com/MTcxNjA4\nExample input files: https://drive.google.com/drive/folders/1VSPw8m7VbZO6roM9syE7Nf2QYwwn7GUz \nExample output files: https://drive.google.com/drive/folders/1NFfomnv6d5RtWy_GwOsKO3uZ_HNOo-2i\n\nFuture work: Started training a 4xRRDBNet version of this, bigger model so maybe better results but slower, for still/ single anime images. Will release in the future or drop, based on achieved results.",
+    "date": "2023-04-18",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 2,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 4838301,
+            "sha256": "78da2d5c636f868f7741d5c736b34cdfc9fae3f2f104bc9dc655b963def784dc",
+            "urls": [
+                "https://drive.google.com/drive/folders/1iW4EHokEsrcIZ7He5g485kvmPKXGk1EV"
+            ]
+        }
+    ],
+    "trainingIterations": 93000,
+    "trainingBatchSize": 12,
+    "trainingHRSize": 384,
+    "trainingOTF": true,
+    "dataset": "HFA2k",
+    "datasetSize": 2568,
+    "pretrainedModelG": "2x-Compact-Pretrain",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/65be5ab9-10b5-4e9c-a696-cb4f2065a7b6.jpg",
+            "SR": "https://imgsli.com/i/bc24aa4c-106c-48a1-8bd7-bf7edfe4b14d.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/2caaa97d-f856-42dc-a6f7-eb7fbb1df3aa.jpg",
+            "SR": "https://imgsli.com/i/d4579ac3-42de-4a50-9679-7f60adc1e81e.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/122592dd-0061-4bd5-a810-6d24c2d93608.jpg",
+            "SR": "https://imgsli.com/i/68527283-8f15-41f5-ba96-9d7858716c01.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/4d2281ad-f447-4a88-a5cc-4301089a3d58.jpg",
+            "SR": "https://imgsli.com/i/8f58d789-a250-4787-a142-460a6a87f975.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/c2753a39-7224-467d-88b5-c6a740fd4ac7.jpg",
+            "SR": "https://imgsli.com/i/310d747a-0adb-4fd2-8ecd-fbb15bae96b2.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/413ac188-3980-4e74-980d-a2cc546f6236.jpg",
+            "SR": "https://imgsli.com/i/cb701611-f9eb-45bf-910b-1d15a433b20c.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1aa896f8-bec4-41cb-a06a-a679a48b3212.jpg",
+            "SR": "https://imgsli.com/i/73788ea5-4ecc-4c9f-99d1-92a9ffcd0f01.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/f71c83ee-1f00-4221-9beb-c9e0d0a2d81c.jpg",
+            "SR": "https://imgsli.com/i/75f7be5b-04cf-4584-a154-98fcef07ebc5.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/802ee306-df5c-4f1b-b0e6-333ef2d0a4b6.jpg",
+            "SR": "https://imgsli.com/i/7d212628-9ac8-4192-97e3-434c5b2b24e6.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b493b386-f1d3-4574-939c-e82fee727ef8.jpg",
+            "SR": "https://imgsli.com/i/aabbbe29-3b65-4b9c-b05f-96efad1fa983.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/528ce193-92b2-4f8e-8d59-b828780e784d.jpg",
+            "SR": "https://imgsli.com/i/2e13ddb6-7ec8-47b3-a9e1-adbe547ebf2d.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/63673e13-9d83-4ab6-984c-cbad80012a61.jpg",
+            "SR": "https://imgsli.com/i/9e1723ea-e4de-4c14-855a-24356d9644e2.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/d6ce2e83-2a46-4754-83cb-3af96be06b74.jpg",
+            "SR": "https://imgsli.com/i/7edc88fa-d2aa-49c1-9be0-6dd48d8ff624.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/8b8079fb-3456-4309-9a77-6149620d66b4.jpg",
+            "SR": "https://imgsli.com/i/f734bc29-d588-4347-bc4a-e48c0dbf0cb4.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ccd0ef27-e31c-429b-b052-d43de4a77439.jpg",
+            "SR": "https://imgsli.com/i/248e6181-64e0-44b2-81d1-dd187835251c.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1f3c66f8-89bf-4449-99ce-6701c12faaaf.jpg",
+            "SR": "https://imgsli.com/i/ebbe2c8e-9f21-4479-8795-bdf520ebd51d.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/47c627cc-3630-4e51-a810-8dc8e04522c1.jpg",
+            "SR": "https://imgsli.com/i/d32a92c4-3239-4646-874d-a04219b4cbd6.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6f3dc814-2c83-4781-9013-96968fbbf0ab.jpg",
+            "SR": "https://imgsli.com/i/7453235d-5c6f-4ca6-b7c4-4acce9305d87.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b3798fa5-67e1-4e9e-b0b0-b10abd0f6c74.jpg",
+            "SR": "https://imgsli.com/i/9482de93-f6e7-42e3-bfd6-29d42b01c6bd.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/cfb2da11-be5c-4bbe-a630-06edd2269dde.jpg",
+            "SR": "https://imgsli.com/i/333eb034-f9ec-45ef-a7ce-56e9fc74fa50.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3cc5e2b6-c095-4371-b5de-095f051a117c.jpg",
+            "SR": "https://imgsli.com/i/7e6214dd-25cc-46c5-9889-a24931f5488e.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/0837d146-49a7-4492-a353-9c19bbd4d08e.jpg",
+            "SR": "https://imgsli.com/i/072cdb58-488a-43cc-86f3-509c943e9616.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/49a0dcea-aac3-4133-bd2a-324601a1b03c.jpg",
+            "SR": "https://imgsli.com/i/8e798366-541e-4512-b325-51746222aef3.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b7d5f0e3-7b21-4b3a-849f-414157cb9636.jpg",
+            "SR": "https://imgsli.com/i/73193181-f54c-4799-a6f6-952b7edd8575.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/d07ad37c-5527-457a-b7fb-439d854873e6.jpg",
+            "SR": "https://imgsli.com/i/81e952af-b5f3-42fe-9c26-f5baef7c4048.jpg"
+        }
+    ]
+}

--- a/data/models/2x-ParimgCompact.json
+++ b/data/models/2x-ParimgCompact.json
@@ -1,0 +1,56 @@
+{
+    "name": "Parimg Compact",
+    "author": "helaman",
+    "license": "CC-BY-4.0",
+    "tags": [
+        "photo"
+    ],
+    "description": "A 2x photo upscaling compact model based on microsofts image pairs. This was one of the earliest models I started training and finished it now for release.",
+    "date": "2023-05-05",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 2,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 2419014,
+            "sha256": "405f8ce5b18ff23107028657c00687c7d27d74976a8999fab39f7c02680b1164",
+            "urls": [
+                "https://cdn.discordapp.com/attachments/579685650824036387/1103997995172765787/2xParimgCompact.pth"
+            ]
+        }
+    ],
+    "trainingIterations": 100000,
+    "trainingHRSize": 256,
+    "trainingOTF": false,
+    "dataset": "Microsoft ImagePairs",
+    "pretrainedModelG": "2x-Compact-Pretrain",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/04402f31-136c-44ba-9495-0440e567f66d.jpg",
+            "SR": "https://imgsli.com/i/25769fbc-4443-4b75-96bb-c13671b66a06.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6e690a1a-104d-4b98-983c-e95c541c987f.jpg",
+            "SR": "https://imgsli.com/i/e82f3cbe-34fe-4dd3-b352-ca4d6f85bd4a.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/92a0726a-0d39-44f9-b8a3-0222a6fde9c2.jpg",
+            "SR": "https://imgsli.com/i/3315a149-e384-480a-97a8-b9a84d60f604.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/6dbbaf5b-38e4-42c7-800c-21bf4107f705.jpg",
+            "SR": "https://imgsli.com/i/3c542c66-5483-4ef6-a9b6-bb8360edcef4.jpg"
+        }
+    ]
+}

--- a/data/models/4x-FatePlusCompact.json
+++ b/data/models/4x-FatePlusCompact.json
@@ -1,0 +1,44 @@
+{
+    "name": "FatePlus Compact",
+    "author": "kim2091",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "anime",
+        "restoration"
+    ],
+    "description": "Images from the Fate/Extra games. Works better on the newer ones.\n\nJust a model I trained quickly to test traiNNer-redux and see what I could do with OTF. Works well enough",
+    "date": "2023-04-11",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 4,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 5004573,
+            "sha256": "87ecbac840d83961340c18c2cd5220780be774b4ad95d79887441c0b92b5e8bf",
+            "urls": [
+                "https://cdn.discordapp.com/attachments/579685650824036387/1095202608655908944/4x-FatePlusCompact.pth"
+            ]
+        }
+    ],
+    "trainingIterations": 26000,
+    "trainingEpochs": 18,
+    "trainingBatchSize": 6,
+    "trainingHRSize": 128,
+    "trainingOTF": true,
+    "dataset": "Custom Fate/Extra Dataset",
+    "datasetSize": 8000,
+    "pretrainedModelG": "4x-Compact-Pretrain",
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1095202609268264960/1681187006.1504378.png"
+        }
+    ]
+}

--- a/data/models/4x-HFA2k.json
+++ b/data/models/4x-HFA2k.json
@@ -1,0 +1,70 @@
+{
+    "name": "HFA2k",
+    "author": "helaman",
+    "license": "CC-BY-4.0",
+    "tags": [
+        "anime",
+        "restoration"
+    ],
+    "description": "4x anime image upscaler with a bit of otf jpg compression and blur. Trained on musl's hfa2k dataset release for Anime SISR, which has been extracted from modern anime films, where the selection criteria was high SNR, no DOF and high frequency information.\n\nExamples: https://imgsli.com/MTc2NDgx (PS Example input images are small, each around 500x280 px) \\\nExample input files: https://drive.google.com/drive/folders/1RI6gGqRy-KxDujbaIrpEMdvFkIWHvfPt \\\nExample output files: https://drive.google.com/drive/folders/1GqHwPlFp6bIQl4R1AxmrmJ6vUUD8FUxH \\\nAll my model files can be found on my github repo https://github.com/Phhofm/models",
+    "date": "2023-05-07",
+    "architecture": "esrgan",
+    "size": [
+        "64nf",
+        "23nb"
+    ],
+    "scale": 4,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 67020037,
+            "sha256": "35dfd9f6e9d2d264f0e79c6a054798a5e71b1c752bd8b668786c01ebd62fe2b0",
+            "urls": [
+                "https://github.com/Phhofm/models/raw/main/4xHFA2k/4xHFA2k.pth"
+            ]
+        }
+    ],
+    "trainingIterations": 91000,
+    "trainingEpochs": 318,
+    "trainingBatchSize": 9,
+    "trainingHRSize": 256,
+    "trainingOTF": true,
+    "dataset": "HFA2k",
+    "datasetSize": 2568,
+    "pretrainedModelG": "4x-realesrgan-x4plus",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3c6c3f96-4d36-45bb-b0c2-d205750bc93c.jpg",
+            "SR": "https://imgsli.com/i/e2948695-e3f7-47af-8750-3430c1395654.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/4bd3e07b-c6e6-460c-840a-8788b16df508.jpg",
+            "SR": "https://imgsli.com/i/cb88ab06-7440-4bab-917c-cef02f987a34.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/13a85c0d-f50e-4dac-940a-a3053b919d82.jpg",
+            "SR": "https://imgsli.com/i/bbe2e58d-243e-4bc0-8bc6-1d56a70fe014.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ce0c2369-459d-462e-800e-4d3004accea1.jpg",
+            "SR": "https://imgsli.com/i/c135278b-9a8d-4909-8dac-8d6be5a4fb26.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/c8bd5d32-d89d-4491-9883-b003045cd1d4.jpg",
+            "SR": "https://imgsli.com/i/f82c5f71-fd62-4205-8ddc-d249e6a97a48.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/ab97c9b2-2eb6-4d54-b754-74c92eb7e066.jpg",
+            "SR": "https://imgsli.com/i/f0907656-069d-4ba4-8a93-4b2625f6fb5a.jpg"
+        }
+    ]
+}

--- a/data/models/4x-LSDIRCompact-v2.json
+++ b/data/models/4x-LSDIRCompact-v2.json
@@ -1,0 +1,67 @@
+{
+    "name": "LSDIR Compact v2",
+    "author": "helaman",
+    "license": "CC-BY-4.0",
+    "tags": [
+        "photo",
+        "restoration"
+    ],
+    "description": "Upscale photos to x4 their size.\n\n4xLSDIRCompactv2 supersedes the previously released models, it combines all my progress on my compact model. Both CompactC and CompactR had received around 8 hours more training since release with batch size 10 (CompactR had only been up to 5 on release), and these two were then interpolated together. This allows v2 to handle some degradations, while preserving the details of the CompactC model. Examples: https://imgsli.com/MTY0Njgz/0/2",
+    "date": "2023-03-25",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 4,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 2500870,
+            "sha256": "4f731443dedd83ccacafeafd2f3bf30efab6e6861e70af12a728460f072f3440",
+            "urls": [
+                "https://drive.google.com/file/d/1nnhovhW3XMsgnXhx5ILATFvzAhtT8R-2"
+            ]
+        }
+    ],
+    "trainingHRSize": 256,
+    "trainingOTF": false,
+    "dataset": "LSDIR",
+    "datasetSize": 84991,
+    "pretrainedModelG": "4x-Compact-Pretrain",
+    "images": [
+        {
+            "type": "paired",
+            "caption": "JPEG 30",
+            "LR": "https://imgsli.com/i/d974c661-7e7a-45ab-998c-0f95848e0454.jpg",
+            "SR": "https://imgsli.com/i/503b1242-c964-483d-b398-ca5e9caf559f.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "JPEG 40",
+            "LR": "https://imgsli.com/i/a95fee89-fb1a-4aa5-8d68-8e926f2910a8.jpg",
+            "SR": "https://imgsli.com/i/96505a3c-b0da-4277-94a2-d9a15c77e512.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "JPEG 45",
+            "LR": "https://imgsli.com/i/7aaff67d-2af7-4ce0-adcf-827544c9c842.jpg",
+            "SR": "https://imgsli.com/i/0fc9ad26-abbc-479f-8f23-3a713b970818.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "JPEG 60",
+            "LR": "https://imgsli.com/i/f6ba549f-6db4-476a-88a5-f1f9f560be64.jpg",
+            "SR": "https://imgsli.com/i/ef4fcfc1-540d-4b60-8bca-344f559e5e24.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "Uncompressed",
+            "LR": "https://imgsli.com/i/304e38bb-4fc1-414a-b009-e1b8a6c1736d.jpg",
+            "SR": "https://imgsli.com/i/6c62cd61-b473-4a13-8338-b49f3f318cee.jpg"
+        }
+    ]
+}

--- a/data/models/4x-LSDIRCompact.json
+++ b/data/models/4x-LSDIRCompact.json
@@ -1,0 +1,142 @@
+{
+    "name": "LSDIR Compact",
+    "author": "helaman",
+    "license": "CC-BY-4.0",
+    "tags": [
+        "photo"
+    ],
+    "description": "Upscale small good quality photos to 4x their size\n\nMy first ever model 😄 Well, it’s not the best, but, it’s something 😉 \nI provide some 15 examples from the validation set here for you to visually see the generated output (with chaiNNer), photo dimensions are in the name",
+    "date": "2023-03-11",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 4,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 5005875,
+            "sha256": "421bae466643b3feb586f4f1446685be2effa8054f3e35a3119e270b8d34b1d4",
+            "urls": [
+                "https://drive.google.com/file/d/1cdGyJewgcY8DwT-D5JrqDHxlL_ZDw3qH"
+            ]
+        }
+    ],
+    "trainingIterations": 160000,
+    "trainingHRSize": 256,
+    "trainingOTF": false,
+    "dataset": "LSDIR",
+    "datasetSize": 84991,
+    "pretrainedModelG": "4x-Compact-Pretrain",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3fd64d30-5713-4d4b-8892-ee41679949b8.jpg",
+            "SR": "https://imgsli.com/i/64d2f558-dcc0-4f98-a4ea-fb6d2ed360ac.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/e71a4fdb-14af-414f-a254-d39e57ee9606.jpg",
+            "SR": "https://imgsli.com/i/a137f768-13e8-4fe0-8ba5-728117994b67.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/dbe5f57a-84f0-45fe-a3f4-a2a99bdbdfae.jpg",
+            "SR": "https://imgsli.com/i/759f45f6-05ae-4f6c-8ffc-efd82b368bd6.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/d9e1ed20-5ac7-4968-b218-8ccfd3d93273.jpg",
+            "SR": "https://imgsli.com/i/d82d4a3e-2074-48ff-95f3-b683abfb6311.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/0644a57e-1fa2-456a-9f5b-cebc082b5c27.jpg",
+            "SR": "https://imgsli.com/i/51080059-0d85-465e-b8fe-6a5eb622e777.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/e48b619a-03b9-4173-bbfd-2684d90ac94c.jpg",
+            "SR": "https://imgsli.com/i/4767feb9-2b08-4221-a165-4dcb7a13f84c.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/3419ab34-4748-4a06-b2fa-c0994c474e3c.jpg",
+            "SR": "https://imgsli.com/i/cbc25ea6-b607-4dca-94d0-9d47dd2f29c3.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/f55b9221-0945-4f8a-acca-49ce58ff52d3.jpg",
+            "SR": "https://imgsli.com/i/33103a77-4fde-43a9-a4e9-5dc1ec519b10.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/8dd87d59-fc86-422c-8dea-c68fcc989545.jpg",
+            "SR": "https://imgsli.com/i/ba98d104-24da-4578-abfd-da165bff91f6.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/01914a73-3140-43b2-ac8d-05e35ed8331d.jpg",
+            "SR": "https://imgsli.com/i/a060feb7-2c9b-4bcd-b144-d46022cde5b8.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b794ab14-b904-4dd7-ae9f-676f3faf2789.jpg",
+            "SR": "https://imgsli.com/i/415212de-a136-4379-8669-9327104bd644.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/c393e5e6-cdf4-4223-9b7b-f841effea625.jpg",
+            "SR": "https://imgsli.com/i/0545fda7-00ee-4997-adcd-4067854b856c.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/1954a6ae-4e9e-4480-9ea3-aff5e79ea329.jpg",
+            "SR": "https://imgsli.com/i/dddd7ebf-b641-402c-a1a1-356f07b20026.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/7f6474c6-4e1f-4c13-a89c-aa17ebfbefe8.jpg",
+            "SR": "https://imgsli.com/i/2c682fd8-3dc8-4ad2-9438-8fe61463035b.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/a2b23855-2b78-4bed-8596-edf2c4dc14e9.jpg",
+            "SR": "https://imgsli.com/i/50c1708c-39dd-429c-ae62-7490186fc74f.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "JPEG 30",
+            "LR": "https://imgsli.com/i/91087439-c866-4438-a74d-7d068bc991df.jpg",
+            "SR": "https://imgsli.com/i/7de86dc2-39e3-45ac-a88d-001106ff61b1.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "JPEG 40",
+            "LR": "https://imgsli.com/i/9a77ffa4-af8d-48db-b306-1713b4e56a48.jpg",
+            "SR": "https://imgsli.com/i/ec6edc87-9d79-49ef-b2d7-fdbcacb172a0.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "JPEG 45",
+            "LR": "https://imgsli.com/i/80c70b77-a8ab-4a9d-8aa1-426d9da8bfb1.jpg",
+            "SR": "https://imgsli.com/i/ba1ae317-cb1d-47a2-94a9-8a2b56888371.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "JPEG 60",
+            "LR": "https://imgsli.com/i/c2df4625-083d-4505-9dbc-904d95dd5f5a.jpg",
+            "SR": "https://imgsli.com/i/11ab8a0a-2864-4a96-8a3f-11a2a94529e7.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "Uncompressed",
+            "LR": "https://imgsli.com/i/ce7ff38e-476a-49c3-b410-5aa8bd5481f6.jpg",
+            "SR": "https://imgsli.com/i/4d1e4b45-1cef-4fc0-9968-0198c0474fc4.jpg"
+        }
+    ]
+}

--- a/data/models/4x-LSDIRCompactC.json
+++ b/data/models/4x-LSDIRCompactC.json
@@ -1,0 +1,68 @@
+{
+    "name": "LSDIR Compact C",
+    "author": "helaman",
+    "license": "CC-BY-4.0",
+    "tags": [
+        "photo",
+        "restoration"
+    ],
+    "description": "Upscale small photos with compression to 4x their size.\n\nTrying to extend my previous model to be able to handle compression (JPG 100-30) by manually altering the training dataset, since 4xLSDIRCompact can't handle compression. Use this instead of 4xLSDIRCompact if your photo has compression (like an image from the web).",
+    "date": "2023-03-17",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 4,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 5005799,
+            "sha256": "194476a7a8821c18c2928a15a05878f07105ee71802a061f018c36fb47259ae5",
+            "urls": [
+                "https://drive.google.com/file/d/1uoU8Q6L2F0LL_pgfbbTROJxtI_OOj47B"
+            ]
+        }
+    ],
+    "trainingIterations": 190000,
+    "trainingHRSize": 256,
+    "trainingOTF": false,
+    "dataset": "LSDIR",
+    "datasetSize": 84991,
+    "pretrainedModelG": "4x-LSDIRCompact",
+    "images": [
+        {
+            "type": "paired",
+            "caption": "JPEG 30",
+            "LR": "https://imgsli.com/i/91087439-c866-4438-a74d-7d068bc991df.jpg",
+            "SR": "https://imgsli.com/i/278a1397-f28a-47d5-89eb-5f558978eeb6.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "JPEG 40",
+            "LR": "https://imgsli.com/i/9a77ffa4-af8d-48db-b306-1713b4e56a48.jpg",
+            "SR": "https://imgsli.com/i/996484c9-25cd-4022-92b6-add0942f414e.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "JPEG 45",
+            "LR": "https://imgsli.com/i/80c70b77-a8ab-4a9d-8aa1-426d9da8bfb1.jpg",
+            "SR": "https://imgsli.com/i/4026406f-5a32-4e7e-becf-7e5243a261e3.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "JPEG 60",
+            "LR": "https://imgsli.com/i/c2df4625-083d-4505-9dbc-904d95dd5f5a.jpg",
+            "SR": "https://imgsli.com/i/cd41e1c9-c1d8-4d11-a07d-345638fc3041.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "Uncompressed",
+            "LR": "https://imgsli.com/i/ce7ff38e-476a-49c3-b410-5aa8bd5481f6.jpg",
+            "SR": "https://imgsli.com/i/36243516-b37e-4964-94e1-f224f2a678fa.jpg"
+        }
+    ]
+}

--- a/data/models/4x-LSDIRCompactC3.json
+++ b/data/models/4x-LSDIRCompactC3.json
@@ -1,0 +1,48 @@
+{
+    "name": "LSDIR Compact C3",
+    "author": "helaman",
+    "license": "CC-BY-4.0",
+    "tags": [
+        "photo",
+        "restoration"
+    ],
+    "description": "Upscale compressed photos to x4 their size.\n\nAble to handle JPG compression (30-100).",
+    "date": "2023-04-11",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 4,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 5004681,
+            "sha256": "a330cac38d956c7c3d98cd477f51b9f69df0f92f6c04d6f22998370718f846b9",
+            "urls": [
+                "https://drive.google.com/file/d/1LMSeS5jZ0RDyXvXYBeip36xbKoaLLvJZ"
+            ]
+        }
+    ],
+    "trainingIterations": 23000,
+    "trainingHRSize": 256,
+    "trainingOTF": false,
+    "dataset": "LSDIR",
+    "datasetSize": 84991,
+    "pretrainedModelG": "4x-LSDIRCompact",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/dc1bb947-a4b6-430a-b95c-a889418139b7.jpg",
+            "SR": "https://imgsli.com/i/4abc5d6d-2ee1-4514-8193-d279b2ddf60f.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/74d7ffda-0ad0-4732-8795-d30e01ef76d8.jpg",
+            "SR": "https://imgsli.com/i/4c8636ed-e959-4971-b79f-03769f8a6be2.jpg"
+        }
+    ]
+}

--- a/data/models/4x-LSDIRCompactN.json
+++ b/data/models/4x-LSDIRCompactN.json
@@ -1,0 +1,57 @@
+{
+    "name": "LSDIRCompactN",
+    "author": "helaman",
+    "license": "CC-BY-4.0",
+    "tags": [
+        "photo"
+    ],
+    "description": "Upscale good quality input photos to x4 their size\n\nThe original 4xLSDIRCompact a bit more trained, cannot handle degradation",
+    "date": "2023-04-11",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 4,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 5005877,
+            "sha256": "9bc7ed761954a0ffb5ac48f34021334253fddb17fc62b94392762a013fb30d7d",
+            "urls": [
+                "https://drive.google.com/file/d/1rn6TxfRe9cWjrub0lW3dfL9HHbOoGtJm"
+            ]
+        }
+    ],
+    "trainingIterations": 185000,
+    "trainingHRSize": 256,
+    "trainingOTF": false,
+    "dataset": "LSDIR",
+    "datasetSize": 84991,
+    "pretrainedModelG": "4x-Compact-Pretrain",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/e98343a9-7cb1-4c2d-940e-ab94969e5660.jpg",
+            "SR": "https://imgsli.com/i/c831dc06-8ada-4218-906c-34a18feaf5bc.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/dd6ac032-34b2-446a-800d-a80c951fa8d9.jpg",
+            "SR": "https://imgsli.com/i/3505df36-f41a-49c6-8782-11ecb4b1d0b5.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/c3e66f8a-152f-4fba-ae24-fbebd8bc851c.jpg",
+            "SR": "https://imgsli.com/i/7859dd91-e1f0-4853-b6fb-aa648d702253.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/706af79a-fb5a-4ab7-b321-40501a24e282.jpg",
+            "SR": "https://imgsli.com/i/4834a5d1-ddd0-4bc9-8027-1a54ae375c53.jpg"
+        }
+    ]
+}

--- a/data/models/4x-LSDIRCompactR.json
+++ b/data/models/4x-LSDIRCompactR.json
@@ -1,0 +1,68 @@
+{
+    "name": "LSDIR Compact R",
+    "author": "helaman",
+    "license": "CC-BY-4.0",
+    "tags": [
+        "photo",
+        "restoration"
+    ],
+    "description": "Upscale small photos with compression, noise and slight blur to 4x their size.\n\nExtending my last 4xLSDIRCompact model to Real-ESRGAN, meaning trained on synthetic data instead to handle more kinds of degradations, it should be able to handle compression, noise, and slight blur.\n\nHere is a comparison to show that 4xLSDIRCompact cannot handle compression artifacts, and that these two models will produce better output for that specific scenario. These models are not ‘better’ than the previous one, they are just meant to handle a different use case.",
+    "date": "2023-03-17",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 4,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 5005885,
+            "sha256": "ee765b15a398d7a0810d9c6936ba7420be2862c32b19fb213d76450306bf3ad1",
+            "urls": [
+                "https://drive.google.com/file/d/1t4-CQc9jfJqt75r7xXI2vQxXOs-zDJt8"
+            ]
+        }
+    ],
+    "trainingIterations": 130000,
+    "trainingHRSize": 256,
+    "trainingOTF": false,
+    "dataset": "LSDIR",
+    "datasetSize": 84991,
+    "pretrainedModelG": "4x-LSDIRCompact",
+    "images": [
+        {
+            "type": "paired",
+            "caption": "JPEG 30",
+            "LR": "https://imgsli.com/i/91087439-c866-4438-a74d-7d068bc991df.jpg",
+            "SR": "https://imgsli.com/i/7ee9e8ae-ce53-48f5-a06c-435115700d73.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "JPEG 40",
+            "LR": "https://imgsli.com/i/9a77ffa4-af8d-48db-b306-1713b4e56a48.jpg",
+            "SR": "https://imgsli.com/i/762a254f-6e93-4fd1-8973-aa54edb41752.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "JPEG 45",
+            "LR": "https://imgsli.com/i/80c70b77-a8ab-4a9d-8aa1-426d9da8bfb1.jpg",
+            "SR": "https://imgsli.com/i/e93aee18-fd5b-4828-ab8e-d913c376a402.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "JPEG 60",
+            "LR": "https://imgsli.com/i/c2df4625-083d-4505-9dbc-904d95dd5f5a.jpg",
+            "SR": "https://imgsli.com/i/9cfcfc95-6dae-4d72-b686-5a150727486b.jpg"
+        },
+        {
+            "type": "paired",
+            "caption": "Uncompressed",
+            "LR": "https://imgsli.com/i/ce7ff38e-476a-49c3-b410-5aa8bd5481f6.jpg",
+            "SR": "https://imgsli.com/i/3997926b-0057-4fb7-a5a3-0742459a064e.jpg"
+        }
+    ]
+}

--- a/data/models/4x-LSDIRCompactR3.json
+++ b/data/models/4x-LSDIRCompactR3.json
@@ -1,0 +1,48 @@
+{
+    "name": "LSDIR Compact R3",
+    "author": "helaman",
+    "license": "CC-BY-4.0",
+    "tags": [
+        "photo",
+        "restoration"
+    ],
+    "description": "Upscale (degraded) photos to x4 their size. \n\nTrained on synthetic data, meant to handle more degradations",
+    "date": "2023-04-11",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 4,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 5004681,
+            "sha256": "5b7d8bccfee8897fb72126f05de83e1bdf36e7dc2b17023b074fc1c97580e568",
+            "urls": [
+                "https://drive.google.com/file/d/1_UrO5UwADJyfOpKWp5y81USFCAgG-z3-"
+            ]
+        }
+    ],
+    "trainingIterations": 192500,
+    "trainingHRSize": 256,
+    "trainingOTF": false,
+    "dataset": "LSDIR",
+    "datasetSize": 84991,
+    "pretrainedModelG": "4x-LSDIRCompact",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/dc1bb947-a4b6-430a-b95c-a889418139b7.jpg",
+            "SR": "https://imgsli.com/i/8db7fe78-f289-4499-a241-cc81c31348b2.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/74d7ffda-0ad0-4732-8795-d30e01ef76d8.jpg",
+            "SR": "https://imgsli.com/i/9c5c5c3d-649f-4402-8a00-618a9841f0aa.jpg"
+        }
+    ]
+}

--- a/data/models/4x-Nomos8kSC.json
+++ b/data/models/4x-Nomos8kSC.json
@@ -1,0 +1,55 @@
+{
+    "name": "Nomos8kSC",
+    "author": "helaman",
+    "license": "CC-BY-4.0",
+    "tags": [
+        "photo",
+        "restoration"
+    ],
+    "description": "4x photo upscaler with otf jpg compression and blur, trained on musl's Nomos8k_sfw dataset for realisic sr",
+    "date": "2023-05-10",
+    "architecture": "esrgan",
+    "size": [
+        "64nf",
+        "23nb"
+    ],
+    "scale": 4,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 67010245,
+            "sha256": "07a7ccd6443d012d528999cd77e40c7d265aaf1f656c499b37936e49603a0b1d",
+            "urls": [
+                "https://github.com/Phhofm/models/raw/main/4xNomos8kSC/4xNomos8kSC.pth"
+            ]
+        }
+    ],
+    "trainingIterations": 85000,
+    "trainingEpochs": 137,
+    "trainingBatchSize": 10,
+    "trainingHRSize": 256,
+    "trainingOTF": true,
+    "dataset": "Nomos8k_sfw",
+    "datasetSize": 6118,
+    "pretrainedModelG": "4x-realesrgan-x4plus",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/b944f78f-9a23-44ba-a54c-f4d10c2481d3.jpg",
+            "SR": "https://imgsli.com/i/83a8b85c-bcab-46e3-8114-5e6e64d3c8e5.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/40806c9e-ba2a-4bc9-8e3a-42679457edf6.jpg",
+            "SR": "https://imgsli.com/i/bf9a0e75-4326-477e-91d3-5f1432f78198.jpg"
+        },
+        {
+            "type": "paired",
+            "LR": "https://imgsli.com/i/e66be126-df62-4b1d-b6be-bd06ecab0e1b.jpg",
+            "SR": "https://imgsli.com/i/dbd2f2d0-b211-4e68-a5af-9bf09eb437a0.jpg"
+        }
+    ]
+}

--- a/data/models/4x-Rybu.json
+++ b/data/models/4x-Rybu.json
@@ -1,0 +1,46 @@
+{
+    "name": "Rybu",
+    "author": "musl",
+    "license": "CC0-1.0",
+    "tags": [
+        "general-upscaler",
+        "photo",
+        "restoration"
+    ],
+    "description": "General realistic super-resolution.",
+    "date": "2023-04-01",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 4,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 5004789,
+            "sha256": "39e7430d727a8369b5580a7bfa42bcc7a2104095fdc4b5ac1c29727a7d452a0d",
+            "urls": [
+                "https://cdn.discordapp.com/attachments/579685650824036387/1091487963738808430/4x_rybu.pth",
+                "https://mega.nz/file/JYFHAYZR#z5dIrKTnQaUcfucT_6unESfZoicGFDQTW3LpDExILtY",
+                "https://www.mediafire.com/file/hx2z0aivcmvx2a2/4x_rybu.7z/file",
+                "https://m2.afileditch.ch/hnneaxSKLYDrJEGzm.7z"
+            ]
+        }
+    ],
+    "trainingIterations": 5000000,
+    "dataset": "Nomos8k",
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1091487964070170704/cmp_0.png"
+        },
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1091487964296642620/cmp_1.png"
+        }
+    ]
+}

--- a/data/models/4x-animerd-v1.json
+++ b/data/models/4x-animerd-v1.json
@@ -1,0 +1,43 @@
+{
+    "name": "animerd v1",
+    "author": "musl",
+    "license": "CC0-1.0",
+    "tags": [
+        "anime",
+        "cartoon",
+        "restoration"
+    ],
+    "description": "Anime super-resolution, with real degradation.",
+    "date": "2023-04-20",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 4,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 5004681,
+            "sha256": "2dbc96a7889ee31e381d3a314a5dd024473426766951a3e99c1175802e658d46",
+            "urls": [
+                "https://cdn.discordapp.com/attachments/579685650824036387/1098693932768055337/4x_animerd_v1.pth",
+                "https://mega.nz/file/ENV1FChR#0dH71yQpnelJ05NLQdmFNA4QUmYhthdMIGhoFfwVCw8",
+                "https://www.mediafire.com/file/cmgx51hkfh5725c/4x_animerd_v1.7z/file",
+                "https://medium.afileditch.ch/m3/ofOCVylexTvqYoOcSeI.7z"
+            ]
+        }
+    ],
+    "trainingIterations": 459000,
+    "dataset": "HFA2k_LUDVAE",
+    "pretrainedModelG": "4x-Rybu",
+    "images": [
+        {
+            "type": "standalone",
+            "url": "https://cdn.discordapp.com/attachments/579685650824036387/1098691128288620665/animerd_cmp2.png"
+        }
+    ]
+}

--- a/data/users.json
+++ b/data/users.json
@@ -80,6 +80,9 @@
     "foolhardy": {
         "name": "FoolhardyVEVO"
     },
+    "helaman": {
+        "name": "Helaman"
+    },
     "hubert": {
         "name": "hubert"
     },
@@ -187,6 +190,9 @@
     },
     "sazoji": {
         "name": "Sazoji"
+    },
+    "sirosky": {
+        "name": "Sirosky"
     },
     "skr": {
         "name": "Skr"

--- a/data/users.json
+++ b/data/users.json
@@ -212,6 +212,9 @@
     "tg": {
         "name": "tg"
     },
+    "the-database": {
+        "name": "the database"
+    },
     "thepi7on": {
         "name": "ThePi7on"
     },


### PR DESCRIPTION
I added all models released in the release channel on EE since 2023-01-18 (2x_Futsuu_Anime) except for sudo_shuffle_cugan_9.584.969.pth and DM600_LUDVAE. LUDVAE is a model for adding noise, which is something our target demo probably isn't interested in. Shuffle cugan just doesn't work with chainner, so I'm just skipping it.