### PR TITLE
Improved thumbnail loading

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -83,10 +83,17 @@ export interface PairedThumbnail {
     type: 'paired';
     LR: string;
     SR: string;
+    LRSize?: ImageSize;
+    SRSize?: ImageSize;
 }
 export interface StandaloneThumbnail {
     type: 'standalone';
     url: string;
+}
+
+export interface ImageSize {
+    readonly width: number;
+    readonly height: number;
 }
 
 export interface User {


### PR DESCRIPTION
This improves the thumbnail loading of non-1x models by storing the size of the LR and SR images. This allows the model card to calculate the max size before both images are fully loaded. Since the zoom of LR images is tied to that max size, this means that LR images are now always zoomed correctly from the start. This makes thumbnail loading appear a lot smoother since LR images don't suddenly zoom in anymore.