### PR TITLE
Add ability to hide tags in simple tag selector

### DIFF
--- a/src/elements/components/editable-tags.tsx
+++ b/src/elements/components/editable-tags.tsx
@@ -5,7 +5,7 @@ import { BsChevronDown } from 'react-icons/bs';
 import { useTags } from '../../lib/hooks/use-tags';
 import { addImpliedTags, removeImplyingTags } from '../../lib/implied-tags';
 import { TagId } from '../../lib/schema';
-import { compareTagId, isDerivedTags } from '../../lib/util';
+import { compareTagId, isDerivedTag } from '../../lib/util';
 import style from './editable-tags.module.scss';
 
 export interface SmallTagProps {
@@ -105,7 +105,7 @@ function EditTags({ tags, onChange }: { tags: readonly TagId[]; onChange: (value
                 >
                     <div className={style.editContainer}>
                         {categoryOrder.map(([categoryId, category]) => {
-                            const manual = category.tags.filter((tagId) => !isDerivedTags(tagId));
+                            const manual = category.tags.filter((tagId) => !isDerivedTag(tagId));
                             if (manual.length === 0) {
                                 return <Fragment key={categoryId} />;
                             }

--- a/src/elements/tag-selector.tsx
+++ b/src/elements/tag-selector.tsx
@@ -178,6 +178,7 @@ function SimpleTagSelector({ selection, onChange }: TagSelectorProps) {
                     .map((tagId) => {
                         const tag = tagData.get(tagId);
                         if (!tag) return undefined;
+                        if (tag.hidden) return undefined;
                         return [tagId, tag] as const;
                     })
                     .filter(isNonNull);

--- a/src/elements/tag-view.tsx
+++ b/src/elements/tag-view.tsx
@@ -1,4 +1,5 @@
 import { BsChevronDoubleDown, BsChevronDoubleUp, BsChevronDown, BsChevronUp } from 'react-icons/bs';
+import { FaEye, FaEyeSlash } from 'react-icons/fa';
 import { MdDelete } from 'react-icons/md';
 import { MarkDownString, Tag, TagId } from '../lib/schema';
 import { TagIdPattern } from '../lib/schema-util';
@@ -14,6 +15,7 @@ interface TagViewProps {
     onDescriptionChange?: (description: MarkDownString) => void;
     onDelete?: () => void;
     onMove?: (difference: number) => void;
+    onSetHidden?: (hidden: boolean) => void;
     readonly?: boolean;
 }
 export function TagView({
@@ -25,6 +27,7 @@ export function TagView({
     onDelete,
     onDescriptionChange,
     onMove,
+    onSetHidden,
 }: TagViewProps) {
     return (
         <div className={style.tagView}>
@@ -36,6 +39,21 @@ export function TagView({
                 />
                 {!TagIdPattern.test(tagId) && (
                     <span className="mr-2 text-red-500 dark:text-red-400">Invalid Tag ID</span>
+                )}
+                {onSetHidden && (
+                    <button
+                        className={style.iconButton}
+                        disabled={readonly}
+                        style={{ margin: '0 0.5rem' }}
+                        title={
+                            tag.hidden
+                                ? 'Tag is currently hidden in the simple tag selector'
+                                : 'Tag is shown in the simple tag selector'
+                        }
+                        onClick={() => onSetHidden(!tag.hidden)}
+                    >
+                        {tag.hidden ? <FaEyeSlash /> : <FaEye />}
+                    </button>
                 )}
                 {!readonly && onDelete && (
                     <button

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -85,6 +85,7 @@ export interface Tag {
     name: string;
     description: MarkDownString;
     implies?: TagId[];
+    hidden?: true;
 }
 
 export interface TagCategory {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -137,7 +137,7 @@ function getTagCategory(id: TagId): string | undefined {
 export function compareTagId(a: TagId, b: TagId): number {
     return compareString(getTagCategory(a) ?? '', getTagCategory(b) ?? '') || compareString(a, b);
 }
-export function isDerivedTags(id: TagId): boolean {
+export function isDerivedTag(id: TagId): boolean {
     return id.includes(':');
 }
 

--- a/src/pages/tags.tsx
+++ b/src/pages/tags.tsx
@@ -109,6 +109,7 @@ export default function Page() {
                     {categoryOrder.map(([categoryId, category]) => {
                         const isArch = categoryId === 'architecture' || undefined;
                         const isFree = !isArch || undefined;
+                        const isSimple = category.simple || undefined;
 
                         const add = () => {
                             if (!webApi) return;
@@ -198,6 +199,10 @@ export default function Page() {
                                                     updateCategory(categoryId, { tags: newTags });
                                                 }}
                                                 onRename={isFree && ((name) => updateTag(tagId, { name }))}
+                                                onSetHidden={
+                                                    isSimple &&
+                                                    ((hidden) => updateTag(tagId, { hidden: hidden || undefined }))
+                                                }
                                             />
                                         );
                                     })}
@@ -225,6 +230,7 @@ export default function Page() {
                                         onDelete={() => deleteTag(tagId)}
                                         onDescriptionChange={(description) => updateTag(tagId, { description })}
                                         onRename={(name) => updateTag(tagId, { name })}
+                                        onSetHidden={(hidden) => updateTag(tagId, { hidden: hidden || undefined })}
                                     />
                                 );
                             })}


### PR DESCRIPTION
To prevent the simple tag selector from being over-crowded, I added the ability to hide tags. Hidden tags will not be shown in the simple tag selector. They will behave just like normal tags anywhere else.

In the follow screenshots, I hid a bunch of subject tags:
![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/7dc01b97-a8aa-473b-bbbb-1fbdb4c2bda3)
![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/dc846cd6-be53-4443-91d5-5459774bb859)

Editing-wise, the tag page now looks like this:
![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/81dd6e24-0d6f-4a3e-aa8e-381fb597747b)

We can use the new eye button toggle the visibility of tags.

---

Note: This PR does **not** hide any tags. It only adds the functionality to hide tags.