### PR TITLE
Get resource info from file

### DIFF
--- a/src/lib/server/file-data.ts
+++ b/src/lib/server/file-data.ts
@@ -7,7 +7,7 @@ import { Arch, ArchId, Model, ModelId, Tag, TagCategory, TagCategoryId, TagId, U
 import { compareTagId, getTagCategoryOrder, hasOwn, sortObjectKeys, typedEntries, typedKeys } from '../util';
 import { JsonFile, fileExists } from './fs-util';
 
-const DATA_DIR = './data/';
+export const DATA_DIR = './data/';
 const MODEL_DIR = join(DATA_DIR, 'models');
 const USERS_JSON = join(DATA_DIR, 'users.json');
 const TAGS_JSON = join(DATA_DIR, 'tags.json');

--- a/src/pages/api/save-model.ts
+++ b/src/pages/api/save-model.ts
@@ -1,0 +1,29 @@
+import { mkdir, writeFile } from 'fs/promises';
+import { NextApiRequest, NextApiResponse } from 'next';
+import path from 'path';
+import { DATA_DIR } from '../../lib/server/file-data';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        const dir = path.join(DATA_DIR, 'model-files');
+        await mkdir(dir, { recursive: true });
+
+        const name = String(req.query.name);
+        await writeFile(path.join(DATA_DIR, 'model-files', name), req);
+        res.status(200).json({ status: 'ok' });
+    } catch (err) {
+        console.error(err);
+
+        let message = String(err);
+        if (err instanceof Error) {
+            message += `\n${String(err.stack)}`;
+        }
+        res.status(500).json({ error: message });
+    }
+}
+
+export const config = {
+    api: {
+        bodyParser: false,
+    },
+};

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -27,7 +27,7 @@ import { getCachedModels } from '../../lib/server/cached-models';
 import { fileApi } from '../../lib/server/file-data';
 import { getSimilarModels } from '../../lib/similar';
 import { STATIC_ARCH_DATA } from '../../lib/static-data';
-import { asArray, getColorMode, getPreviewImage, joinListString, typedEntries } from '../../lib/util';
+import { EMPTY_ARRAY, asArray, getColorMode, getPreviewImage, joinListString, typedEntries } from '../../lib/util';
 
 const MAX_SIMILAR_MODELS = 12 * 2;
 
@@ -58,7 +58,7 @@ const defaultVals = {
     boolean: false,
 } as const;
 
-const renderTags = (tags: string[], editMode: boolean, onChange: (newTags: string[]) => void) => (
+const renderTags = (tags: readonly string[], editMode: boolean, onChange: (newTags: string[]) => void) => (
     <div className="flex flex-row flex-wrap gap-2">
         {tags.map((tag, index) => {
             return (
@@ -413,6 +413,7 @@ export default function Page({ modelId, similar: staticSimilar, modelData: stati
                                                     <BsFillTrashFill />
                                                 </button>
                                                 <EditResourceButton
+                                                    modelId={modelId}
                                                     resource={resource}
                                                     onChange={(newResource) => {
                                                         const newResources = model.resources;
@@ -429,6 +430,7 @@ export default function Page({ modelId, similar: staticSimilar, modelData: stati
                             })}
                             {editMode && (
                                 <EditResourceButton
+                                    modelId={modelId}
                                     onChange={(newResource) => {
                                         const newResources = [...model.resources, newResource];
                                         updateModelProperty('resources', newResources);
@@ -459,9 +461,9 @@ export default function Page({ modelId, similar: staticSimilar, modelData: stati
                                             updateModelProperty={updateModelProperty}
                                         />,
                                     ],
-                                    model.size && [
+                                    (model.size || editMode) && [
                                         'Size',
-                                        renderTags(model.size, editMode, (newTags: string[]) => {
+                                        renderTags(model.size ?? EMPTY_ARRAY, editMode, (newTags: string[]) => {
                                             updateModelProperty('size', newTags);
                                         }),
                                     ],


### PR DESCRIPTION
This adds a little "Get info from file..." button to the resource edit pop over. When clicked, it opens a file dialog for model files. Upon selecting a model file, it will fill in the size, SHA 256, and platform. This makes it pretty easy to add new resources now.

It will also save the model under the correct model id in the data directory. This will be important later when we add a workflow for generating upscales of standard images.