### PR TITLE
Support editing optional booleans

### DIFF
--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -137,6 +137,32 @@ const editableMetadata = (
             if (!editMode) {
                 return <span>{value ? 'Yes' : 'No'}</span>;
             }
+            if (prop.optional) {
+                return (
+                    <span>
+                        <span
+                            className={`${value === true ? 'font-bold underline ' : ''}cursor-pointer hover:underline`}
+                            onClick={() => onChange(true)}
+                        >
+                            Yes
+                        </span>
+                        {' / '}
+                        <span
+                            className={`${value === false ? 'font-bold underline ' : ''}cursor-pointer hover:underline`}
+                            onClick={() => onChange(false)}
+                        >
+                            No
+                        </span>
+                        {' / '}
+                        <span
+                            className={`${value == null ? 'font-bold underline ' : ''}cursor-pointer hover:underline`}
+                            onClick={() => onChange(undefined)}
+                        >
+                            Unknown
+                        </span>
+                    </span>
+                );
+            }
             return (
                 <Switch
                     value={Boolean(value ?? false)}


### PR DESCRIPTION
We displayed Training OTF as a switch before, which wasn't right, because the value can be null (=unknown). This PR replaced the switch with simple Yes/No/Unknown options.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/b49624b2-36ad-47fb-99aa-cab19735a0ef)
