### PR TITLE
Fixed thumbnail `[object Object]` on model pages

### DIFF
--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -561,29 +561,18 @@ export default function Page({ modelId, similar: staticSimilar, modelData: stati
                                         />,
                                     ],
                                     ...typedKeys(MODEL_PROPS)
-                                        .filter(
-                                            (key) =>
-                                                ![
-                                                    // Handled by other parts of page
-                                                    'name',
-                                                    'author',
-                                                    'description',
-                                                    'resources',
-                                                    // Already handled manually
-                                                    'architecture',
-                                                    'scale',
-                                                    'size',
-                                                    'tags',
-                                                    'inputChannels',
-                                                    'outputChannels',
-                                                    'license',
-                                                    // This is just messed up in the data
-                                                    'pretrainedModelG',
-                                                    'pretrainedModelD',
-                                                    // Definitely don't want to show this
-                                                    'images',
-                                                ].includes(key)
-                                        )
+                                        .filter((key) => {
+                                            return [
+                                                'date',
+                                                'dataset',
+                                                'datasetSize',
+                                                'trainingIterations',
+                                                'trainingEpochs',
+                                                'trainingBatchSize',
+                                                'trainingHRSize',
+                                                'trainingOTF',
+                                            ].includes(key);
+                                        })
                                         .map((key) => [key, model[key]] as const)
                                         .filter(([, value]) => editMode || value != null)
                                         .map(([key, value]) => {


### PR DESCRIPTION
I didn't test thoroughly enough, which caused this:

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/bfa2db3c-8595-4b19-8e12-5cf959d14fb5)

I fixed this by changing the way model props are filtered. Instead of saying which props shouldn't be displayed, it should have said which props should be displayed from the start.