### PR TITLE
Fixed "No description." in tag selector

### DIFF
--- a/src/elements/tag-selector.tsx
+++ b/src/elements/tag-selector.tsx
@@ -42,7 +42,7 @@ function TagButton({ state, name, onClick, noIcon = false, tooltipContent }: Tag
             )}
             data-tooltip-content={tooltipContent}
             data-tooltip-delay-show={300}
-            data-tooltip-id={tooltipId}
+            data-tooltip-id={tooltipContent ? tooltipId : undefined}
             onClick={onClick}
         >
             {!noIcon && <span className={style.icon}>{stateIcon[state]()}</span>}


### PR DESCRIPTION
I messed up in #301. When I refactored how tooltips work, I didn't test the tag selector enough. So the tag selector showed "No description." for all tags with a description. This PR fixes this by simply not showing that useless tooltip.