### PR TITLE
Add tags label in edit mode

### DIFF
--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -534,7 +534,8 @@ export default function Page({ modelId, similar: staticSimilar, modelData: stati
                                     />
                                 </div>
                             </div>
-                            <div className="mt-2 text-xs">
+                            <div className="mt-2 flex gap-2 text-xs">
+                                {editMode && <div>tags:</div>}
                                 <EditableTags
                                     readonly={!editMode}
                                     tags={model.tags}


### PR DESCRIPTION
I noticed it was non-obvious where tags are supposed to be edited from since they aren't labeled and are just a button when adding a model that has no tags yet, so I added a little label for when in edit mode.

![image](https://github.com/OpenModelDB/open-model-database/assets/34788790/e3047a7c-8a25-42c9-8ed9-f4afb488e4ee)
