### PR TITLE
Use the `async-mutex` library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@headlessui/react": "^1.7.9",
         "@headlessui/tailwindcss": "^0.1.2",
         "@tailwindcss/line-clamp": "^0.4.2",
+        "async-mutex": "^0.4.0",
         "chokidar": "^3.5.3",
         "chroma-js": "^2.4.2",
         "fast-deep-equal": "^3.1.3",
@@ -13847,6 +13848,14 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
+    },
+    "node_modules/async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -36433,6 +36442,14 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
+    },
+    "async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@headlessui/react": "^1.7.9",
     "@headlessui/tailwindcss": "^0.1.2",
     "@tailwindcss/line-clamp": "^0.4.2",
+    "async-mutex": "^0.4.0",
     "chokidar": "^3.5.3",
     "chroma-js": "^2.4.2",
     "fast-deep-equal": "^3.1.3",

--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -1,25 +1,4 @@
-class Mutex {
-    private locked = false;
-    private pending: (() => void)[] = [];
-    lock(): Promise<void> {
-        if (this.locked) {
-            return new Promise((resolve) => {
-                this.pending.push(resolve);
-            });
-        } else {
-            this.locked = true;
-            return Promise.resolve();
-        }
-    }
-    unlock(): void {
-        const next = this.pending.shift();
-        if (next) {
-            next();
-        } else {
-            this.locked = false;
-        }
-    }
-}
+import { Mutex } from 'async-mutex';
 
 export class RWLock {
     private b = 0;
@@ -27,26 +6,32 @@ export class RWLock {
     private g = new Mutex();
 
     private async lockRead() {
-        await this.r.lock();
-        this.b++;
-        if (this.b === 1) {
-            await this.g.lock();
+        const release = await this.r.acquire();
+        try {
+            this.b++;
+            if (this.b === 1) {
+                await this.g.acquire();
+            }
+        } finally {
+            release();
         }
-        this.r.unlock();
     }
     private async unlockRead() {
-        await this.r.lock();
-        this.b--;
-        if (this.b === 0) {
-            this.g.unlock();
+        const release = await this.r.acquire();
+        try {
+            this.b--;
+            if (this.b === 0) {
+                this.g.release();
+            }
+        } finally {
+            release();
         }
-        this.r.unlock();
     }
     private async lockWrite() {
-        await this.g.lock();
+        await this.g.acquire();
     }
     private unlockWrite() {
-        this.g.unlock();
+        this.g.release();
     }
 
     async read<T>(operation: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
I never liked my own mutex implementation, so I finally replaced it with [the `async-mutex` library](https://www.npmjs.com/package/async-mutex#what-is-it).