### PR TITLE
Scroll to results on search enter

### DIFF
--- a/src/elements/components/searchbar.tsx
+++ b/src/elements/components/searchbar.tsx
@@ -1,11 +1,12 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, KeyboardEvent } from 'react';
 
 type SearchBarProps = {
     value: string;
     onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+    onEnter?: (event: KeyboardEvent<HTMLInputElement>) => void;
 };
 
-export const SearchBar = ({ value, onChange }: SearchBarProps) => (
+export const SearchBar = ({ value, onChange, onEnter }: SearchBarProps) => (
     <div className="relative mb-4 flex h-10 w-full">
         <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
             <svg
@@ -30,6 +31,11 @@ export const SearchBar = ({ value, onChange }: SearchBarProps) => (
             type="text"
             value={value}
             onChange={onChange}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                    onEnter?.(e);
+                }
+            }}
         />
     </div>
 );

--- a/src/lib/hooks/use-search.ts
+++ b/src/lib/hooks/use-search.ts
@@ -105,10 +105,10 @@ export const useSearch = (
     const update = useCallback(
         (newStatePartial: Partial<SearchState>, delay = 0): void => {
             const newState: SearchState = { ...stateRef.current, ...newStatePartial };
-            if (isEqualState(newState, stateRef.current)) return;
-
-            setState(newState);
-            stateRef.current = newState;
+            if (!isEqualState(newState, stateRef.current)) {
+                setState(newState);
+                stateRef.current = newState;
+            }
 
             if (lastTimerRef.current !== undefined) {
                 clearTimeout(lastTimerRef.current);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -137,6 +137,25 @@ export default function Page({ modelData: staticModelData }: Props) {
                 <SearchBar
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value, 400)}
+                    onEnter={(e) => {
+                        setSearchQuery(e.currentTarget.value, 0);
+
+                        // scroll to search results on mobile
+                        if (window.innerWidth < 600 || window.navigator.maxTouchPoints > 0) {
+                            e.currentTarget.blur();
+                            const anchor = document.getElementById('scroll-anchor');
+                            if (anchor) {
+                                const headerOffset = 80;
+                                const elementPosition = anchor.getBoundingClientRect().top;
+                                const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
+
+                                window.scrollTo({
+                                    top: offsetPosition,
+                                    behavior: 'smooth',
+                                });
+                            }
+                        }
+                    }}
                 />
 
                 {/* Tags */}
@@ -148,6 +167,8 @@ export default function Page({ modelData: staticModelData }: Props) {
                         }}
                     />
                 </div>
+
+                <span id="scroll-anchor" />
 
                 {/* Model Cards */}
                 {selectedModels.length > 0 ? (


### PR DESCRIPTION
Changes:
- Immediately update results when the user presses Enter in the search bar.
- Scroll to search results on mobile after Enter.
- Fixed a bug in `useSearch` where search results were not updated quickly enough.