### PR TITLE
Use different port for dev sever

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3010",
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext \".js,.jsx,.ts,.tsx\" && stylelint \"src/**/*.{scss,css}\"",


### PR DESCRIPTION
The dev server used to use 3000, which is also used by forge, so I could work on this website and have chainner open at the same time. So I changed the port of the dev server.