### PR TITLE
Require resource size

### DIFF
--- a/src/elements/components/download-button.tsx
+++ b/src/elements/components/download-button.tsx
@@ -151,7 +151,7 @@ export const DownloadButton = ({ resource, readonly, onChange }: DownloadButtonP
                             <path d="M13 8V2H7v6H2l8 8 8-8h-5zM0 18h20v2H0v-2z" />
                         </svg>
                     )}
-                    Download {resource.size ? `(${(resource.size / 1024 / 1024).toFixed(1)} MB)` : ''}
+                    Download ({(resource.size / 1024 / 1024).toFixed(1)} MB)
                     <div className="text-center text-sm font-normal">
                         <span className="whitespace-nowrap px-1">{fileType[resource.type]()}</span>
                         {isExternal && (

--- a/src/lib/model-props.ts
+++ b/src/lib/model-props.ts
@@ -229,7 +229,6 @@ export const MODEL_PROPS: Readonly<Record<keyof Model, ModelProp>> = {
                 },
                 size: {
                     name: 'Size',
-                    optional: true,
                     type: 'number',
                     isInteger: true,
                     min: 1,

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -47,7 +47,7 @@ interface ExtraModelProperties {
 export type Resource = PthFile | OnnxFile;
 
 interface SingleFile {
-    size: number | null;
+    size: number;
     sha256: string | null;
     urls: string[];
     platform: Platform;

--- a/src/lib/sort-models.ts
+++ b/src/lib/sort-models.ts
@@ -69,10 +69,8 @@ function getSortKeyFn(
                 // find the minimum size
                 let size: number | undefined = undefined;
                 for (const resource of resources) {
-                    if (resource.size !== null) {
-                        if (size === undefined || resource.size < size) {
-                            size = resource.size;
-                        }
+                    if (size === undefined || resource.size < size) {
+                        size = resource.size;
                     }
                 }
                 return size;


### PR DESCRIPTION
This PR makes the `size` property on resources required. It has been nullable up until now because we didn't know the size of all model files in the beginning. This is no longer the case, so I think it's fine to require `size` now.