### PR TITLE
Don't show carousel controls if there's only a single image

### DIFF
--- a/src/elements/components/image-carousel.tsx
+++ b/src/elements/components/image-carousel.tsx
@@ -57,144 +57,146 @@ export const ImageCarousel = ({ images, readonly, indexKey, onChange }: ImageCar
                     </div>
                 )}
             </div>
-            <div className="space-between flex w-full py-2">
-                {images.length >= 2 && (
-                    <button
-                        aria-label="Previous image"
-                        className="inline-flex cursor-pointer items-center rounded-lg border-0 bg-fade-200 p-2.5 text-center text-sm text-fade-900 transition duration-100 ease-in-out hover:bg-fade-300 focus:outline-none focus:ring-4 focus:ring-fade-700 dark:bg-fade-700 dark:text-white dark:hover:bg-fade-600 dark:focus:ring-fade-500"
-                        onClick={() => {
-                            setImageIndex((imageIndex + images.length - 1) % images.length);
-                        }}
-                    >
-                        <BsCaretLeftFill />
-                    </button>
-                )}
-                <div className="flex grow items-center justify-center justify-items-center gap-2 align-middle">
-                    {sliceStartIndex > 0 && (
-                        <div>
-                            <FiMoreHorizontal />
-                        </div>
-                    )}
-                    {images.slice(sliceStartIndex, sliceEndIndex).map((image, actualIndex) => {
-                        const index = sliceStartIndex + actualIndex;
-                        return (
-                            <div
-                                className="flex flex-col items-center"
-                                key={image.type === 'paired' ? image.SR : image.url}
-                            >
-                                {!readonly && (
-                                    <div className="flex flex-row items-center">
-                                        <EditImageButton
-                                            image={image}
-                                            onChange={(editedImage) => {
-                                                const newImages = [...images];
-                                                newImages[index] = editedImage;
-                                                if (onChange) {
-                                                    onChange(newImages);
-                                                }
-                                            }}
-                                        >
-                                            <AiFillEdit />
-                                        </EditImageButton>
-                                        <button
-                                            className="block"
-                                            onClick={() => {
-                                                const newImages = [...images];
-                                                // Remove image
-                                                newImages.splice(index, 1);
-                                                if (onChange) {
-                                                    onChange(newImages);
-                                                }
-                                            }}
-                                        >
-                                            <BsFillTrashFill />
-                                        </button>
-                                    </div>
-                                )}
-                                <div
-                                    className={joinClasses(
-                                        'border-3 m-0 flex h-12 w-12 cursor-pointer overflow-hidden rounded-lg border-solid p-0 transition duration-100 ease-in-out',
-                                        index === imageIndex
-                                            ? 'border-accent-500'
-                                            : 'border-fade-200 hover:border-fade-300 dark:border-fade-700 dark:hover:border-fade-600'
-                                    )}
-                                    onClick={() => {
-                                        setImageIndex(index);
-                                    }}
-                                >
-                                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                                    <img
-                                        alt={image.caption || 'Thumbnail'}
-                                        className="m-auto h-auto max-h-full w-auto max-w-full"
-                                        src={image.thumbnail || (image.type === 'paired' ? image.SR : image.url)}
-                                        title={image.caption}
-                                    />
-                                </div>
-                                {!readonly && (
-                                    <div className="flex flex-row items-center">
-                                        <button
-                                            onClick={() => {
-                                                const newImages = [...images];
-                                                // Move image to the left
-                                                newImages.splice(index, 1);
-                                                newImages.splice(index - 1, 0, image);
-                                                if (onChange) {
-                                                    onChange(newImages);
-                                                }
-                                            }}
-                                        >
-                                            <BsChevronLeft />
-                                        </button>
-
-                                        <button
-                                            onClick={() => {
-                                                const newImages = [...images];
-                                                // Move image to the right
-                                                newImages.splice(index, 1);
-                                                newImages.splice(index + 1, 0, image);
-                                                if (onChange) {
-                                                    onChange(newImages);
-                                                }
-                                            }}
-                                        >
-                                            <BsChevronRight />
-                                        </button>
-                                    </div>
-                                )}
-                            </div>
-                        );
-                    })}
-                    {sliceEndIndex < images.length && (
-                        <div>
-                            <FiMoreHorizontal />
-                        </div>
-                    )}
-                    {!readonly && (
-                        <EditImageButton
-                            onChange={(newImage) => {
-                                const newImages = [...images];
-                                newImages.push(newImage);
-                                if (onChange) {
-                                    onChange(newImages);
-                                }
+            {(!readonly || images.length > 1) && (
+                <div className="space-between flex w-full py-2">
+                    {images.length >= 2 && (
+                        <button
+                            aria-label="Previous image"
+                            className="inline-flex cursor-pointer items-center rounded-lg border-0 bg-fade-200 p-2.5 text-center text-sm text-fade-900 transition duration-100 ease-in-out hover:bg-fade-300 focus:outline-none focus:ring-4 focus:ring-fade-700 dark:bg-fade-700 dark:text-white dark:hover:bg-fade-600 dark:focus:ring-fade-500"
+                            onClick={() => {
+                                setImageIndex((imageIndex + images.length - 1) % images.length);
                             }}
                         >
-                            <BsPlusLg />
-                        </EditImageButton>
+                            <BsCaretLeftFill />
+                        </button>
+                    )}
+                    <div className="flex grow items-center justify-center justify-items-center gap-2 align-middle">
+                        {sliceStartIndex > 0 && (
+                            <div>
+                                <FiMoreHorizontal />
+                            </div>
+                        )}
+                        {images.slice(sliceStartIndex, sliceEndIndex).map((image, actualIndex) => {
+                            const index = sliceStartIndex + actualIndex;
+                            return (
+                                <div
+                                    className="flex flex-col items-center"
+                                    key={image.type === 'paired' ? image.SR : image.url}
+                                >
+                                    {!readonly && (
+                                        <div className="flex flex-row items-center">
+                                            <EditImageButton
+                                                image={image}
+                                                onChange={(editedImage) => {
+                                                    const newImages = [...images];
+                                                    newImages[index] = editedImage;
+                                                    if (onChange) {
+                                                        onChange(newImages);
+                                                    }
+                                                }}
+                                            >
+                                                <AiFillEdit />
+                                            </EditImageButton>
+                                            <button
+                                                className="block"
+                                                onClick={() => {
+                                                    const newImages = [...images];
+                                                    // Remove image
+                                                    newImages.splice(index, 1);
+                                                    if (onChange) {
+                                                        onChange(newImages);
+                                                    }
+                                                }}
+                                            >
+                                                <BsFillTrashFill />
+                                            </button>
+                                        </div>
+                                    )}
+                                    <div
+                                        className={joinClasses(
+                                            'border-3 m-0 flex h-12 w-12 cursor-pointer overflow-hidden rounded-lg border-solid p-0 transition duration-100 ease-in-out',
+                                            index === imageIndex
+                                                ? 'border-accent-500'
+                                                : 'border-fade-200 hover:border-fade-300 dark:border-fade-700 dark:hover:border-fade-600'
+                                        )}
+                                        onClick={() => {
+                                            setImageIndex(index);
+                                        }}
+                                    >
+                                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                                        <img
+                                            alt={image.caption || 'Thumbnail'}
+                                            className="m-auto h-auto max-h-full w-auto max-w-full"
+                                            src={image.thumbnail || (image.type === 'paired' ? image.SR : image.url)}
+                                            title={image.caption}
+                                        />
+                                    </div>
+                                    {!readonly && (
+                                        <div className="flex flex-row items-center">
+                                            <button
+                                                onClick={() => {
+                                                    const newImages = [...images];
+                                                    // Move image to the left
+                                                    newImages.splice(index, 1);
+                                                    newImages.splice(index - 1, 0, image);
+                                                    if (onChange) {
+                                                        onChange(newImages);
+                                                    }
+                                                }}
+                                            >
+                                                <BsChevronLeft />
+                                            </button>
+
+                                            <button
+                                                onClick={() => {
+                                                    const newImages = [...images];
+                                                    // Move image to the right
+                                                    newImages.splice(index, 1);
+                                                    newImages.splice(index + 1, 0, image);
+                                                    if (onChange) {
+                                                        onChange(newImages);
+                                                    }
+                                                }}
+                                            >
+                                                <BsChevronRight />
+                                            </button>
+                                        </div>
+                                    )}
+                                </div>
+                            );
+                        })}
+                        {sliceEndIndex < images.length && (
+                            <div>
+                                <FiMoreHorizontal />
+                            </div>
+                        )}
+                        {!readonly && (
+                            <EditImageButton
+                                onChange={(newImage) => {
+                                    const newImages = [...images];
+                                    newImages.push(newImage);
+                                    if (onChange) {
+                                        onChange(newImages);
+                                    }
+                                }}
+                            >
+                                <BsPlusLg />
+                            </EditImageButton>
+                        )}
+                    </div>
+                    {images.length >= 2 && (
+                        <button
+                            aria-label="Next image"
+                            className="inline-flex cursor-pointer items-center rounded-lg border-0 bg-fade-200 p-2.5 text-center text-sm text-fade-900 transition duration-100 ease-in-out hover:bg-fade-300 focus:outline-none focus:ring-4 focus:ring-fade-700 dark:bg-fade-700 dark:text-white dark:hover:bg-fade-600 dark:focus:ring-fade-500"
+                            onClick={() => {
+                                setImageIndex((imageIndex + 1) % images.length);
+                            }}
+                        >
+                            <BsCaretRightFill />
+                        </button>
                     )}
                 </div>
-                {images.length >= 2 && (
-                    <button
-                        aria-label="Next image"
-                        className="inline-flex cursor-pointer items-center rounded-lg border-0 bg-fade-200 p-2.5 text-center text-sm text-fade-900 transition duration-100 ease-in-out hover:bg-fade-300 focus:outline-none focus:ring-4 focus:ring-fade-700 dark:bg-fade-700 dark:text-white dark:hover:bg-fade-600 dark:focus:ring-fade-500"
-                        onClick={() => {
-                            setImageIndex((imageIndex + 1) % images.length);
-                        }}
-                    >
-                        <BsCaretRightFill />
-                    </button>
-                )}
-            </div>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
What the title says. When there's only a single image, then the controls don't do anything, so I hid them in non-edit mode.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/2550fee9-f828-4573-8e71-080a406cf719)


This PR is best reviewed while hiding whitespace changes.