### PR TITLE
Allow `onChange` transformation in `EditableLabel`

### DIFF
--- a/src/elements/components/editable-label.tsx
+++ b/src/elements/components/editable-label.tsx
@@ -7,7 +7,7 @@ export interface EditableLabelProps {
     text: string;
     className?: string;
     readonly?: boolean;
-    onChange?: (newText: string) => void;
+    onChange?: (newText: string) => void | string;
 }
 
 export function EditableLabel({ className, text, onChange, readonly }: EditableLabelProps) {
@@ -35,7 +35,10 @@ export function EditableLabel({ className, text, onChange, readonly }: EditableL
 
     const submit = () => {
         if (value !== text) {
-            onChange(value);
+            const newValue = onChange(value);
+            if (newValue !== undefined) {
+                setValue(newValue);
+            }
         }
         setEdit(false);
     };

--- a/src/pages/users.tsx
+++ b/src/pages/users.tsx
@@ -131,11 +131,13 @@ export default function Page() {
                                 <EditableLabel
                                     readonly={!editMode}
                                     text={userId}
-                                    onChange={(newId) => {
+                                    onChange={(newIdString) => {
                                         if (!webApi) return;
-                                        webApi.users
-                                            .changeId(userId, canonicalizeUserId(newId))
-                                            .catch((e) => console.error(e));
+                                        const newId = canonicalizeUserId(newIdString);
+                                        if (newId !== userId) {
+                                            webApi.users.changeId(userId, newId).catch((e) => console.error(e));
+                                        }
+                                        return newId;
                                     }}
                                 />
                             </span>


### PR DESCRIPTION
This fixes a minor bug I noticed in #250. `EditableLabel` (EL) assumes that its value is written into the database as is. But we canonicalize user ids first to prevent invalid data. This can lead to 2 situations:
1. The user presses Enter, EL displays the text they just entered, and that text is then updated to the canonicalized version ~3sec later.
2. The user presses Enter, EL displays the text they just entered, and canonicalized version of the text is the same as the old id, which causes EL to never update and keep displaying the wrong user id.

Neither of those situations are ideally but 2 is really bad.

This PR fixes that by allowing `onChange` to return a string. `onChange` handlers that transform the entered string can now return the transformed version, which causes EL to immediately display the correct version. This fixes both situations.