### PR TITLE
More tag descriptions and removed "Game Texture Maps"

### DIFF
--- a/data/models/1x-FrankenMapGenerator-CX-Lite.json
+++ b/data/models/1x-FrankenMapGenerator-CX-Lite.json
@@ -3,7 +3,7 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "game-texture-maps"
+        "game-textures"
     ],
     "description": "Category: Normal Map/Bump Map Generation\nPurpose: Map Generation - roughness and displacement maps\n\nThis model generates \"Franken Maps\" (named after Frankenstein), which is a custom material map combination I made. Basically, the Red channel of RGB is just the texture converted to grayscale, the Green channel is the roughness map, and the Blue channel is the displacement map. I had to do this to get around the current limitation of CX loss where it requires a 3 channel output (otherwise I would have just made a 2 channel model, or separate single channel models). As of right now the channels need to be manually split from each other but I will be making a tool for doing this automatically in the coming days.\n\nPretrained model: 1x_DIV2K-Lite_450k.pth",
     "date": "2020-11-07",

--- a/data/models/1x-FrankenMapGenerator-CX-Lite.json
+++ b/data/models/1x-FrankenMapGenerator-CX-Lite.json
@@ -3,7 +3,8 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "game-textures"
+        "game-textures",
+        "texture-generation"
     ],
     "description": "Category: Normal Map/Bump Map Generation\nPurpose: Map Generation - roughness and displacement maps\n\nThis model generates \"Franken Maps\" (named after Frankenstein), which is a custom material map combination I made. Basically, the Red channel of RGB is just the texture converted to grayscale, the Green channel is the roughness map, and the Blue channel is the displacement map. I had to do this to get around the current limitation of CX loss where it requires a 3 channel output (otherwise I would have just made a 2 channel model, or separate single channel models). As of right now the channels need to be manually split from each other but I will be making a tool for doing this automatically in the coming days.\n\nPretrained model: 1x_DIV2K-Lite_450k.pth",
     "date": "2020-11-07",

--- a/data/models/1x-NormalMapGenerator-CX-Lite.json
+++ b/data/models/1x-NormalMapGenerator-CX-Lite.json
@@ -3,7 +3,8 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "game-textures"
+        "game-textures",
+        "texture-generation"
     ],
     "description": "Category: Normal Map/Bump Map Generation\nPurpose: Map Generation - normal maps\n\nGenerating normal maps from textures\n\nPretrained model: 1x_DIV2K-Lite_450k.pth",
     "date": "2020-11-04",

--- a/data/models/1x-NormalMapGenerator-CX-Lite.json
+++ b/data/models/1x-NormalMapGenerator-CX-Lite.json
@@ -3,7 +3,7 @@
     "author": "joey",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "game-texture-maps"
+        "game-textures"
     ],
     "description": "Category: Normal Map/Bump Map Generation\nPurpose: Map Generation - normal maps\n\nGenerating normal maps from textures\n\nPretrained model: 1x_DIV2K-Lite_450k.pth",
     "date": "2020-11-04",

--- a/data/models/1x-normals-generator-general.json
+++ b/data/models/1x-normals-generator-general.json
@@ -3,7 +3,7 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "game-texture-maps"
+        "game-textures"
     ],
     "description": "Category: Normal Map/Bump Map Generation\nPurpose: Map Generation - Normal Maps\n\nThis model generates \"Franken Maps\" (named after Frankenstein), which is a custom material map combination I made. Basically, the Red channel of RGB is just the texture converted to grayscale, the Green channel is the roughness map, and the Blue channel is the displacement map. I had to do this to get around the current limitation of CX loss where it requires a 3 channel output (otherwise I would have just made a 2 channel model, or separate single channel models). As of right now the channels need to be manually split from each other but I will be making a tool for doing this automatically in the coming days.",
     "date": "2019-04-28",

--- a/data/models/1x-normals-generator-general.json
+++ b/data/models/1x-normals-generator-general.json
@@ -3,7 +3,8 @@
     "author": "lyonhrt",
     "license": "CC-BY-NC-SA-4.0",
     "tags": [
-        "game-textures"
+        "game-textures",
+        "texture-generation"
     ],
     "description": "Category: Normal Map/Bump Map Generation\nPurpose: Map Generation - Normal Maps\n\nThis model generates \"Franken Maps\" (named after Frankenstein), which is a custom material map combination I made. Basically, the Red channel of RGB is just the texture converted to grayscale, the Green channel is the roughness map, and the Blue channel is the displacement map. I had to do this to get around the current limitation of CX loss where it requires a 3 channel output (otherwise I would have just made a 2 channel model, or separate single channel models). As of right now the channels need to be manually split from each other but I will be making a tool for doing this automatically in the coming days.",
     "date": "2019-04-28",

--- a/data/tag-categories.json
+++ b/data/tag-categories.json
@@ -35,7 +35,8 @@
             "jpeg",
             "pretrained",
             "research",
-            "restoration"
+            "restoration",
+            "texture-generation"
         ]
     },
     "architecture": {

--- a/data/tag-categories.json
+++ b/data/tag-categories.json
@@ -8,7 +8,6 @@
             "anime",
             "cartoon",
             "faces",
-            "game-texture-maps",
             "game-textures",
             "manga",
             "photo",

--- a/data/tags.json
+++ b/data/tags.json
@@ -93,6 +93,10 @@
         "name": "Text",
         "description": "Image or video of text."
     },
+    "texture-generation": {
+        "name": "Texture Generation",
+        "description": "The model generates textures from other textures. E.g. a model could generate a normal map from a diffuse texture."
+    },
     "video-frame": {
         "name": "Video Frame",
         "description": "Image of individual video frames."

--- a/data/tags.json
+++ b/data/tags.json
@@ -1,7 +1,7 @@
 {
     "anime": {
         "name": "Anime",
-        "description": ""
+        "description": "Image or video of anime or anime-style artwork."
     },
     "anti-aliasing": {
         "name": "Anti-aliasing",
@@ -9,7 +9,7 @@
     },
     "cartoon": {
         "name": "Cartoon",
-        "description": ""
+        "description": "Image or video of western cartoon or artwork in a similar style."
     },
     "colorization": {
         "name": "Colorization",
@@ -44,15 +44,11 @@
     },
     "faces": {
         "name": "Faces",
-        "description": ""
-    },
-    "game-texture-maps": {
-        "name": "Game Texture Maps",
-        "description": ""
+        "description": "Image or video of faces. This can be photograph or artwork."
     },
     "game-textures": {
         "name": "Game Textures",
-        "description": ""
+        "description": "Textures used in video games or other 3D applications. These textures are typically diffuse/albedo maps, but other types of textures (such as normal maps) are also included."
     },
     "general-upscaler": {
         "name": "General Upscaler",
@@ -71,15 +67,15 @@
     },
     "manga": {
         "name": "Manga",
-        "description": ""
+        "description": "Image of manga pages or manga-style artwork."
     },
     "photo": {
         "name": "Photo",
-        "description": ""
+        "description": "Image or video of realistic scenes recorded with a camera."
     },
     "pixel-art": {
         "name": "Pixel Art",
-        "description": ""
+        "description": "Digital art. This includes everything from retro pixel artworks to modern CGI."
     },
     "pretrained": {
         "name": "Pretrained",
@@ -95,11 +91,11 @@
     },
     "text": {
         "name": "Text",
-        "description": ""
+        "description": "Image or video of text."
     },
     "video-frame": {
         "name": "Video Frame",
-        "description": ""
+        "description": "Image of individual video frames."
     },
     "arch:cain": {
         "name": "CAIN",
@@ -255,27 +251,27 @@
     },
     "platform:ncnn": {
         "name": "NCNN",
-        "description": ""
+        "description": "The model has NCNN models (`.bin`+`.param`) to download."
     },
     "platform:ncnn-compatible": {
         "name": "NCNN Compatible",
-        "description": ""
+        "description": "The either has NCNN models to download or can be converted into an NCNN model."
     },
     "platform:onnx": {
         "name": "ONNX",
-        "description": ""
+        "description": "The model has ONNX models (`.onnx`) to download."
     },
     "platform:onnx-compatible": {
         "name": "ONNX Compatible",
-        "description": ""
+        "description": "The either has ONNX models to download or can be converted into an ONNX model."
     },
     "platform:pytorch": {
         "name": "PyTorch",
-        "description": ""
+        "description": "The model has PyTorch models (`.pth`/`.pt`) to download."
     },
     "platform:pytorch-compatible": {
         "name": "PyTorch Compatible",
-        "description": ""
+        "description": "The either has PyTorch models to download or can be converted into a PyTorch model."
     },
     "scale:1": {
         "name": "1x",


### PR DESCRIPTION
Changes:
- Added descriptions to all Subject tags.
- Added descriptions to all Platform tags.
- Removed the "Game Texture Maps" tag. I think I was the one that added this tag, but even I can't remember what the difference between this tag and "Game Textures" is. So I removed the tag to make things easier.