### PR TITLE
Added break words to dataset string

### DIFF
--- a/data/models/4x-Deoldify.json
+++ b/data/models/4x-Deoldify.json
@@ -29,7 +29,7 @@
     "trainingIterations": 790000,
     "trainingBatchSize": 16,
     "trainingHRSize": 128,
-    "dataset": "ADE20K(https://groups.csail.mit.edu/vision/datasets/ADE20K/), DIV2K(https://data.vision.ee.ethz.ch/cvl/DIV2K/), Library of Congress Scans (http://www.loc.gov/pictures/). I hand picked few thousand images here.",
+    "dataset": "ADE20K (https://groups.csail.mit.edu/vision/datasets/ADE20K/), DIV2K (https://data.vision.ee.ethz.ch/cvl/DIV2K/), Library of Congress Scans (http://www.loc.gov/pictures/). I hand picked few thousand images here.",
     "datasetSize": 2931607,
     "pretrainedModelG": "4x-Falcon-Fanart",
     "images": []

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -112,6 +112,7 @@ const editableMetadata = (
         case 'string':
             return (
                 <EditableLabel
+                    className="break-words"
                     readonly={!editMode}
                     text={value}
                     onChange={onChange}

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -106,6 +106,11 @@ a {
     image-rendering: pixelated;
 }
 
+.break-words {
+    word-break: normal;
+    overflow-wrap: anywhere;
+}
+
 // a small hack for ReactCompareSlider to make the handle bigger
 .react-compare-slider > [data-rcs='handle-container'] > * {
     padding: 0 1rem;


### PR DESCRIPTION
This fixes the text overflow we see on DeOldify's page. I also added spaces to the dataset description itself for better formatting.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/3d23dd51-89e5-4549-a203-a84b4cc5092d)
