### PR TITLE
Remove owncube.com links

### DIFF
--- a/data/models/1x-Anti-Aliasing.json
+++ b/data/models/1x-Anti-Aliasing.json
@@ -22,8 +22,7 @@
             "size": 66662414,
             "sha256": "7a4cb10276899d6d93ba35f174653a11ebdcea5c6ca93aee226c108d177f311f",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-Anti-Aliasing.pth",
-                "https://de-next.owncube.com/index.php/s/mmYCcK4H3rQQR5Y"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-Anti-Aliasing.pth"
             ]
         }
     ],

--- a/data/models/1x-DeJpeg-Fatality-PlusULTRA.json
+++ b/data/models/1x-DeJpeg-Fatality-PlusULTRA.json
@@ -23,8 +23,7 @@
             "size": 66662414,
             "sha256": "1c93728803e9a3525afa4d7b23e08be531202e2ffc1f046f79bd1733be139c21",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-DeJpeg-Fatality-PlusULTRA.pth",
-                "https://de-next.owncube.com/index.php/s/w82HLrLWmWi4SQ5"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-DeJpeg-Fatality-PlusULTRA.pth"
             ]
         }
     ],

--- a/data/models/1x-Fatality-DeBlur.json
+++ b/data/models/1x-Fatality-DeBlur.json
@@ -22,8 +22,7 @@
             "size": 66662414,
             "sha256": "949ab41ddccaa13f4ae89c0f2ec3715b6786cca521e5300f5f57f66e85cf4dec",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-Fatality-DeBlur.pth",
-                "https://de-next.owncube.com/index.php/s/aAojXwLTPZto8rP"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-Fatality-DeBlur.pth"
             ]
         }
     ],

--- a/data/models/1x-ReFocus-Cleanly.json
+++ b/data/models/1x-ReFocus-Cleanly.json
@@ -22,8 +22,7 @@
             "size": 66665765,
             "sha256": "f38e8be5524126e9923849cc37e1c9ca308d2d72f26e89147c95d6fde8b18a13",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-ReFocus-Cleanly.pth",
-                "https://de-next.owncube.com/index.php/s/GjbBw7pcgm5gmYm"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-ReFocus-Cleanly.pth"
             ]
         }
     ],

--- a/data/models/1x-ReFocus-V3.json
+++ b/data/models/1x-ReFocus-V3.json
@@ -22,8 +22,7 @@
             "size": 66665765,
             "sha256": "94d8f38726c7abaa83a3fad27c01863ba961f76a995d8541c173eb3195062547",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-ReFocus-V3.pth",
-                "https://de-next.owncube.com/index.php/s/HyygDgXEB45JqBH"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-ReFocus-V3.pth"
             ]
         }
     ],

--- a/data/models/1x-UnResize-V3.json
+++ b/data/models/1x-UnResize-V3.json
@@ -22,8 +22,7 @@
             "size": 66665765,
             "sha256": "41c1fd640c265375b4649f6c41772714081ea77faf07593456c8021638d3e1d3",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-UnResize-V3.pth",
-                "https://de-next.owncube.com/index.php/s/nmNfcd33mnLLwEC"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-UnResize-V3.pth"
             ]
         }
     ],

--- a/data/models/1x-cinepak.json
+++ b/data/models/1x-cinepak.json
@@ -23,8 +23,7 @@
             "size": 66662414,
             "sha256": "daff496050e7eccd300f011e3abe08cdcb44d100236fe66cc291de86cb7262b5",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-cinepak.pth",
-                "https://de-next.owncube.com/index.php/s/wKjLmYsq7M5JAmx"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-cinepak.pth"
             ]
         }
     ],

--- a/data/models/1x-mdeblur.json
+++ b/data/models/1x-mdeblur.json
@@ -22,8 +22,7 @@
             "size": 66662414,
             "sha256": "e4c19f65bc0d217b4c3c17e32ac12d4a351ba6e3f7d5d36118c1f4f7a5b7abec",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-mdeblur.pth",
-                "https://cloud.owncube.com/s/p3w7M2sfaWWYCK9/download?path=%2F&files=1x_mdeblur.pth"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-mdeblur.pth"
             ]
         }
     ],

--- a/data/models/4x-Face-Ality-V1.json
+++ b/data/models/4x-Face-Ality-V1.json
@@ -22,8 +22,7 @@
             "size": 66958607,
             "sha256": "6bc795427098441bb1a90a56244fe0970fa80b2c25e9a7a88fd98d89824877cf",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-Face-Ality-V1.pth",
-                "https://de-next.owncube.com/index.php/s/mZRG4HB3KdP2iP6"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-Face-Ality-V1.pth"
             ]
         }
     ],

--- a/data/models/4x-Faces-04-N.json
+++ b/data/models/4x-Faces-04-N.json
@@ -22,8 +22,7 @@
             "size": 66958607,
             "sha256": "d2d7f702cdd22db2575f70694c2baabb7f6893bfdda84b1159fe158d065456bb",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-Faces-04-N.pth",
-                "https://de-next.owncube.com/index.php/s/PF5GTJ9jix4Log8"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-Faces-04-N.pth"
             ]
         }
     ],

--- a/data/models/4x-Fatal-Anime.json
+++ b/data/models/4x-Fatal-Anime.json
@@ -23,8 +23,7 @@
             "size": 66958607,
             "sha256": "54cfb3217bb68bfc31678bd79c2ebd6559f5cdbd9f3420332bf84c24b83b5b67",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-Fatal-Anime.pth",
-                "https://de-next.owncube.com/index.php/s/x99pKzS7TNaErrC"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-Fatal-Anime.pth"
             ]
         }
     ],

--- a/data/models/4x-Fatal-Pixels.json
+++ b/data/models/4x-Fatal-Pixels.json
@@ -22,8 +22,7 @@
             "size": 66958607,
             "sha256": "d30ac78343e0a7ffaa805b8ab7840fb1d6b9e6083fe1728c651e2064210e5994",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-Fatal-Pixels.pth",
-                "https://de-next.owncube.com/index.php/s/KRa4bDzZpAGgyWr"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-Fatal-Pixels.pth"
             ]
         }
     ],

--- a/data/models/4x-FatalimiX.json
+++ b/data/models/4x-FatalimiX.json
@@ -23,8 +23,7 @@
             "size": 66958607,
             "sha256": "3d3ebdc1abcd24b02556a64d9c65adc3c31ec2f55d731f70370ddc49067ecbb8",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-FatalimiX.pth",
-                "https://de-next.owncube.com/index.php/s/jYnFtncarkBmpcF"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-FatalimiX.pth"
             ]
         }
     ],

--- a/data/models/4x-Fatality-MK2.json
+++ b/data/models/4x-Fatality-MK2.json
@@ -22,8 +22,7 @@
             "size": 66958607,
             "sha256": "4240715ce77c04159a0712ffe065acf098b458109d63824686c8fafeed857a30",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-Fatality-MK2.pth",
-                "https://de-next.owncube.com/index.php/s/bT8nHoK4oD2MjoH"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-Fatality-MK2.pth"
             ]
         }
     ],

--- a/data/models/4x-Fatality.json
+++ b/data/models/4x-Fatality.json
@@ -25,8 +25,7 @@
             "size": 66958607,
             "sha256": "fde2299d8c98794e5fa36669978e6b69cce6fd7390ec6fe3a30d39da71ce5f30",
             "urls": [
-                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-Fatality.pth",
-                "https://de-next.owncube.com/index.php/s/LQSgW98ZeaoA3Po"
+                "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/4x-Fatality.pth"
             ]
         }
     ],


### PR DESCRIPTION
owncube.com recently messed up, went down, and lost the data of a bunch of customers. [Read more about this here](https://www.reddit.com/r/NextCloud/comments/16hneg0/owncube_provider_3rd_day_of_downtime/). This unfortunately included a few of our models. Luckily, we already self-hosted all of them, so nothing was lost.

This PR removes the dead owncube links. If they ever come back online (which seems unlikely), we can revert this PR.