### PR TITLE
Add pyright config for python script

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,29 @@
+{
+	"include": [
+		"scripts"
+	],
+	"exclude": [
+		"**/__pycache__"
+	],
+	"ignore": [],
+	"typeCheckingMode": "basic",
+	"useLibraryCodeForTypes": false,
+	"strictListInference": true,
+	"strictDictionaryInference": true,
+	"strictSetInference": true,
+	"reportDuplicateImport": "warning",
+	"reportImportCycles": "error",
+	"reportIncompatibleVariableOverride": "error",
+	"reportOverlappingOverload": "error",
+	"reportPrivateImportUsage": "error",
+	"reportUninitializedInstanceVariable": "error",
+	"reportUnnecessaryCast": "error",
+	"reportUnnecessaryComparison": "error",
+	"reportUnnecessaryContains": "error",
+	"reportUnnecessaryIsInstance": "error",
+	// "reportUnnecessaryTypeIgnoreComment": "warning",
+	"reportUnusedClass": "warning",
+	"reportUnusedFunction": "warning",
+	"reportUnusedImport": "warning",
+	"reportUnusedVariable": "warning",
+}


### PR DESCRIPTION
We have a bit of Python code, so I added a pyright config file to at least add type checking in the IDE. We can set up CI later if needed.