### PR TITLE
Only render full header in client

### DIFF
--- a/src/elements/components/client.tsx
+++ b/src/elements/components/client.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { useIsClient } from '../../lib/hooks/use-is-client';
+
+export function ClientOnly({ children }: React.PropsWithChildren<unknown>) {
+    const isClient = useIsClient();
+    return isClient ? <>{children}</> : null;
+}

--- a/src/elements/header.tsx
+++ b/src/elements/header.tsx
@@ -10,6 +10,7 @@ import Logo from '../../public/logo.svg';
 import { toggleColorScheme } from '../lib/color-scheme';
 import { useEditModeToggle } from '../lib/hooks/use-web-api';
 import { joinClasses } from '../lib/util';
+import { ClientOnly } from './components/client';
 import { SearchIcon } from './components/custom-icons';
 import { Link } from './components/link';
 import { SearchBar } from './components/searchbar';
@@ -42,7 +43,9 @@ export function Header({ searchBar }: HeaderProps) {
                         href="/"
                     >
                         <div className={style.logoContainer}>
-                            <Logo />
+                            <ClientOnly>
+                                <Logo />
+                            </ClientOnly>
                         </div>
                     </Link>
 
@@ -84,55 +87,57 @@ export function Header({ searchBar }: HeaderProps) {
                         </button>
                     )}
 
-                    {searchBar && (
-                        <>
-                            <SearchBar
-                                className={`${style.search} mx-4 hidden lg:flex`}
-                                placeholder="Search models"
-                                value={searchQuery}
-                                onChange={(e) => setSearchQuery(e.target.value)}
-                                onEnter={onSearch}
-                            />
-                            <Link
-                                aria-label="Search models"
-                                className={joinClasses(style.iconLink, 'lg:hidden')}
-                                href="/"
-                            >
-                                <SearchIcon
-                                    height="1em"
-                                    width="1em"
+                    <ClientOnly>
+                        {searchBar && (
+                            <>
+                                <SearchBar
+                                    className={`${style.search} mx-4 hidden lg:flex`}
+                                    placeholder="Search models"
+                                    value={searchQuery}
+                                    onChange={(e) => setSearchQuery(e.target.value)}
+                                    onEnter={onSearch}
                                 />
-                            </Link>
-                        </>
-                    )}
+                                <Link
+                                    aria-label="Search models"
+                                    className={joinClasses(style.iconLink, 'lg:hidden')}
+                                    href="/"
+                                >
+                                    <SearchIcon
+                                        height="1em"
+                                        width="1em"
+                                    />
+                                </Link>
+                            </>
+                        )}
 
-                    <Link
-                        external
-                        aria-label="GitHub"
-                        className={joinClasses(style.iconLink, style.hideMobile)}
-                        href="https://github.com/OpenModelDB/open-model-database"
-                    >
-                        <FaGithub />
-                    </Link>
-                    <Link
-                        external
-                        aria-label="Discord"
-                        className={joinClasses(style.iconLink, style.hideMobile)}
-                        href="https://discord.gg/enhance-everything-547949405949657098"
-                    >
-                        <FaDiscord />
-                    </Link>
-                    <button
-                        aria-label="Toggle color scheme"
-                        className={joinClasses(style.themeButton, style.hideMobile)}
-                        type="button"
-                        onClick={toggleColorScheme}
-                    >
-                        <MdLightMode className={style.light} />
-                        <MdDarkMode className={style.dark} />
-                    </button>
+                        <Link
+                            external
+                            aria-label="GitHub"
+                            className={joinClasses(style.iconLink, style.hideMobile)}
+                            href="https://github.com/OpenModelDB/open-model-database"
+                        >
+                            <FaGithub />
+                        </Link>
+                        <Link
+                            external
+                            aria-label="Discord"
+                            className={joinClasses(style.iconLink, style.hideMobile)}
+                            href="https://discord.gg/enhance-everything-547949405949657098"
+                        >
+                            <FaDiscord />
+                        </Link>
+                        <button
+                            aria-label="Toggle color scheme"
+                            className={joinClasses(style.themeButton, style.hideMobile)}
+                            type="button"
+                            onClick={toggleColorScheme}
+                        >
+                            <MdLightMode className={style.light} />
+                            <MdDarkMode className={style.dark} />
+                        </button>
 
-                    <HeaderDrawer />
+                        <HeaderDrawer />
+                    </ClientOnly>
                 </div>
             </header>
         </>


### PR DESCRIPTION
Currently, every page of the website contains a copy of the header with all of its icon (OMDB logo + the other icons for links and buttons). This adds up to roughly 15KB per page, or roughly 9MB for all pages. 9MB is quite significant considering that all thumbnails combined are 10MB.

This PR addresses this issue by only rendering the full header on the client. The 15KB for the header are stored in a JS chunk that is shared between all pages. 

Since the header now needs to be loaded, users will briefly see a blank space when the OMDB logo will be. All the elements on the right side of the header also aren't loaded. This shouldn't be an issue since this only happens on their first page visit.