### PR TITLE
Require SHA256 hash for all resources

### DIFF
--- a/src/lib/model-props.ts
+++ b/src/lib/model-props.ts
@@ -235,7 +235,6 @@ export const MODEL_PROPS: Readonly<Record<keyof Model, ModelProp>> = {
                 },
                 sha256: {
                     name: 'SHA256',
-                    optional: true,
                     type: 'string',
                     format: /^[0-9a-f]{64}$/i,
                 },

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -48,7 +48,7 @@ export type Resource = PthFile | OnnxFile;
 
 interface SingleFile {
     size: number;
-    sha256: string | null;
+    sha256: string;
     urls: string[];
     platform: Platform;
 }


### PR DESCRIPTION
Since all models have a hash since #368, I made it a required property of all resources.

Similar to #366.