### PR TITLE
fix: disable optimizeFonts to fix CI build

### DIFF
--- a/data/models/2x-Fallin-Soft.json
+++ b/data/models/2x-Fallin-Soft.json
@@ -20,7 +20,7 @@
             "size": 5657145,
             "sha256": "526a4bb8a01273b420105458f850435576d7be95c4029add6cc05cad57d2c3b4",
             "urls": [
-                "https://mega.nz/file/LwoxXZgS#J5kh2DIkn7NhxbSKOqhyX4gIO39MrVWLCTJGOZd9yzo"
+                "https://github.com/renarchi/Re-SISR/releases/tag/Fallin"
             ]
         }
     ],

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const path = require('path');
 const nextConfig = {
     // output: 'export',
     reactStrictMode: true,
+    optimizeFonts: false,
     sassOptions: {
         includePaths: [path.join(__dirname, 'styles')],
     },


### PR DESCRIPTION
Adding `optimizeFonts: false` to next.config.js prevents 
Next.js from trying to fetch fonts at build time.