### PR TITLE
Fixed download links of Nomos8k_span_otf_strong

### DIFF
--- a/data/models/4x-Nomos8k-span-otf-strong.json
+++ b/data/models/4x-Nomos8k-span-otf-strong.json
@@ -21,7 +21,8 @@
             "size": 9015866,
             "sha256": "c1a4395b6d34ffa86b1c6e8a443d32ccaba7a53fabf600f7c17d804cc8156b46",
             "urls": [
-                "https://drive.google.com/drive/folders/1fJIzWN6UicvFNZADVWTchPjJpQFarA4v?usp=drive_link"
+                "https://drive.google.com/file/d/1K_OUt9lwvDXn280OTfURm0tD3E0lVZ5b/view?usp=drive_link",
+                "https://drive.google.com/drive/folders/1zqkuh-RBx7CDUxqmRU2IYyL371re0vwU"
             ]
         },
         {
@@ -30,7 +31,7 @@
             "size": 866325,
             "sha256": "5ea41b6280ff98cee6537c0f41c21bf5417328de3330a04845eaab9ec20e55c3",
             "urls": [
-                "https://drive.google.com/drive/folders/1fJIzWN6UicvFNZADVWTchPjJpQFarA4v?usp=drive_link"
+                "https://drive.google.com/drive/folders/1zqkuh-RBx7CDUxqmRU2IYyL371re0vwU"
             ]
         }
     ],


### PR DESCRIPTION
I noticed that the links pointed to the files of Nomos8k_span_otf_medium instead.