### PR TITLE
Fixed validation for safetensors files

### DIFF
--- a/src/lib/model-props.ts
+++ b/src/lib/model-props.ts
@@ -285,7 +285,7 @@ export const MODEL_PROPS: Readonly<Record<keyof Model, ModelProp>> = {
                 type: {
                     name: 'Type',
                     type: 'string',
-                    enum: ['pth', 'onnx'],
+                    enum: ['pth', 'onnx', 'safetensors'],
                 },
                 size: {
                     name: 'Size',


### PR DESCRIPTION
Fixes #403.

I forgot to add safetensors files to list of allowed resource types in model props, which is used for validation.

Thanks for reporting @Phhofm!