### PR TITLE
Make metadata table more readable in light mode

### DIFF
--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -282,7 +282,7 @@ function LicenseProp({ model, updateModelProperty, editMode }: PropertyProps) {
 
 function MetadataTable({ rows }: { rows: (false | null | undefined | readonly [string, ReactNode])[] }) {
     return (
-        <table className="w-full border-collapse text-left text-sm text-gray-500 dark:text-gray-400 ">
+        <table className="w-full border-collapse text-left text-sm text-gray-700 dark:text-gray-400 ">
             <tbody>
                 {rows.map((row, i) => {
                     if (!row) return null;


### PR DESCRIPTION
I used a darker font color to make the text more readable in light mode.