### PR TITLE
Smaller thumbnails for edge cases

### DIFF
--- a/src/elements/components/model-card-grid.module.scss
+++ b/src/elements/components/model-card-grid.module.scss
@@ -9,7 +9,7 @@
     @media screen and (max-width: 896px) {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
-    @media screen and (max-width: 640px) {
+    @media screen and (max-width: 600px) {
         grid-template-columns: repeat(1, minmax(0, 1fr));
     }
 }

--- a/src/elements/components/model-card.tsx
+++ b/src/elements/components/model-card.tsx
@@ -62,9 +62,10 @@ const SideBySideImage = ({ model, image }: { model: Model; image: PairedImage })
     // This is necessary to prevent scaling artifacts. Such artifacts are especially noticeable for 1x models.
     // Here is how the scale is calculated:
     // 1. `1/dpr` scales the image such that 1px in the image is 1px on the screen.
-    // 2. `Math.round(dpr - 0.01)` rounds the dpr to the nearest integer. Importantly, it rounds .5 down.
+    // 2. `Math.round(dpr + 0.16)` rounds the dpr to the nearest integer. Importantly, it rounds .35 up.
+    //    This guarantees that we show at most 1.35x the original image size.
     // 3. `Math.max(1, ...)` ensures that the scale is at least 1. A scale of 0 would cause the image to disappear.
-    const scale = (1 / dpr) * Math.max(1, Math.round(dpr - 0.01));
+    const scale = (1 / dpr) * Math.max(1, Math.round(dpr + 0.16));
 
     return (
         <div className="flex h-full w-full">


### PR DESCRIPTION
This PR is preparation for automated thumbnails. I changed 2 things:
- I changed the break point when the model grid transitions from 2 models to 1 model per row. This reduces the width of the model card and shows less of the thumbnail.
- I changed the scale rounding for integer scaling. Instead of rounding down at .5, we now round up at .35. This ensures that the maximum thumbnail size is now at most 1.35x that at 100% zoom instead of 1.5. This might not seem like much, but this for both width and height, so it's the difference between 1.8x file size and 2.25x file size.