### PR TITLE
Disallow models with empty tags

### DIFF
--- a/src/lib/model-props.ts
+++ b/src/lib/model-props.ts
@@ -168,7 +168,7 @@ export const MODEL_PROPS: Readonly<Record<keyof Model, ModelProp>> = {
         name: 'Tags',
         type: 'array',
         of: { type: 'string', kind: 'tag-id' },
-        allowEmpty: true,
+        allowEmpty: false,
     },
     description: {
         name: 'Description',


### PR DESCRIPTION
Thanks to @Kim2091, all models have tags now, so I added a check that disallows models without tags. This will ensure that all models have at least one tag going forward.