### PR TITLE
Fixed relative links in doc pages

### DIFF
--- a/src/elements/markdown.module.scss
+++ b/src/elements/markdown.module.scss
@@ -23,6 +23,8 @@
 }
 
 .linkableHeading {
+    scroll-margin-top: 80px;
+
     a:hover {
         border-bottom: 1px dotted;
 

--- a/src/elements/markdown.tsx
+++ b/src/elements/markdown.tsx
@@ -65,12 +65,13 @@ const LinkableHeading: HeadingComponent = ({ children, level }) => {
 export interface MarkdownProps {
     markdown: string;
     className?: string;
+    isIndexPage?: boolean;
 }
-export function MarkdownContainer(props: MarkdownProps) {
+export function MarkdownContainer({ markdown, className, isIndexPage = false }: MarkdownProps) {
     const baseUrl = useCurrentPath();
 
     return (
-        <div className={joinClasses(style.markdown, props.className)}>
+        <div className={joinClasses(style.markdown, className)}>
             <ReactMarkdown
                 skipHtml
                 components={{
@@ -83,7 +84,7 @@ export function MarkdownContainer(props: MarkdownProps) {
                         }
 
                         const origin = 'https://openmodeldb.info';
-                        const url = new URL(href, origin + baseUrl);
+                        const url = new URL(href, origin + baseUrl + (isIndexPage ? '/index' : ''));
                         if (url.href === origin) {
                             return <TextLink href="/">{children}</TextLink>;
                         }
@@ -92,6 +93,8 @@ export function MarkdownContainer(props: MarkdownProps) {
                             if (relative.startsWith('/docs')) {
                                 // remove .md endings in doc links
                                 relative = relative.replace(/\.md(?=$|#)/, '');
+                                // remove index
+                                relative = relative.replace(/\/index(?=$|#)/, '');
                             }
                             return <TextLink href={relative}>{children}</TextLink>;
                         }
@@ -142,7 +145,7 @@ export function MarkdownContainer(props: MarkdownProps) {
                 }}
                 remarkPlugins={[remarkGfm]}
             >
-                {props.markdown}
+                {markdown}
             </ReactMarkdown>
         </div>
     );

--- a/src/pages/docs/[[...slug]].tsx
+++ b/src/pages/docs/[[...slug]].tsx
@@ -45,7 +45,10 @@ export default function Page({ title, markdown, sideBar, docPath, lastModified }
                         <SideBarView sideBar={sideBar} />
                     </div>
                     <div className={style.content}>
-                        <MarkdownContainer markdown={markdown} />
+                        <MarkdownContainer
+                            isIndexPage={docPath.endsWith('index.md')}
+                            markdown={markdown}
+                        />
                         {(prev || next) && (
                             <div className={style.links}>
                                 {prev && (


### PR DESCRIPTION
This fixes 2 bugs:

- When linking to any `foo/index.md`, the relative compiled links where to `foo/index`, which doesn't exist because it's just `foo`.
- When linking to other pages from any `foo/index.md`, the relative links were wrong because the page is just `foo`, which is one directory level up.

I also improved the scrolling behavior of links. They will no longer be behind the header.