### PR TITLE
Removed thumbnail for paired images in model card

### DIFF
--- a/src/elements/components/model-card.tsx
+++ b/src/elements/components/model-card.tsx
@@ -109,16 +109,6 @@ const getModelCardImageComponent = (model: Model) => {
     const image = model.images[0] as Image | undefined;
     switch (image?.type) {
         case 'paired': {
-            if (image.thumbnail) {
-                return (
-                    <img
-                        alt={model.name}
-                        className="margin-auto z-0 h-full w-full object-cover"
-                        loading="lazy"
-                        src={image.thumbnail}
-                    />
-                );
-            }
             return (
                 <SideBySideImage
                     image={image}


### PR DESCRIPTION
Added a thumbnail to paired images resulted in the model card being messed up.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/0888e587-07dd-4acc-8c2e-632a39bfb682)

I fixed this.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/600a18af-ccfd-48a7-b6f0-389b8b52ecd1)