### PR TITLE
Add structured data for models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-tooltip": "^5.10.4",
         "react-zoom-pan-pinch": "^3.0.7",
         "remark-gfm": "^3.0.1",
+        "schema-dts": "^1.1.2",
         "simple-git": "^3.16.0"
       },
       "devDependencies": {
@@ -17525,6 +17526,14 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/schema-dts": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-1.1.2.tgz",
+      "integrity": "sha512-MpNwH0dZJHinVxk9bT8XUdjKTxMYrA5bLtrrGmFA6PTLwlOKnhi67XoRd6/ty+Djt6ZC0slR57qFhZDNMI6DhQ==",
+      "peerDependencies": {
+        "typescript": ">=4.1.0"
+      }
+    },
     "node_modules/schema-utils": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
@@ -19239,7 +19248,6 @@
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -32778,6 +32786,12 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "schema-dts": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-1.1.2.tgz",
+      "integrity": "sha512-MpNwH0dZJHinVxk9bT8XUdjKTxMYrA5bLtrrGmFA6PTLwlOKnhi67XoRd6/ty+Djt6ZC0slR57qFhZDNMI6DhQ==",
+      "requires": {}
+    },
     "schema-utils": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
@@ -34052,8 +34066,7 @@
     "typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "devOptional": true
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
     },
     "typescript-plugin-css-modules": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-tooltip": "^5.10.4",
     "react-zoom-pan-pinch": "^3.0.7",
     "remark-gfm": "^3.0.1",
+    "schema-dts": "^1.1.2",
     "simple-git": "^3.16.0"
   },
   "devDependencies": {

--- a/src/elements/components/model-card.tsx
+++ b/src/elements/components/model-card.tsx
@@ -9,6 +9,7 @@ import { useUsers } from '../../lib/hooks/use-users';
 import { useWebApi } from '../../lib/hooks/use-web-api';
 import { joinList } from '../../lib/react-util';
 import { Image, Model, ModelId, PairedImage } from '../../lib/schema';
+import { getTextDescription } from '../../lib/text-description';
 import { asArray, joinClasses } from '../../lib/util';
 import { EditableTags } from './editable-tags';
 import { Link } from './link';
@@ -140,7 +141,7 @@ export const ModelCardContent = memo(({ id, model }: BaseModelCardProps) => {
     const { webApi, editMode } = useWebApi();
     const { updateModelProperty } = useUpdateModel(webApi, id);
 
-    const description = fixDescription(model.description, model.scale);
+    const description = getTextDescription(model);
     const isPaired = model.images[0]?.type === 'paired' && !editMode;
 
     return (
@@ -229,31 +230,6 @@ export const ModelCard = memo(({ id, model, lazy = false }: ModelCardProps) => {
         </LazyLoadComponent>
     );
 });
-
-function fixDescription(description: string, scale: number): string {
-    const lines = description.trim().split('\n');
-    const descLines: string[] = [];
-    let purpose = '',
-        pretrained = '';
-    lines.forEach((line) => {
-        if (line.startsWith('Category: ')) {
-            // ignore category
-        } else if (line.startsWith('Purpose: ')) {
-            purpose = line.replace('Purpose: ', '');
-        } else if (line.startsWith('Pretrained: ')) {
-            pretrained = line.replace(/Pretrained: (?:Trained on )?/i, '');
-        } else if (line !== '') {
-            descLines.push(line.trim());
-        }
-    });
-    if (!purpose && !pretrained && descLines.length > 0) {
-        return descLines.join('\n');
-    }
-    const purposeSentence = purpose ? `A ${scale}x model for ${purpose}.` : `A ${scale}x model.`;
-    const pretrainedSentence = pretrained ? `Pretrained using ${pretrained}.` : '';
-    const actualDescription = `${purposeSentence} ${pretrainedSentence}\n${descLines.join('\n')}`.trim();
-    return actualDescription;
-}
 
 function AccentTag({ children }: React.PropsWithChildren<unknown>) {
     return <div className={`${style.tagBase} bg-accent-600 text-sm text-gray-100`}>{children}</div>;

--- a/src/elements/head-common.tsx
+++ b/src/elements/head-common.tsx
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import { useCurrentPath } from '../lib/hooks/use-current-path';
 import { SITE_URL } from '../lib/site-data';
+import type { Thing, WithContext } from 'schema-dts';
 
 export interface SiteMetaProps {
     title: string;
@@ -8,6 +9,7 @@ export interface SiteMetaProps {
     image?: string;
     noTitlePrefix?: boolean;
     noIndex?: boolean;
+    structuredData?: WithContext<Thing>;
 }
 
 export function HeadCommon({
@@ -16,6 +18,7 @@ export function HeadCommon({
     image = `${SITE_URL}/assets/OpenModelDB_Jelly.png`,
     noTitlePrefix = false,
     noIndex = false,
+    structuredData,
 }: SiteMetaProps) {
     const relPath = useCurrentPath();
 
@@ -66,6 +69,12 @@ export function HeadCommon({
                 <meta
                     content="noindex"
                     name="robots"
+                />
+            )}
+            {structuredData && (
+                <script
+                    dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+                    type="application/ld+json"
                 />
             )}
         </Head>

--- a/src/lib/text-description.ts
+++ b/src/lib/text-description.ts
@@ -1,0 +1,31 @@
+import { Model } from './schema';
+
+/**
+ * Returns a text description of the model, without any formatting elements.
+ */
+export function getTextDescription(model: Model): string {
+    const { scale, description } = model;
+
+    const lines = description.trim().split('\n');
+    const descLines: string[] = [];
+    let purpose = '',
+        pretrained = '';
+    lines.forEach((line) => {
+        if (line.startsWith('Category: ')) {
+            // ignore category
+        } else if (line.startsWith('Purpose: ')) {
+            purpose = line.replace('Purpose: ', '');
+        } else if (line.startsWith('Pretrained: ')) {
+            pretrained = line.replace(/Pretrained: (?:Trained on )?/i, '');
+        } else if (line !== '') {
+            descLines.push(line.trim());
+        }
+    });
+    if (!purpose && !pretrained && descLines.length > 0) {
+        return descLines.join('\n');
+    }
+    const purposeSentence = purpose ? `A ${scale}x model for ${purpose}.` : `A ${scale}x model.`;
+    const pretrainedSentence = pretrained ? `Pretrained using ${pretrained}.` : '';
+    const actualDescription = `${purposeSentence} ${pretrainedSentence}\n${descLines.join('\n')}`.trim();
+    return actualDescription;
+}

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -315,6 +315,7 @@ export default function Page({ modelId, similar: staticSimilar, modelData: stati
 
     const authors = asArray(model.author);
     const authorsJoined = joinListString(authors.map((userId) => userData.get(userId)?.name ?? 'unknown'));
+    const title = (model.scale ? `${model.scale}x ` : '') + model.name;
 
     const archName = archData.get(model.architecture)?.name ?? 'unknown';
 
@@ -345,10 +346,10 @@ export default function Page({ modelId, similar: staticSimilar, modelData: stati
                     author: authors.length === 1 ? { '@type': 'Person', name: authorsJoined } : authorsJoined,
                     datePublished: model.date ? new Date(model.date).toISOString() : undefined,
                     image: previewImage,
-                    name: model.name,
+                    name: title,
                     description: getTextDescription(model),
                 }}
-                title={model.name}
+                title={title}
             />
             {/* Only use a large card when we have an image to show */}
             {previewImage && (

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -28,6 +28,7 @@ import { getCachedModels } from '../../lib/server/cached-models';
 import { fileApi } from '../../lib/server/file-data';
 import { getSimilarModels } from '../../lib/similar';
 import { STATIC_ARCH_DATA } from '../../lib/static-data';
+import { getTextDescription } from '../../lib/text-description';
 import { EMPTY_ARRAY, asArray, getColorMode, getPreviewImage, joinListString, typedKeys } from '../../lib/util';
 
 const MAX_SIMILAR_MODELS = 12 * 2;
@@ -336,6 +337,17 @@ export default function Page({ modelId, similar: staticSimilar, modelData: stati
             <HeadCommon
                 description={`A ${model.scale}x ${archName} model by ${authorsJoined}.`}
                 image={previewImage}
+                structuredData={{
+                    '@context': 'https://schema.org',
+                    '@type': 'SoftwareApplication',
+                    applicationCategory: 'Multimedia',
+                    applicationSubCategory: 'AI Model',
+                    author: authors.length === 1 ? { '@type': 'Person', name: authorsJoined } : authorsJoined,
+                    datePublished: model.date ? new Date(model.date).toISOString() : undefined,
+                    image: previewImage,
+                    name: model.name,
+                    description: getTextDescription(model),
+                }}
                 title={model.name}
             />
             {/* Only use a large card when we have an image to show */}


### PR DESCRIPTION
The text displayed by search engines for our model pages was pretty bad, so I added [structured data](https://blog.logrocket.com/improving-seo-rending-structured-data-react/). This allows search engines to better display our models. Hopefully, they will soon look like the search results of civitai.com.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/432e6b01-fcb6-484b-a761-1203555ff2d3)
![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/d1b3734a-292b-4e29-a20d-f3a1d338914e)
