### PR TITLE
More arch data

### DIFF
--- a/data/architectures.json
+++ b/data/architectures.json
@@ -1,11 +1,4 @@
 {
-    "2c2-esrgan": {
-        "name": "2C2-ESRGAN",
-        "input": "image",
-        "compatiblePlatforms": [
-            "pytorch"
-        ]
-    },
     "cain": {
         "name": "CAIN",
         "input": "video",
@@ -49,7 +42,18 @@
         "name": "ESRGAN+",
         "input": "image",
         "compatiblePlatforms": [
-            "pytorch"
+            "pytorch",
+            "onnx",
+            "ncnn"
+        ]
+    },
+    "esrgan-2c2": {
+        "name": "ESRGAN 2C2",
+        "input": "image",
+        "compatiblePlatforms": [
+            "pytorch",
+            "onnx",
+            "ncnn"
         ]
     },
     "omnisr": {
@@ -61,7 +65,7 @@
     },
     "rife": {
         "name": "RIFE",
-        "input": "image",
+        "input": "video",
         "compatiblePlatforms": [
             "pytorch"
         ]
@@ -77,7 +81,8 @@
         "name": "SPSR",
         "input": "image",
         "compatiblePlatforms": [
-            "pytorch"
+            "pytorch",
+            "onnx"
         ]
     },
     "swinir": {

--- a/data/models/4x-2C2-ESRGAN-Nomos2K.json
+++ b/data/models/4x-2C2-ESRGAN-Nomos2K.json
@@ -7,7 +7,7 @@
     ],
     "description": "Technically my previous experiment was the pretrained model, but for all intents and purposes this was trained from scratch. Description: Pretrained model for the new architecture modification I made. You can read more about it in the [GitHub README](https://github.com/joeyballentine/2C2-ESRGAN). Basically it makes smaller ESRGAN models that theoretically can produce the same level of quality.\n\n**NOTE:** THIS WILL NOT WORK IN CUPSCALE or IEU! You have to use chaiNNer or my fork to use it for now.\n\nPretrained model: Technically my previous experiment was the pretrained model, but for all intents and purposes this was trained from scratch.",
     "date": "2022-04-20",
-    "architecture": "2c2-esrgan",
+    "architecture": "esrgan-2c2",
     "size": [
         "64nf",
         "23nb"

--- a/data/tag-categories.json
+++ b/data/tag-categories.json
@@ -47,7 +47,7 @@
             "arch:esrgan",
             "arch:compact",
             "arch:swinir",
-            "arch:2c2-esrgan",
+            "arch:esrgan-2c2",
             "arch:esrgan+",
             "arch:omnisr",
             "arch:cain",

--- a/data/tags.json
+++ b/data/tags.json
@@ -97,10 +97,6 @@
         "name": "Video Frame",
         "description": ""
     },
-    "arch:2c2-esrgan": {
-        "name": "2C2-ESRGAN",
-        "description": ""
-    },
     "arch:cain": {
         "name": "CAIN",
         "description": ""
@@ -123,6 +119,10 @@
     },
     "arch:esrgan+": {
         "name": "ESRGAN+",
+        "description": ""
+    },
+    "arch:esrgan-2c2": {
+        "name": "ESRGAN 2C2",
         "description": ""
     },
     "arch:omnisr": {


### PR DESCRIPTION
Changes:
- Renamed "2c2 ESRGAN" to "ESRGAN 2c2".
- Added more compatibility data. Progress toward #56.
- Fixed RIFE being classified as an image architecture.