### PR TITLE
Disable collapsing items in sidebar

### DIFF
--- a/src/elements/side-bar.tsx
+++ b/src/elements/side-bar.tsx
@@ -90,13 +90,17 @@ function isBranch(item: SideBarItem): item is Branch {
 function SideBarBranch({ item, level, isCurrent }: { item: Branch } & RecurseProps) {
     const [collapsed, setCollapsed] = useState(false);
     const toggle = useCallback(() => setCollapsed((prev) => !prev), []);
+
     return (
         <div className={style.branch}>
             <SideBarItem
                 icon={collapsed ? 'branch-collapsed' : 'branch-open'}
                 isCurrent={isCurrent}
                 item={item}
-                onClick={toggle}
+                // Disable this feature for now.
+                // Documentation is not deep enough to warrant this.
+                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                onClick={false ? toggle : undefined}
             />
             {!collapsed && (
                 <SideBarItems


### PR DESCRIPTION
I found that the really small buttons to collapse sidebar items were not only close to useless, but they could even be harmful. It's not obvious that the small icons are buttons, so users might accidentally click them, collapsing child items, and not know how to expand them again.