### PR TITLE
More reliable HTML fetching

### DIFF
--- a/src/lib/image-util.ts
+++ b/src/lib/image-util.ts
@@ -2,8 +2,26 @@ import { Image, PairedImage, StandaloneImage } from './schema';
 
 export type GetDocument = (url: string) => Promise<Document>;
 
+export async function fetchHtml(url: string): Promise<string> {
+    if (location.hostname === 'localhost') {
+        // we should have access to our API routes
+        const res = await fetch('/api/fetch', {
+            method: 'POST',
+            body: JSON.stringify({ url }),
+        });
+        const json = (await res.json()) as { ok: true; data: string } | { ok: false; error: string };
+        if (!json.ok) {
+            throw new Error(json.error);
+        }
+        return json.data;
+    }
+
+    // use cors-anywhere to bypass CORS
+    return fetch(`https://cors-anywhere.herokuapp.com/${url}`).then((res) => res.text());
+}
+
 export async function getDocumentBrowser(url: string): Promise<Document> {
-    const html = await fetch(`https://cors-anywhere.herokuapp.com/${url}`).then((res) => res.text());
+    const html = await fetchHtml(url);
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, 'text/html');
 

--- a/src/pages/api/fetch.ts
+++ b/src/pages/api/fetch.ts
@@ -1,0 +1,15 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+interface Body {
+    url: string;
+}
+
+export default async function fetchReq(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        const body = JSON.parse(req.body as string) as Body;
+        const text = await fetch(body.url).then((res) => res.text());
+        res.status(200).json({ ok: true, data: text });
+    } catch (err) {
+        res.status(500).json({ ok: false, error: String(err) });
+    }
+}


### PR DESCRIPTION
To fetch the HTML of a website, we need to circumvent CORS restrictions. I previously did that with `cors-anywhere.herokuapp.com`, but that service requires that you manually enable it via a button press. So I added another API route to our website that just does a fetch. This fetch doesn't have any CORS restrictions, because the NodeJS server is doing the fetching.