### PR TITLE
Add form to automatically parse discord messages

### DIFF
--- a/src/lib/implied-tags.ts
+++ b/src/lib/implied-tags.ts
@@ -1,4 +1,5 @@
 import { Tag, TagId } from './schema';
+import { compareTagId } from './util';
 
 /**
  * If a tag is in the given set, then all of its implied tags are added to the set.
@@ -12,6 +13,15 @@ export function addImpliedTags(tags: Set<TagId>, tagData: ReadonlyMap<TagId, Tag
             }
         }
     }
+}
+
+/**
+ * Returns a sorted sorted list of tags with all of their implied tags.
+ */
+export function withImpliedTags(tags: Iterable<TagId>, tagData: ReadonlyMap<TagId, Tag>): TagId[] {
+    const result = new Set<TagId>(tags);
+    addImpliedTags(result, tagData);
+    return [...result].sort(compareTagId);
 }
 
 /**

--- a/src/lib/parse-discord-message.ts
+++ b/src/lib/parse-discord-message.ts
@@ -1,0 +1,339 @@
+import { KNOWN_LICENSES } from './license';
+import { Arch, ArchId, Model, ModelId, SPDXLicenseId } from './schema';
+import { typedEntries } from './util';
+
+export interface ParseMessageTemplate {
+    name: string;
+    license: SPDXLicenseId;
+    link: string;
+    architecture: ArchId;
+    scale: number;
+    purpose: string;
+    trainingIterations: number;
+    batchSize: number;
+    hrSize: number;
+    epoch: number;
+    dataset: string;
+    datasetSize: number;
+    otf: boolean;
+    pretrained: ModelId;
+    description: string;
+}
+
+export interface ParseResult {
+    parsed: Partial<ParseMessageTemplate>;
+    failed: string[];
+}
+
+function parseNumber(value: string): number {
+    const simplified = value
+        .toLowerCase()
+        .replace(/[,']/g, '')
+        .replace(/[gx]$/, '')
+        .replace(/^~/, '')
+        .replace(/[kк]$/, '000')
+        .replace(/m$/, '000000')
+        .trim();
+    if (/^\d+$/.test(simplified)) {
+        return parseInt(simplified, 10);
+    }
+    throw new Error(`Invalid number: ${value}`);
+}
+function parseBoolean(value: string): boolean {
+    const simplified = value.toLowerCase().replace(/\.$/, '').trim();
+    if (simplified === 'y' || simplified === 'ye' || simplified === 'yes' || simplified === 'true') {
+        return true;
+    }
+    if (simplified === 'n' || simplified === 'no' || simplified === 'false') {
+        return false;
+    }
+    throw new Error(`Invalid boolean: ${value}`);
+}
+function parseMarkdownUrl(value: string): string {
+    let match = /^(https?:\/\/[^()<>\s]+?)\.?$/.exec(value);
+    if (match) {
+        return match[1];
+    }
+    match = /^<(https?:\/\/[^<>]+)>$/.exec(value);
+    if (match) {
+        return match[1];
+    }
+    match = /^\[[^\[\]]*\]\((https?:\/\/[^()]+)\)$/.exec(value);
+    if (match) {
+        return match[1];
+    }
+
+    throw new Error(`Invalid markdown link: ${value}`);
+}
+
+function getMarkdownLinkTitle(value: string): string | undefined {
+    const match = /^\[([^\[\]]+)\]\([^()]*\)$/.exec(value);
+    return match?.[1];
+}
+
+const simplifyKey = (key: string): string =>
+    key
+        .toLowerCase()
+        .trim()
+        .replace(/[\s_\-]/g, '');
+const keyAliases: Record<keyof ParseMessageTemplate, string[]> = {
+    name: ['Model Name'],
+    license: [],
+    link: ['download', 'model link', 'model download'],
+    architecture: ['Arch', 'Model Architecture', 'network'],
+    scale: [],
+    purpose: [],
+    trainingIterations: ['Iterations'],
+    batchSize: [],
+    hrSize: [],
+    epoch: ['epochs'],
+    dataset: [],
+    datasetSize: ['Number of train images'],
+    otf: ['OTF Training'],
+    pretrained: ['Pretrained Model', 'Pretrained_Model_G', 'Pretrained\\_Model\\_G'],
+    description: [],
+};
+const keyMapping = new Map<string, keyof ParseMessageTemplate>();
+for (const [key, aliases] of typedEntries(keyAliases)) {
+    keyMapping.set(simplifyKey(key), key);
+    for (const alias of aliases) {
+        keyMapping.set(simplifyKey(alias), key);
+    }
+}
+
+function findBestMatch<T>(value: string, iter: Iterable<T>, selector: (item: T) => Iterable<string>): T | undefined {
+    const items = Array.from(iter);
+
+    // find exact matches
+    for (const item of items) {
+        for (const s of selector(item)) {
+            if (s === value) {
+                return item;
+            }
+        }
+    }
+
+    // find a single item such that value is a prefix of one of its strings
+    const contains = items.filter((item) => {
+        for (const s of selector(item)) {
+            if (s.includes(value)) {
+                return true;
+            }
+        }
+        return false;
+    });
+    if (contains.length === 1) {
+        return contains[0];
+    }
+
+    if (contains.length > 1) {
+        // find a single item such that value is a prefix of one of its strings
+        const prefixes = items.filter((item) => {
+            for (const s of selector(item)) {
+                if (s.startsWith(value)) {
+                    return true;
+                }
+            }
+            return false;
+        });
+        if (prefixes.length === 1) {
+            return prefixes[0];
+        }
+    }
+
+    // find the longest prefix of value
+    let longest: T | undefined = undefined;
+    let longestLength = 0;
+
+    for (const item of items) {
+        for (const s of selector(item)) {
+            const l = s.length;
+            if (l > longestLength && value.startsWith(s)) {
+                longest = item;
+                longestLength = l;
+            }
+        }
+    }
+
+    return longest;
+}
+
+interface ParseContext {
+    models: ReadonlyMap<ModelId, Model>;
+    architectures: ReadonlyMap<ArchId, Arch>;
+}
+
+const parseValue: Record<
+    keyof ParseMessageTemplate,
+    (value: string, context: ParseContext) => Partial<ParseMessageTemplate>
+> = {
+    // simple strings
+    name: (value) => ({ name: value }),
+    purpose: (value) => ({ purpose: value }),
+    dataset: (value) => ({ dataset: value }),
+    description: (value) => ({ description: value }),
+
+    // numbers
+    scale: (value) => ({ scale: parseNumber(value) }),
+    datasetSize: (value) => ({
+        datasetSize: parseNumber(
+            value.replace(/\b(?:\d+[x\-]\d+\s+)?(?:page|tile|image)s?(?:\s+(?:64|128|256|512|1024|2048))?$/i, '').trim()
+        ),
+    }),
+    trainingIterations: (value) => ({ trainingIterations: parseNumber(value) }),
+    batchSize: (value) => ({ batchSize: parseNumber(value) }),
+    hrSize: (value) => ({ hrSize: parseNumber(value) }),
+    epoch: (value) => ({ epoch: parseNumber(value) }),
+
+    // boolean
+    otf: (value) => ({ otf: parseBoolean(value) }),
+
+    // other
+    architecture: (value, { architectures }) => {
+        const canonicalize = (s: string): string =>
+            s
+                .trim()
+                .toLowerCase()
+                .replace(/[\s_\-]/g, '');
+
+        const best = findBestMatch(
+            canonicalize(getMarkdownLinkTitle(value) || value),
+            architectures,
+            ([archId, arch]) => {
+                return [canonicalize(arch.name), canonicalize(archId)];
+            }
+        );
+        if (best) {
+            return { architecture: best[0] };
+        }
+
+        throw new Error(`Unknown arch: ${value}`);
+    },
+    link: (value) => {
+        return { link: parseMarkdownUrl(value) };
+    },
+    license: (value) => {
+        const canonicalize = (s: string): string =>
+            s
+                .trim()
+                .toLowerCase()
+                .replace(/[\s_\-]/g, '');
+
+        const best = findBestMatch(
+            canonicalize(getMarkdownLinkTitle(value) || value),
+            typedEntries(KNOWN_LICENSES),
+            ([licenseId, license]) => {
+                if (!license) return [];
+                return [canonicalize(license.name), canonicalize(licenseId)];
+            }
+        );
+        if (best) {
+            return { license: best[0] };
+        }
+
+        throw new Error(`Unknown license: ${value}`);
+    },
+    pretrained: (value, { models }) => {
+        if (/^(?:no|custom|scratch)\b/i.test(value)) {
+            return { pretrained: undefined };
+        }
+
+        const canonicalize = (s: string): string =>
+            s
+                .trim()
+                .toLowerCase()
+                .replace(/[\s_\-]/g, '');
+
+        const best = findBestMatch(
+            canonicalize(getMarkdownLinkTitle(value) || value).replace(/pth?$/, ''),
+            models,
+            ([modelId, model]) => {
+                return [canonicalize(modelId), canonicalize(model.name)];
+            }
+        );
+        if (best) {
+            return { pretrained: best[0] };
+        }
+
+        throw new Error(`Invalid pretrained model: ${value}`);
+    },
+};
+
+export function parseDiscordMessage(
+    message: string,
+    models: ReadonlyMap<ModelId, Model>,
+    architectures: ReadonlyMap<ArchId, Arch>
+): ParseResult {
+    const parsed: Partial<ParseMessageTemplate> = {};
+    const failed: string[] = [];
+
+    const lines = message
+        .split(/(\n|^\*{0,2}Description\s*(?::\s*\*{0,2}|\*{0,2}\s*:)[\s\S]+)/m)
+        .filter(Boolean)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .filter((l) => {
+            // remove lines that just ping certain channels
+            return !/^\s*(?:<@&\d+>\s*)+$/.test(l);
+        });
+
+    const context: ParseContext = { models, architectures };
+
+    for (const line of lines) {
+        const parsedLine = /^(\*{0,2})(?<key>[\w\- \\().,]{1,25})(?::\s*\1|\1\s*:|(?=\*)\1)(?<value>[\s\S]*)/u.exec(
+            line
+        );
+        if (parsedLine?.groups) {
+            const rawKey = parsedLine.groups.key;
+            const key =
+                keyMapping.get(simplifyKey(rawKey)) ?? keyMapping.get(simplifyKey(rawKey.replace(/\([^()]+\)$/, '')));
+            const value = parsedLine.groups.value.trim();
+            if (['?', 'unknown', 'n/a', 'none', '-', ''].includes(value.toLowerCase())) {
+                // skip unknown values
+                continue;
+            }
+
+            const parser = key && parseValue[key];
+            if (parser) {
+                try {
+                    const parsedValue = parser(value, context);
+                    Object.assign(parsed, parsedValue);
+                } catch (error) {
+                    failed.push(line);
+                }
+                continue;
+            }
+        }
+
+        if (!parsedLine && !parsed.link) {
+            try {
+                parsed.link = parseMarkdownUrl(line.trim());
+                continue;
+            } catch {}
+        }
+
+        if (!parsedLine && line.toLowerCase().startsWith('otf training')) {
+            try {
+                parsed.otf = parseBoolean(line.slice('otf training'.length).trim());
+                continue;
+            } catch {}
+        }
+
+        if (!parsedLine && parsed.description !== undefined) {
+            parsed.description = `${parsed.description}\n\n${line}`.trim();
+            continue;
+        }
+
+        failed.push(line);
+    }
+
+    // clean up name
+    if (parsed.name) {
+        parsed.name = parsed.name.replace(/[.\-_\s]?pth?$/i, '');
+        if (parsed.scale && parsed.name.toLowerCase().startsWith(`${parsed.scale}x`)) {
+            parsed.name = parsed.name.replace(/^\d+x[.\-_\s]?/i, '');
+        }
+    }
+
+    return { parsed, failed };
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -9,7 +9,7 @@ export type SPDXLicense = string & { readonly SPDXLicense: never };
  * A SPDX license id (short).
  * @see https://spdx.org/licenses/
  */
-export type SPDXLicenseId = string & { readonly SPDXLicenseId: never };
+export type SPDXLicenseId = SPDXLicense & { readonly SPDXLicenseId: never };
 export type TagId = string & { readonly TagId: never };
 export type TagCategoryId = string & { readonly TagCategoryId: never };
 export type ArchId = string & { readonly ArchId: never };

--- a/src/pages/add-model.tsx
+++ b/src/pages/add-model.tsx
@@ -1,12 +1,16 @@
 import { useRouter } from 'next/router';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { TextLink } from '../elements/components/link';
 import { HeadCommon } from '../elements/head-common';
 import { PageContainer } from '../elements/page';
 import { useArchitectures } from '../lib/hooks/use-architectures';
 import { useModels } from '../lib/hooks/use-models';
+import { useTags } from '../lib/hooks/use-tags';
 import { useWebApi } from '../lib/hooks/use-web-api';
+import { withImpliedTags } from '../lib/implied-tags';
 import { hashSha256 } from '../lib/model-files';
-import { Arch, ArchId, Model, ModelId, TagId } from '../lib/schema';
+import { ParseResult, parseDiscordMessage } from '../lib/parse-discord-message';
+import { Arch, ArchId, Model, ModelId, Tag, TagId } from '../lib/schema';
 import { canonicalizeModelId } from '../lib/schema-util';
 import type { ResponseJson } from './api/pth-metadata';
 
@@ -50,6 +54,52 @@ function findArch(architectures: ReadonlyMap<ArchId, Arch>, search: string): Arc
     }
 }
 
+function guessTags(model: Model, tagData: ReadonlyMap<TagId, Tag>): TagId[] {
+    const tags = new Set<TagId>();
+
+    if (model.trainingOTF) {
+        tags.add('restoration' as TagId);
+    }
+    if (/\bjpe?g\b/i.test(`${model.name} ${model.description}`)) {
+        tags.add('jpeg' as TagId);
+    }
+    if (/\b(?:dds|dxt[1-5]?|bc[1-7])\b/i.test(`${model.name} ${model.description}`)) {
+        tags.add('dds' as TagId);
+    }
+
+    if (/\b(?:anime|cartoon)\b/i.test(`${model.name} ${model.description}`)) {
+        tags.add('anime' as TagId);
+        tags.add('cartoon' as TagId);
+    }
+    if (/\b(?:manga)\b/i.test(`${model.name} ${model.description}`)) {
+        tags.add('manga' as TagId);
+    }
+
+    return withImpliedTags(tags, tagData);
+}
+
+const EMPTY_PARSE_RESULT: ParseResult = { failed: [], parsed: {} };
+
+const discordMessageTemplate = `
+**Name:** ModelNameThatIsCreative
+**License:** GNU GPL3 for example
+**Link:** <Link.to.the.model.com>
+**Model Architecture:** ESRGAN / PPON / PSNR / SR / ...
+**Scale:** 1, 2, 3, 4, 8 or 16
+**Purpose:** The kind of images the model is intended to process.
+
+**Iterations:** Your Iterations
+**batch_size:** Your batch_size
+**HR_size:** Probably either 128 or 192
+**Epoch:** The amounts of Epochs you trained your model for.
+**Dataset:** What source images you trained you model on. Feel free to use links.
+**Dataset_size:** How many images were in your training HR folder
+**OTF Training** Yes / No
+**Pretrained_Model_G:** What model did you use as a base
+
+**Description:** Your Description
+`.trim();
+
 interface PthInfo {
     arch?: ArchId;
     size?: string[];
@@ -63,6 +113,7 @@ interface PthInfo {
 function PageContent() {
     const { modelData } = useModels();
     const { archData } = useArchitectures();
+    const { tagData } = useTags();
     const router = useRouter();
     const { webApi, editMode } = useWebApi();
 
@@ -82,6 +133,21 @@ function PageContent() {
     const [mainPthUrl, setMainPthUrl] = useState<string>();
     const [loadingMainPth, setLoadingMainPth] = useState(false);
 
+    const [parseMessageTemplate, setParseMessageTemplate] = useState(false);
+    const [messageTemplate, setMessageTemplate] = useState('');
+    const parsedMessage = useMemo((): ParseResult => {
+        if (!parseMessageTemplate) {
+            return EMPTY_PARSE_RESULT;
+        }
+        return parseDiscordMessage(messageTemplate, modelData, archData);
+    }, [parseMessageTemplate, messageTemplate, modelData, archData]);
+
+    useEffect(() => {
+        if (parsedMessage.parsed.name) {
+            setName(parsedMessage.parsed.name.replace(/[\s_\-]+/g, ' '));
+            setPartialId(undefined);
+        }
+    }, [parsedMessage.parsed.name]);
     useEffect(() => {
         if (hasMainPth && mainPthInfo?.scale) {
             setScale(mainPthInfo.scale);
@@ -96,8 +162,26 @@ function PageContent() {
                 return;
             }
         }
+        if (parsedMessage.parsed.scale) {
+            setScale(parsedMessage.parsed.scale);
+            setScaleDefinedBy('discord message');
+            return;
+        }
         setScaleDefinedBy(undefined);
-    }, [hasMainPth, mainPthInfo, pretrained, modelData]);
+    }, [parsedMessage, hasMainPth, mainPthInfo, pretrained, modelData]);
+    useEffect(() => {
+        if (parsedMessage.parsed.link) {
+            setHasMainPth(true);
+            setMainPthUrl(parsedMessage.parsed.link);
+            setMainPthInfo(undefined);
+            setMainPthSpandrelError(undefined);
+        } else {
+            setHasMainPth(false);
+        }
+    }, [parsedMessage.parsed.link]);
+    useEffect(() => {
+        setPretrained(parsedMessage.parsed.pretrained ?? '');
+    }, [parsedMessage.parsed.pretrained]);
 
     useEffect(() => {
         if (!hasMainPth) {
@@ -113,20 +197,33 @@ function PageContent() {
             return;
         }
 
+        const description = [
+            parsedMessage.parsed.purpose ? `Purpose: ${parsedMessage.parsed.purpose}` : '',
+            parsedMessage.parsed.description ?? '',
+        ].join('\n\n');
+
         const model: Model = {
             name,
             author: [],
-            license: null,
+            license: parsedMessage.parsed.license ?? null,
             tags: [],
-            description: '',
+            description,
             date: new Date().toISOString().split('T')[0],
-            architecture: 'esrgan' as ArchId,
+            architecture: parsedMessage.parsed.architecture ?? ('esrgan' as ArchId),
             size: null,
             scale,
             inputChannels: 3,
             outputChannels: 3,
             resources: [],
             images: [],
+            dataset: parsedMessage.parsed.dataset,
+            datasetSize: parsedMessage.parsed.datasetSize,
+            trainingIterations: parsedMessage.parsed.trainingIterations,
+            trainingBatchSize: parsedMessage.parsed.batchSize,
+            trainingEpochs: parsedMessage.parsed.epoch,
+            trainingHRSize: parsedMessage.parsed.hrSize,
+            trainingOTF: parsedMessage.parsed.otf,
+            pretrainedModelG: parsedMessage.parsed.pretrained,
         };
 
         const pre = pretrained ? modelData.get(pretrained) : undefined;
@@ -152,6 +249,8 @@ function PageContent() {
                 urls: [mainPthUrl],
             });
         }
+
+        model.tags = guessTags(model, tagData);
 
         setProcessing(true);
         await webApi.models.update([[fullId, model]]);
@@ -211,7 +310,7 @@ function PageContent() {
     if (name.trim() === '') {
         inputError = 'Name cannot be empty';
     } else if (hasMainPth && !mainPthInfo) {
-        inputError = 'Main .pth file is invalid';
+        inputError = 'Select a valid .pth file';
     } else if (hasMainPth && !mainPthUrl) {
         inputError = 'Main .pth file URL is empty';
     }
@@ -221,6 +320,55 @@ function PageContent() {
     return (
         <>
             <h1>Add Model</h1>
+            <div className="pb-4">
+                <input
+                    checked={parseMessageTemplate}
+                    className="mr-2"
+                    id="parse-message-template"
+                    type="checkbox"
+                    onChange={(e) => {
+                        setParseMessageTemplate(e.target.checked);
+                    }}
+                />
+                <label htmlFor="parse-message-template">Parse Discord Message Template?</label>
+
+                {parseMessageTemplate && (
+                    <div className="pt-2">
+                        <p className="mt-0">
+                            How to use: Paste a message from the{' '}
+                            <TextLink
+                                external
+                                href="https://discord.com/channels/547949405949657098/579685650824036387"
+                            >
+                                model-releases
+                            </TextLink>{' '}
+                            channel (or any message following the message template). <br />
+                            To copy a message: Move your mouse over the message &gt; click on the three dots
+                            (&#x22;More&#x22;) &gt; Copy Text.
+                        </p>
+                        <textarea
+                            className="box-border w-full text-sm"
+                            placeholder={discordMessageTemplate}
+                            style={{ resize: 'vertical', minHeight: '24em' }}
+                            value={messageTemplate}
+                            onChange={(e) => setMessageTemplate(e.target.value)}
+                        />
+                        {parsedMessage.failed.length > 0 && (
+                            <pre className="whitespace-pre-wrap text-red-800 dark:text-red-300">
+                                <code>
+                                    <span className="italic">Unable to parse the following parts of the message:</span>
+                                    {'\n\n'}
+                                    {parsedMessage.failed.join('\n')}
+                                </code>
+                            </pre>
+                        )}
+                        <pre className="hidden whitespace-pre-wrap">
+                            <code>Parsed: {JSON.stringify(parsedMessage.parsed, undefined, 4)}</code>
+                        </pre>
+                        <hr />
+                    </div>
+                )}
+            </div>
             <div className="grid grid-cols-4 gap-2">
                 <div>Pretrained model:</div>
                 <div className="col-span-3">
@@ -338,7 +486,7 @@ function PageContent() {
                     <div>
                         <input
                             checked={hasMainPth}
-                            className="ml-2"
+                            className="mr-2"
                             id="main-pth"
                             type="checkbox"
                             onChange={(e) => {
@@ -371,6 +519,13 @@ function PageContent() {
                                     value={mainPthUrl}
                                     onChange={(e) => setMainPthUrl(e.target.value)}
                                 />
+                                <TextLink
+                                    external
+                                    className={!mainPthUrl ? 'pointer-events-none opacity-0' : ''}
+                                    href={mainPthUrl || ''}
+                                >
+                                    Visit link
+                                </TextLink>
                             </div>
                         </>
                     )}

--- a/tests/search/__snapshots__/parse-discord-messages.test.ts.snap
+++ b/tests/search/__snapshots__/parse-discord-messages.test.ts.snap
@@ -1,0 +1,218 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parse discord messages 1x_Dehalo_v1_Compact 1`] = `
+{
+  "failed": [
+    "**Model Architecture:** Real-ESRGAN Compact",
+  ],
+  "parsed": {
+    "description": "This is a 1x model for removing halos in animation. I was training this a while back and considered it a failed project, but I recently found it useful on a few things I was working on, so I decided to release it. I don't remember any details regarding how it was trained.
+https://imgsli.com/MjE3Nzc4",
+    "license": "WTFPL",
+    "link": "https://mega.nz/file/lBFnHI7K#OGDMb8foOEDsNhXYoIuQIg5N6-2F9-gS9FA0G6lKcc8",
+    "name": "Dehalo_v1_Compact",
+    "pretrained": "1x-Compact-Pretrain",
+    "purpose": "For removing halos in anime.",
+    "scale": 1,
+  },
+}
+`;
+
+exports[`parse discord messages 1x-BroadcastToStudio_SPAN 1`] = `
+{
+  "failed": [],
+  "parsed": {
+    "architecture": "span",
+    "dataset": "SaurusX's BroadcastToStudio dataset",
+    "description": "This is SaurusX's original description:
+Improvement of low-quality cartoons from broadcast sources. Will greatly increase the visual quality of bad broadcast tape sources of '80s and '90s cartoons (e.g. Garfield and Friends, Heathcliff, DuckTales, etc). Directly addresses chroma blur, dot crawl, and rainbowing. You're highly advised to take care of haloing beforehand in your favorite video editor as the model will not fix it and may make existing halos more noticeable.
+
+-------
+
+Sadly this model has some intense artifacts. Thankfully the SPAN re-train reduced these a bit, but they're still problematic. This was just a quick test of SPAN's capabilities. This was trained only to ~66k iterations, compared to the 480k of the original.",
+    "license": "CC-BY-NC-SA-4.0",
+    "link": "https://mega.nz/folder/3JIHUbpT#bSsO0RK9MOzjA8dEbl1kbw",
+    "name": "BroadcastToStudio_SPAN",
+    "pretrained": "1x-span-anime-pretrain",
+    "purpose": "Restoring classic cartoons",
+    "scale": 1,
+    "trainingIterations": 66000,
+  },
+}
+`;
+
+exports[`parse discord messages 2x_span_anime_pretrain 1`] = `
+{
+  "failed": [
+    "Pretrained: trained on basic degradations",
+  ],
+  "parsed": {
+    "architecture": "span",
+    "dataset": "HFA2k_LUDVAE modified",
+    "description": "This is just a very basic 2x model to start your anime models with on SPAN, nothing special. I tried to keep it as basic as possible",
+    "license": "CC0-1.0",
+    "link": "https://mega.nz/file/HMZ0jLyL#oRUi6pn53THVgHrqwf1YNYlhaBCEcm9r7EUho9kCOLc",
+    "name": "span_anime_pretrain",
+    "purpose": "Pretrain to quick start new models",
+    "scale": 2,
+    "trainingIterations": 67000,
+  },
+}
+`;
+
+exports[`parse discord messages 2xEvangelion_dat2 1`] = `
+{
+  "failed": [
+    "Release Date: 12.02.2024 (dd/mm/yy)",
+    "Author: Philip Hofmann",
+    "Network: SRVGGNetCompact",
+    "Pretrained_Model_G: DAT_2_x2",
+  ],
+  "parsed": {
+    "batchSize": 4,
+    "dataset": ""Upscale Archive Evangelion DVD's" by pwnsweet",
+    "datasetSize": 3174,
+    "description": "For the evangelion upscale project still, this time a dat2 model. A 2x upscaler for evangelion episodes on the evangelion dataset provided by pwnsweet, which called for model trainers to train models on it.
+
+[Slowpoke Pics 4 Examples](https://slow.pics/s/IfJyBnIM)",
+    "epoch": 47,
+    "hrSize": 128,
+    "license": "CC-BY-4.0",
+    "link": "https://drive.google.com/drive/folders/1SzyvuIUVHDjNMtapvtDdE3RkDGJsrHd3?usp=drive_link",
+    "name": "Evangelion_dat2",
+    "otf": false,
+    "purpose": "2x upscaler for evangelion episodes",
+    "scale": 2,
+    "trainingIterations": 196000,
+  },
+}
+`;
+
+exports[`parse discord messages 4x_ditn_w16_pretrain 1`] = `
+{
+  "failed": [],
+  "parsed": {
+    "architecture": "ditn",
+    "dataset": "nomos_uni",
+    "description": "Meant to quick start new DITN models trained on \\\`neosr\\\`. Trained only on downscale degradation (bicubic, bilinear, nearest, lanczos and mitchell).
+Note: [Flash Attention](https://github.com/muslll/neosr/blob/master/neosr/archs/ditn_arch.py#L108) breaks inference compatibility with official code.",
+    "license": "CC0-1.0",
+    "link": "https://drive.google.com/drive/folders/1Fzmuw2xCChAYgX7WznaPcTFpsYdbXBWG?usp=sharing",
+    "name": "ditn_w16_pretrain",
+    "pretrained": undefined,
+    "purpose": "Pretrain to quick start new models.",
+    "scale": 4,
+    "trainingIterations": 215000,
+  },
+}
+`;
+
+exports[`parse discord messages 4x_span_pretrain 1`] = `
+{
+  "failed": [
+    "**Pretrained**: official pixel loss only pretrained",
+  ],
+  "parsed": {
+    "architecture": "span",
+    "dataset": "nomos_uni",
+    "description": "Please load it using \\\`strict_load_g: false\\\`. Model trained only on downscale degradation (bicubic, bilinear, nearest, lanczos and mitchell). Can be used to start new SPAN models.",
+    "license": "CC0-1.0",
+    "link": "https://drive.google.com/drive/folders/17Wyr7yCQhh9GdZcv1KT2oEXuMaV-bGjg?usp=drive_link",
+    "name": "span_pretrain",
+    "purpose": "Pretrain to quick start new models.",
+    "scale": 4,
+    "trainingIterations": 430000,
+  },
+}
+`;
+
+exports[`parse discord messages 4x-ClearRealityV1 Soft + Normal 1`] = `
+{
+  "failed": [
+    "**Iterations:** 300k (over multiple models)",
+    "**batch_size:** 12-20",
+    "**HR_size:** 128-256",
+    "**Epoch:** 40?",
+    "**OTF Training** No (made with datasetDestroyer)",
+    "**Pretrained_Model_G:** Official pretrain",
+  ],
+  "parsed": {
+    "architecture": "span",
+    "dataset": "My own UltraSharpV2 dataset, my 8k dataset (v2), Nomos8k, and FaceUp",
+    "datasetSize": 19000,
+    "description": "Nice to release a model again! This one is intended for realistic imagery, and works especially well on faces, hair, and nature shots. It should only be used on somewhat clear shots, without a lot of grain. I trained this model on SPAN, which as of the time of release, you'll need chaiNNer-nightly for. I aimed for a softer, more natural look for this model with as few artifacts as possible.
+
+In addition to the Normal model, I've included a "soft" model. The Soft model is... softer. Basically it was an earlier version of the model with a more limited dataset. It produces more natural output on games or rendered content, but suffers a bit more with realistic stuff.
+
+Note: In shots with DOF (depth of field) or bokeh, unfortunately there will be artifacts.
+
+**Compatibility:** You'll have to use the [latest chaiNNer-nightly](<https://github.com/chaiNNer-org/chaiNNer-nightly/releases/tag/2023-12-12>) to use this model
+
+<https://imgsli.com/MjI1Nzc5>",
+    "license": "CC-BY-NC-SA-4.0",
+    "link": "https://mega.nz/folder/Xc4wnC7T#yUS5-9-AbRxLhpdPW_8f2w",
+    "name": "ClearRealityV1 Soft + Normal",
+    "purpose": "Realistic images of humans, foliage, trees, buildings, etc.",
+    "scale": 4,
+  },
+}
+`;
+
+exports[`parse discord messages 4xNomos8kHAT-L_bokeh_jpg 1`] = `
+{
+  "failed": [],
+  "parsed": {
+    "architecture": "hat",
+    "batchSize": 4,
+    "dataset": "nomos8k",
+    "datasetSize": 8492,
+    "description": "4x photo upscaler, made to specifically handle bokeh effect and jpg compression. Basically a HAT-L variant of the already released 4xNomosUniDAT_bokeh_jpg model, but specifically trained for photos on the nomos8k dataset (and hopefully without the smoothing effect).
+
+The three strengths of this model (design purpose):
+Specifically for photos / photography
+Handles bokeh effect
+Handles jpg compression
+
+This model will not attempt to:
+Denoise
+Deblur
+
+[Example image](https://slow.pics/c/12rO9MPT) - 4xNomosUniDAT_bokeh_jpg vs 4xNomos8kHAT-L_bokeh_jpg - have a look at the back of the car, for example the WESTFALIA section",
+    "epoch": 66,
+    "hrSize": 128,
+    "license": "CC-BY-4.0",
+    "link": "https://drive.google.com/file/d/1VSxJ6rMoaah7hyIqzJsdMLxHIgW5jYNm/view?usp=sharing",
+    "name": "Nomos8kHAT-L_bokeh_jpg",
+    "otf": false,
+    "pretrained": "4x-HAT-L-SRx4-ImageNet-pretrain",
+    "purpose": "4x photo upscaler (handles bokeh effect and jpg compression)",
+    "scale": 4,
+    "trainingIterations": 145000,
+  },
+}
+`;
+
+exports[`parse discord messages 4xNomos8kHAT-L_otf 1`] = `
+{
+  "failed": [
+    "Training time: 60 hours on a remote P100",
+  ],
+  "parsed": {
+    "architecture": "hat",
+    "batchSize": 4,
+    "dataset": "nomos8k",
+    "datasetSize": 8492,
+    "description": "4x photo upscaler trained with otf",
+    "epoch": 19,
+    "hrSize": 128,
+    "license": "CC-BY-4.0",
+    "link": "https://drive.google.com/file/d/1_7cmypb7d-GGgGwmWmPg8ugJjOozXrFU/view?usp=drive_link",
+    "name": "Nomos8kHAT-L_otf",
+    "otf": true,
+    "pretrained": "4x-HAT-L-SRx4-ImageNet-pretrain",
+    "purpose": "4x photo upscaler",
+    "scale": 4,
+    "trainingIterations": 220000,
+  },
+}
+`;

--- a/tests/search/parse-discord-messages.test.ts
+++ b/tests/search/parse-discord-messages.test.ts
@@ -1,0 +1,205 @@
+import { parseDiscordMessage } from '../../src/lib/parse-discord-message';
+import { fileApi } from '../../src/lib/server/file-data';
+
+const messages = String.raw`
+**Name**: 4x_ditn_w16_pretrain
+**License**: [CC0](https://creativecommons.org/share-your-work/public-domain/cc0/)
+**Download (3.5mb)**: [GDrive](https://drive.google.com/drive/folders/1Fzmuw2xCChAYgX7WznaPcTFpsYdbXBWG?usp=sharing)
+**Model Architecture**: DITN with Flash Attention
+**Scale**: 4
+**Iterations**: 215k
+**Dataset**: nomos_uni
+**Pretrained**: scratch
+**Purpose**: Pretrain to quick start new models.
+**Description**:
+
+Meant to quick start new DITN models trained on \`neosr\`. Trained only on downscale degradation (bicubic, bilinear, nearest, lanczos and mitchell).
+Note: [Flash Attention](https://github.com/muslll/neosr/blob/master/neosr/archs/ditn_arch.py#L108) breaks inference compatibility with official code.
+
+
+
+<@&560103931204861954> <@&577839492199874570>
+Name: 4xNomos8kHAT-L_bokeh_jpg
+[Download](https://drive.google.com/file/d/1VSxJ6rMoaah7hyIqzJsdMLxHIgW5jYNm/view?usp=sharing)
+License: CC BY 4.0
+Network: HAT
+Scale: 4
+Purpose: 4x photo upscaler (handles bokeh effect and jpg compression)
+Iterations: 145000
+epoch: 66
+batch_size: 4
+HR_size: 128
+Dataset: nomos8k
+Number of train images: 8492
+OTF Training: No
+Pretrained_Model_G: HAT-L_SRx4_ImageNet-pretrain
+
+Description:
+4x photo upscaler, made to specifically handle bokeh effect and jpg compression. Basically a HAT-L variant of the already released 4xNomosUniDAT_bokeh_jpg model, but specifically trained for photos on the nomos8k dataset (and hopefully without the smoothing effect).
+
+The three strengths of this model (design purpose):
+Specifically for photos / photography
+Handles bokeh effect
+Handles jpg compression
+
+This model will not attempt to:
+Denoise
+Deblur
+
+[Example image](https://slow.pics/c/12rO9MPT) - 4xNomosUniDAT_bokeh_jpg vs 4xNomos8kHAT-L_bokeh_jpg - have a look at the back of the car, for example the WESTFALIA section
+
+
+
+<@&560103931204861954> <@&577839492199874570>
+Name: 4xNomos8kHAT-L_otf
+[Download](https://drive.google.com/file/d/1_7cmypb7d-GGgGwmWmPg8ugJjOozXrFU/view?usp=drive_link)
+License: CC BY 4.0
+Network: HAT
+Scale: 4
+Purpose: 4x photo upscaler
+Iterations: 220000
+epoch: 19
+batch_size: 4
+HR_size: 128
+Dataset: nomos8k
+Number of train images: 8492
+OTF Training: Yes
+Training time: 60 hours on a remote P100
+Pretrained_Model_G: HAT-L_SRx4_ImageNet-pretrain
+
+Description:
+4x photo upscaler trained with otf
+
+
+
+<@&560103931204861954> <@&577839492199874570>
+**Name:** 1x_Dehalo_v1_Compact
+**License:** WTFPL
+**Link:** https://mega.nz/file/lBFnHI7K#OGDMb8foOEDsNhXYoIuQIg5N6-2F9-gS9FA0G6lKcc8
+**Model Architecture:** Real-ESRGAN Compact
+**Scale:** 1
+**Purpose:** For removing halos in anime.
+**Pretrained_Model_G:** 1x_Compact_Pretrain.pth
+
+**Description:** This is a 1x model for removing halos in animation. I was training this a while back and considered it a failed project, but I recently found it useful on a few things I was working on, so I decided to release it. I don't remember any details regarding how it was trained.
+https://imgsli.com/MjE3Nzc4
+
+
+
+**Name**: 4x_span_pretrain
+**License**: CC0
+**Download (7.1MB)**: [GDrive](https://drive.google.com/drive/folders/17Wyr7yCQhh9GdZcv1KT2oEXuMaV-bGjg?usp=drive_link)
+**Model Architecture**: SPAN
+**Scale**: 4
+**Iterations**: 430k
+**Dataset**: nomos_uni
+**Pretrained**: official pixel loss only pretrained
+**Purpose**: Pretrain to quick start new models.
+**Description**:
+
+Please load it using \`strict_load_g: false\`. Model trained only on downscale degradation (bicubic, bilinear, nearest, lanczos and mitchell). Can be used to start new SPAN models.
+
+
+
+Name: 2x_span_anime_pretrain
+License: CC0
+Link: <https://mega.nz/file/HMZ0jLyL#oRUi6pn53THVgHrqwf1YNYlhaBCEcm9r7EUho9kCOLc>
+Model Architecture: SPAN
+Scale: 2
+Iterations: 67k
+Dataset: HFA2k_LUDVAE modified
+Pretrained: trained on basic degradations
+Purpose: Pretrain to quick start new models
+Description:
+
+This is just a very basic 2x model to start your anime models with on SPAN, nothing special. I tried to keep it as basic as possible
+
+
+
+<@&560103931204861954> <@&577839492199874570>
+**Name:** 4x-ClearRealityV1 Soft + Normal
+**License:** CC BY-NC-SA 4.0
+**Link:** <https://mega.nz/folder/Xc4wnC7T#yUS5-9-AbRxLhpdPW_8f2w>
+**Model Architecture:** SPAN
+**Scale:** 4
+**Purpose:** Realistic images of humans, foliage, trees, buildings, etc.
+
+**Iterations:** 300k (over multiple models)
+**batch_size:** 12-20
+**HR_size:** 128-256
+**Epoch:** 40?
+**Dataset:** My own UltraSharpV2 dataset, my 8k dataset (v2), Nomos8k, and FaceUp
+**Dataset_size:** 19k tiles
+**OTF Training** No (made with datasetDestroyer)
+**Pretrained_Model_G:** Official pretrain
+
+**Description:** Nice to release a model again! This one is intended for realistic imagery, and works especially well on faces, hair, and nature shots. It should only be used on somewhat clear shots, without a lot of grain. I trained this model on SPAN, which as of the time of release, you'll need chaiNNer-nightly for. I aimed for a softer, more natural look for this model with as few artifacts as possible.
+
+In addition to the Normal model, I've included a "soft" model. The Soft model is... softer. Basically it was an earlier version of the model with a more limited dataset. It produces more natural output on games or rendered content, but suffers a bit more with realistic stuff.
+
+Note: In shots with DOF (depth of field) or bokeh, unfortunately there will be artifacts.
+
+**Compatibility:** You'll have to use the [latest chaiNNer-nightly](<https://github.com/chaiNNer-org/chaiNNer-nightly/releases/tag/2023-12-12>) to use this model
+
+<https://imgsli.com/MjI1Nzc5>
+
+
+
+**Name:** 1x-BroadcastToStudio_SPAN
+**License:** CC BY-NC-SA 4.0
+**Link:** <https://mega.nz/folder/3JIHUbpT#bSsO0RK9MOzjA8dEbl1kbw>
+**Model Architecture:** SPAN
+**Scale:** 1
+**Iterations:** 66k
+**Dataset:** SaurusX's BroadcastToStudio dataset
+**Pretrained:** 1x_span_anime_pretrain
+**Purpose:** Restoring classic cartoons
+**Description:**
+
+This is SaurusX's original description:
+Improvement of low-quality cartoons from broadcast sources. Will greatly increase the visual quality of bad broadcast tape sources of '80s and '90s cartoons (e.g. Garfield and Friends, Heathcliff, DuckTales, etc). Directly addresses chroma blur, dot crawl, and rainbowing. You're highly advised to take care of haloing beforehand in your favorite video editor as the model will not fix it and may make existing halos more noticeable.
+
+-------
+
+Sadly this model has some intense artifacts. Thankfully the SPAN re-train reduced these a bit, but they're still problematic. This was just a quick test of SPAN's capabilities. This was trained only to ~66k iterations, compared to the 480k of the original.
+
+
+
+Name: 2xEvangelion_dat2
+License: CC BY 4.0
+[Google Drive](https://drive.google.com/drive/folders/1SzyvuIUVHDjNMtapvtDdE3RkDGJsrHd3?usp=drive_link)
+Release Date: 12.02.2024 (dd/mm/yy)
+Author: Philip Hofmann
+Network: SRVGGNetCompact
+Scale: 2
+Purpose: 2x upscaler for evangelion episodes
+Iterations: 196'000
+epoch: 47
+batch_size: 4
+HR_size: 128
+Dataset: "Upscale Archive Evangelion DVD's" by pwnsweet
+Number of train images: 3174
+OTF Training: No
+Pretrained_Model_G: DAT_2_x2
+
+Description:
+For the evangelion upscale project still, this time a dat2 model. A 2x upscaler for evangelion episodes on the evangelion dataset provided by pwnsweet, which called for model trainers to train models on it.
+
+[Slowpoke Pics 4 Examples](https://slow.pics/s/IfJyBnIM)
+`;
+
+describe('parse discord messages', () => {
+    const messageList = messages.split(/\n{4,}/).map((message, i) => {
+        const name = /^\*{0,2}Name\*{0,2}:\*{0,2}\s*(.+)/m.exec(message)?.[1] ?? `message ${i}`;
+        return { message, name };
+    });
+
+    const models = fileApi.models.getAll();
+    const archs = fileApi.architectures.getAll();
+
+    for (const { message, name } of messageList) {
+        test(name, async () => {
+            expect(parseDiscordMessage(message, await models, await archs)).toMatchSnapshot();
+        });
+    }
+});


### PR DESCRIPTION
This adds a form to automatically parse discord messages from model-releases. 

This makes adding model released on discord very easy. You basically just have to copy the message, paste it in, download the model file, select the model file, and then add the model. Most information will already be filled in. All that is left to do is to set the author, add more tags, add images (if any), and maybe clean up the description.

In the following example, I just pasted the message. See how it automatically filled out name, scale, and .pth link. The other information from the message is automatically inserted when the model is added. Some tags will also automatically be added based on the model description.

![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/a2cef0ac-bf38-4898-aec8-ee0eb1274bce)

Adding the model then yields this page:
![image](https://github.com/OpenModelDB/open-model-database/assets/20878432/d43aa5ee-23f6-4b65-b8cb-6b4398e6b3da)
