### PR TITLE
Removed No License tag

### DIFF
--- a/data/tag-categories.json
+++ b/data/tag-categories.json
@@ -128,7 +128,6 @@
             "license:commercial",
             "license:modifications",
             "license:sa",
-            "license:no-license",
             "license:unknown"
         ]
     },

--- a/data/tags.json
+++ b/data/tags.json
@@ -241,17 +241,13 @@
         "name": "Modifications",
         "description": "The author allows that this model may be used to create derivative works (e.g. model interpolations)."
     },
-    "license:no-license": {
-        "name": "No License",
-        "description": "The model is not licensed by the author."
-    },
     "license:sa": {
         "name": "Same license",
         "description": "The author **requires** that derivative works have the same license or a compatible license as the model. Derivative works include model interpolations and using it a pretrained model."
     },
     "license:unknown": {
         "name": "Unknown License",
-        "description": "The model is licensed under a custom or infrequently used license."
+        "description": "The model either has no license or is licensed under a custom or infrequently used license."
     },
     "platform:ncnn": {
         "name": "NCNN",

--- a/src/lib/derive-tags.ts
+++ b/src/lib/derive-tags.ts
@@ -21,7 +21,7 @@ type Tag<T extends string> = `${T}:${string}`;
 const getLicenseTags = lazyWithKey((license: SPDXLicense | null): Iterable<Tag<'license'>> => {
     const ids = parseLicense(license);
     if (ids.length === 0) {
-        return ['license:no-license'];
+        return ['license:unknown'];
     }
 
     const tags = new Set<Tag<'license'>>();


### PR DESCRIPTION
I removed the No License tag by combining it with the Unknown License tag. These tags were quite similar in the first place, and there's not much difference between the two anyway.