### PR TITLE
Properly break model names

### DIFF
--- a/src/elements/components/editable-label.module.scss
+++ b/src/elements/components/editable-label.module.scss
@@ -36,3 +36,8 @@
     line-height: 1;
     width: 100%;
 }
+
+.breakable {
+    word-break: normal;
+    overflow-wrap: anywhere;
+}

--- a/src/elements/components/editable-label.tsx
+++ b/src/elements/components/editable-label.tsx
@@ -17,12 +17,12 @@ export function EditableLabel({ className, text, onChange, readonly }: EditableL
     useEffect(() => setValue(text), [text]);
 
     if (readonly || !onChange) {
-        return <span className={className}>{value}</span>;
+        return <span className={joinClasses(style.breakable, className)}>{value}</span>;
     }
     if (!edit) {
         return (
             <span
-                className={joinClasses(style.editable, className)}
+                className={joinClasses(style.editable, style.breakable, className)}
                 onClick={() => setEdit(true)}
             >
                 {value}


### PR DESCRIPTION
Where long model names were not properly broken on mobile. They now are.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/68cfba4a-141b-4b7e-955d-153e004deaac)
