### PR TITLE
Add AnimeJaNai HD V3 models

### DIFF
--- a/data/models/2x-AnimeJaNai-HD-V3-Compact.json
+++ b/data/models/2x-AnimeJaNai-HD-V3-Compact.json
@@ -1,0 +1,58 @@
+{
+    "name": "AnimeJaNai_HD_V3_Compact",
+    "author": "the-database",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "anime",
+        "restoration"
+    ],
+    "description": "Real-time 2x Real-ESRGAN Compact/UltraCompact/SuperUltraCompact models designed for upscaling 1080p anime to 4K. \n\nThe aim of these models is to address scaling, blur, oversharpening, and compression artifacts while upscaling to deliver a result that appears as if the anime was originally mastered in 4K resolution. Can be set up to run in real-time with mpv on Windows using https://github.com/the-database/mpv-upscale-2x_animejanai\n\nThe development of the V3 models spanned over seven months, during which over 100 release candidate models were trained and meticulously refined. The V3 models introduce several improvements compared to V2, including:\n\nMore faithful appearance to original source\nImproved handling of oversharpening artifacts, ringing, aliasing\nBetter at preserving intentional blur in scenes using depth of field\nMore accurate line colors, darkness, and thickness\nBetter preservation of soft shadow edges\n\nOverall, the V3 models yield significantly more natural and faithful results compared to the V2 models.test",
+    "date": "2024-01-17",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "16nc"
+    ],
+    "scale": 2,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 4838742,
+            "sha256": "af7307eee19e5982a8014dd0e4650d3bde2e25aa78d2105a4bdfd947636e4c8f",
+            "urls": [
+                "https://github.com/the-database/mpv-upscale-2x_animejanai/releases/download/3.0.0/2x_AnimeJaNai_HD_V3_ModelsOnly.zip"
+            ]
+        }
+    ],
+    "trainingIterations": 583000,
+    "trainingBatchSize": 9,
+    "trainingHRSize": 512,
+    "trainingOTF": false,
+    "dataset": "1080p anime",
+    "datasetSize": 239484,
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/xttdFobW.png",
+            "SR": "https://i.slow.pics/1rp2lkNh.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/m8ld0h5o.png",
+            "SR": "https://i.slow.pics/jsSGcwwm.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/Ux67Hgot.png",
+            "SR": "https://i.slow.pics/K7r6vKNE.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/Gu5oDhzV.png",
+            "SR": "https://i.slow.pics/mYLY1vsu.png"
+        }
+    ]
+}

--- a/data/models/2x-AnimeJaNai-HD-V3-SuperUltraCompact.json
+++ b/data/models/2x-AnimeJaNai-HD-V3-SuperUltraCompact.json
@@ -1,0 +1,59 @@
+{
+    "name": "AnimeJaNai_HD_V3_SuperUltraCompact",
+    "author": "the-database",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "anime",
+        "restoration"
+    ],
+    "description": "Real-time 2x Real-ESRGAN Compact/UltraCompact/SuperUltraCompact models designed for upscaling 1080p anime to 4K.\n\nThe aim of these models is to address scaling, blur, oversharpening, and compression artifacts while upscaling to deliver a result that appears as if the anime was originally mastered in 4K resolution. Can be set up to run in real-time with mpv on Windows using https://github.com/the-database/mpv-upscale-2x_animejanai\n\nThe development of the V3 models spanned over seven months, during which over 100 release candidate models were trained and meticulously refined. The V3 models introduce several improvements compared to V2, including:\n\nMore faithful appearance to original source Improved handling of oversharpening artifacts, ringing, aliasing Better at preserving intentional blur in scenes using depth of field More accurate line colors, darkness, and thickness Better preservation of soft shadow edges\n\nOverall, the V3 models yield significantly more natural and faithful results compared to the V2 models.",
+    "date": "2024-01-17",
+    "architecture": "compact",
+    "size": [
+        "24nf",
+        "8nc"
+    ],
+    "scale": 2,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 378338,
+            "sha256": "402f81e5b3202dfead0e6d2e092c9fc0372b687bff4bf2b5da68735bdc8206c8",
+            "urls": [
+                "https://github.com/the-database/mpv-upscale-2x_animejanai/releases/download/3.0.0/2x_AnimeJaNai_HD_V3_ModelsOnly.zip"
+            ]
+        }
+    ],
+    "trainingIterations": 5000,
+    "trainingBatchSize": 9,
+    "trainingHRSize": 512,
+    "trainingOTF": false,
+    "dataset": "1080p anime",
+    "datasetSize": 727,
+    "pretrainedModelG": "2x-SuperUltraCompact-Pretrain",
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/xttdFobW.png",
+            "SR": "https://i.slow.pics/j5b2Ryls.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/m8ld0h5o.png",
+            "SR": "https://i.slow.pics/OKmGQ7p3.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/Ux67Hgot.png",
+            "SR": "https://i.slow.pics/BmxIOc3t.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/Gu5oDhzV.png",
+            "SR": "https://i.slow.pics/fJfabxXt.png"
+        }
+    ]
+}

--- a/data/models/2x-AnimeJaNai-HD-V3-UltraCompact.json
+++ b/data/models/2x-AnimeJaNai-HD-V3-UltraCompact.json
@@ -1,0 +1,58 @@
+{
+    "name": "AnimeJaNai_HD_V3_UltraCompact",
+    "author": "the-database",
+    "license": "CC-BY-NC-SA-4.0",
+    "tags": [
+        "anime",
+        "restoration"
+    ],
+    "description": "Real-time 2x Real-ESRGAN Compact/UltraCompact/SuperUltraCompact models designed for upscaling 1080p anime to 4K.\n\nThe aim of these models is to address scaling, blur, oversharpening, and compression artifacts while upscaling to deliver a result that appears as if the anime was originally mastered in 4K resolution. Can be set up to run in real-time with mpv on Windows using https://github.com/the-database/mpv-upscale-2x_animejanai\n\nThe development of the V3 models spanned over seven months, during which over 100 release candidate models were trained and meticulously refined. The V3 models introduce several improvements compared to V2, including:\n\nMore faithful appearance to original source Improved handling of oversharpening artifacts, ringing, aliasing Better at preserving intentional blur in scenes using depth of field More accurate line colors, darkness, and thickness Better preservation of soft shadow edges\n\nOverall, the V3 models yield significantly more natural and faithful results compared to the V2 models.",
+    "date": "2024-01-17",
+    "architecture": "compact",
+    "size": [
+        "64nf",
+        "8nc"
+    ],
+    "scale": 2,
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "resources": [
+        {
+            "platform": "pytorch",
+            "type": "pth",
+            "size": 2456096,
+            "sha256": "7c74ae2f919a31b96a08afc7dee37f1d1bae8b80844b7cc24ee82d43efd64110",
+            "urls": [
+                "https://github.com/the-database/mpv-upscale-2x_animejanai/releases/download/3.0.0/2x_AnimeJaNai_HD_V3_ModelsOnly.zip"
+            ]
+        }
+    ],
+    "trainingIterations": 425000,
+    "trainingBatchSize": 9,
+    "trainingHRSize": 512,
+    "trainingOTF": false,
+    "dataset": "1080p anime",
+    "datasetSize": 239484,
+    "images": [
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/xttdFobW.png",
+            "SR": "https://i.slow.pics/vRsU6flj.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/m8ld0h5o.png",
+            "SR": "https://i.slow.pics/xQLCMI26.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/Ux67Hgot.png",
+            "SR": "https://i.slow.pics/tffombLv.png"
+        },
+        {
+            "type": "paired",
+            "LR": "https://i.slow.pics/Gu5oDhzV.png",
+            "SR": "https://i.slow.pics/QVkSxUjC.png"
+        }
+    ]
+}

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -83,7 +83,7 @@ Let's take a look at the project structure. This will help you find your way aro
 
 > _This section assumes that you have [checked out the project locally](#checking-out-the-project-locally)._
 
-GitHub has great [documentation](https://docs.github.com/en/get-started/quickstart/contributing-to-projectss) on making pull requests. We will not repeat that here. Instead, we will focus on the specifics of this project.
+GitHub has great [documentation](https://docs.github.com/en/get-started/quickstart/contributing-to-projects) on making pull requests. We will not repeat that here. Instead, we will focus on the specifics of this project.
 
 A few things you should know about making pull requests to this project:
 


### PR DESCRIPTION
Adds AnimeJaNai HD V3 models to the database, and also fixes a broken link in the docs. 