### PR TITLE
Export file types from `schema.ts`

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -52,11 +52,11 @@ interface SingleFile {
     urls: string[];
     platform: Platform;
 }
-interface PthFile extends SingleFile {
+export interface PthFile extends SingleFile {
     type: 'pth';
     platform: 'pytorch';
 }
-interface OnnxFile extends SingleFile {
+export interface OnnxFile extends SingleFile {
     type: 'onnx';
     platform: 'onnx';
 }


### PR DESCRIPTION
I need this for an upcoming PR and those 2 types should have been exported from the beginning.