### PR TITLE
Fixed `useEditModeToggle`

### DIFF
--- a/src/lib/hooks/use-web-api.tsx
+++ b/src/lib/hooks/use-web-api.tsx
@@ -41,9 +41,11 @@ export interface UseEditModeToggle {
 export function useEditModeToggle(): UseEditModeToggle {
     const { webApi, enabled, toggleEnabled } = useContext(WebApiContext);
 
+    const editModeAvailable = webApi !== undefined;
+
     return {
-        editModeAvailable: webApi !== undefined,
-        editMode: enabled,
+        editModeAvailable,
+        editMode: editModeAvailable && enabled,
         toggleEditMode: toggleEnabled,
     };
 }


### PR DESCRIPTION
So I noticed that the Add model button as displayed on our deployed website.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/31154f00-4564-4f1d-b8b4-53a76d9d7d1f)

This was because `useEditModeToggle` had a bug where `editMode` as always enabled on the deployed website.