### PR TITLE
Fixed deployment checkout not including history

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Setup Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
The doc pages use git history to figure out they have been last modified. This timestamp is then displayed on the website.

However, `actions/checkout@v3` doesn't checkout git history by default (for good reason), so it caused all our doc pages to have the same last modified date. This PR fixes that by configuring the action to fetch git history as well.