### PR TITLE
Larger compare slider handle

### DIFF
--- a/src/elements/components/carousel/comparison.tsx
+++ b/src/elements/components/carousel/comparison.tsx
@@ -50,7 +50,7 @@ export const ImageComparison = ({ image }: ImageComparisonProps) => {
     return (
         <ReactCompareSlider
             onlyHandleDraggable
-            className="w-full"
+            className="react-compare-slider w-full"
             handle={
                 <ReactCompareSliderHandle
                     buttonStyle={{

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -105,3 +105,9 @@ a {
 .rendering-pixelated {
     image-rendering: pixelated;
 }
+
+// a small hack for ReactCompareSlider to make the handle bigger
+.react-compare-slider > [data-rcs='handle-container'] > * {
+    padding: 0 1rem;
+    cursor: ew-resize;
+}


### PR DESCRIPTION
This makes the hitbox for the comparison slider handle larger than it visually appears. This makes it a lot easy to actually hit the damn thing, especially on mobile.

Unfortunately, `ReactCompareSlider` does not have an option for this aside from replacing the whole handle, so I added a bit of hacky CSS.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/47c67993-05bd-42fd-9ff3-56aeb3483703)
