### PR TITLE
Only allow valid model props

### DIFF
--- a/src/lib/model-props.ts
+++ b/src/lib/model-props.ts
@@ -249,11 +249,17 @@ export const MODEL_PROPS: Readonly<Record<keyof Model, ModelProp>> = {
             },
         },
     },
-    images: {
-        name: 'Images',
-        type: 'array',
-        of: { type: 'unknown' },
-        allowEmpty: true,
+    dataset: {
+        name: 'Dataset',
+        optional: true,
+        type: 'string',
+    },
+    datasetSize: {
+        name: 'Dataset size',
+        optional: true,
+        type: 'number',
+        isInteger: true,
+        min: 1,
     },
     trainingIterations: {
         name: 'Training iterations',
@@ -288,18 +294,6 @@ export const MODEL_PROPS: Readonly<Record<keyof Model, ModelProp>> = {
         optional: true,
         type: 'boolean',
     },
-    dataset: {
-        name: 'Dataset',
-        optional: true,
-        type: 'string',
-    },
-    datasetSize: {
-        name: 'Dataset size',
-        optional: true,
-        type: 'number',
-        isInteger: true,
-        min: 1,
-    },
     pretrainedModelG: {
         name: 'Pretrained Model (G)',
         optional: true,
@@ -311,5 +305,11 @@ export const MODEL_PROPS: Readonly<Record<keyof Model, ModelProp>> = {
         optional: true,
         type: 'string',
         kind: 'model-id',
+    },
+    images: {
+        name: 'Images',
+        type: 'array',
+        of: { type: 'unknown' },
+        allowEmpty: true,
     },
 };


### PR DESCRIPTION
Fixes an issue we discussed in #249.

This PR changes the way we do the metadata table. Everything relies on `MODEL_PROPS` now. It's used for entry order and its `ModelProp`s are used to determine the current value type (string, number, bool). They are also used to get the min/max of numbers to figure out which values are valid. This is then used to not write invalid values into the DB.